### PR TITLE
Removing the fake initial supply from LivepeerToken. Closes #1

### DIFF
--- a/contracts/LivepeerToken.sol
+++ b/contracts/LivepeerToken.sol
@@ -12,10 +12,9 @@ contract LivepeerToken is MintableToken {
     uint8 public decimals = 18;
     string public symbol = "LPT";
     string public version = "0.1";
-    uint64 public initialSupply = 10000;
 
     function LivepeerToken() {
-        mint(msg.sender, initialSupply);        
+
     }
 
     /* Don't accept random ETH sent to this contract */

--- a/test/LivepeerToken.js
+++ b/test/LivepeerToken.js
@@ -39,7 +39,12 @@ contract('LivepeerToken', function(accounts) {
         const lpt = await LivepeerToken.new();
 
         const balance0 = await lpt.balanceOf.call(accounts[0]);
-        assert.equal(balance0.valueOf(), 10000, "10000 wasn't in the first account");
+        assert.equal(balance0.valueOf(), 0, "0 wasn't in the first account");
+
+        await lpt.mint(accounts[0], 10000);
+
+        const balance01 = await lpt.balanceOf.call(accounts[0]);
+        assert.equal(balance01.valueOf(), 10000, "10000 wasn't in the first account");
 
         await lpt.mint(accounts[1], 25);
 


### PR DESCRIPTION
Preparing for opening up the repo and hitting the MintableToken milestone by removing some of the unnecessary cruft.