### PR TITLE
Verification interface with IdentityVerifier

### DIFF
--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -149,6 +149,12 @@ contract JobsManager is IJobsManager, Verifiable, Controllable {
         return true;
     }
 
+    /*
+     * @dev Callback function that receives the results of transcoding verification
+     * @param _jobId Job identifier
+     * @param _segmentSequenceNumber Segment being verified for job
+     * @param _result Boolean result of whether verification succeeded or not
+     */
     function receiveVerification(uint256 _jobId, uint256 _segmentSequenceNumber, bool _result) onlyVerifier external returns (bool) {
         // TODO: Check if result matches transcoded data hash
 

--- a/contracts/verification/IdentityVerifier.sol
+++ b/contracts/verification/IdentityVerifier.sol
@@ -3,20 +3,22 @@ pragma solidity ^0.4.11;
 import "./Verifier.sol";
 import "./Verifiable.sol";
 
+/*
+ * @title Verifier contract that always returns true
+ */
 contract IdentityVerifier is Verifier {
+    /*
+     * @dev Verify implementation that always returns true. Used primarily for testing purposes
+     * @param _jobId Job identifier
+     * @param _segmentSequenceNumber Segment being verified for job
+     * @param _code Swarm hash of binary to execute off-chain
+     * @param _transcodedDataHash Swarm hash of transcoded input data of segment
+     * @param _callbackContract Address of Verifiable contract to call back
+     */
     function verify(uint256 _jobId, uint256 _segmentSequenceNumber, bytes32 _code, bytes32 _transcodedDataHash, address _callbackContract) external returns (bool) {
-        bytes32 result = _transcodedDataHash;
+        // Check if receiveVerification on callback contract succeeded
+        if (!Verifiable(_callbackContract).receiveVerification(_jobId, _segmentSequenceNumber, true)) throw;
 
-        if (result == _transcodedDataHash) {
-            // Check if receiveVerification on callback contract succeeded
-            if (!Verifiable(_callbackContract).receiveVerification(_jobId, _segmentSequenceNumber, true)) throw;
-
-            return true;
-        } else {
-            // Check if receiveVerification on callback contract succeeded
-            if (!Verifiable(_callbackContract).receiveVerification(_jobId, _segmentSequenceNumber, false)) throw;
-
-            return false;
-        }
+        return true;
     }
 }

--- a/contracts/verification/IdentityVerifier.sol
+++ b/contracts/verification/IdentityVerifier.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.4.11;
+
+import "./Verifier.sol";
+import "./Verifiable.sol";
+
+contract IdentityVerifier is Verifier {
+    function verify(uint256 _jobId, uint256 _segmentSequenceNumber, bytes32 _code, bytes32 _transcodedDataHash, address _callbackContract) external returns (bool) {
+        bytes32 result = _transcodedDataHash;
+
+        if (result == _transcodedDataHash) {
+            // Check if receiveVerification on callback contract succeeded
+            if (!Verifiable(_callbackContract).receiveVerification(_jobId, _segmentSequenceNumber, true)) throw;
+
+            return true;
+        } else {
+            // Check if receiveVerification on callback contract succeeded
+            if (!Verifiable(_callbackContract).receiveVerification(_jobId, _segmentSequenceNumber, false)) throw;
+
+            return false;
+        }
+    }
+}

--- a/contracts/verification/Verifiable.sol
+++ b/contracts/verification/Verifiable.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.4.11;
+
+/*
+ * @title Interface for contract that receives verification results
+ * TODO: switch to interface type
+ */
+contract Verifiable {
+    // External functions
+    function receiveVerification(uint256 _jobId, uint256 _segmentSequenceNumber, bool _result) external returns (bool);
+}

--- a/contracts/verification/Verifier.sol
+++ b/contracts/verification/Verifier.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.4.11;
+
+/*
+ * @title Interface for verifier contract. Can be backed by any implementation including oracles or Truebit
+ * TODO: switch to interface type
+ */
+contract Verifier {
+    // External functions
+    function verify(uint256 _jobId, uint256 _segmentSequenceNumber, bytes32 _code, bytes32 _transcodedDataHash, address _callbackContract) external returns (bool);
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -8,6 +8,7 @@ var TranscodeJobs = artifacts.require("TranscodeJobs")
 var BondingManager = artifacts.require("BondingManager")
 var RoundsManager = artifacts.require("RoundsManager")
 var JobsManager = artifacts.require("JobsManager")
+var IdentityVerifier = artifacts.require("IdentityVerifier")
 var LivepeerToken = artifacts.require("LivepeerToken");
 var LivepeerProtocol = artifacts.require("LivepeerProtocol");
 
@@ -38,7 +39,10 @@ module.exports = function(deployer) {
         deployer.deploy(BondingManager, LivepeerToken.address)
     })
 
-    deployer.deploy(LivepeerProtocol)
-    deployer.deploy(JobsManager)
+    deployer.deploy(IdentityVerifier).then(() => {
+        deployer.deploy(JobsManager, IdentityVerifier.address)
+    })
+
     deployer.deploy(RoundsManager)
+    deployer.deploy(LivepeerProtocol)
 };

--- a/test/LivepeerProtocolIntegration.js
+++ b/test/LivepeerProtocolIntegration.js
@@ -9,6 +9,7 @@ var LivepeerToken = artifacts.require("LivepeerToken")
 var BondingManager = artifacts.require("BondingManager")
 var RoundsManager = artifacts.require("RoundsManager")
 var JobsManager = artifacts.require("JobsManager")
+var IdentityVerifier = artifacts.require("IdentityVerifier")
 
 const ROUND_LENGTH = 50
 const CYCLE_LENGTH = 25
@@ -39,7 +40,9 @@ contract("LivepeerProtocolIntegration", accounts => {
         token.transferOwnership(bondingManager.address, {from: accounts[0]})
 
         roundsManager = await RoundsManager.new()
-        jobsManager = await JobsManager.new()
+
+        const verifier = await IdentityVerifier.new()
+        jobsManager = await JobsManager.new(verifier.address)
 
         const protocol = await LivepeerProtocol.new()
         const bondingManagerKey = await protocol.bondingManagerKey.call()

--- a/test/jobs/JobsManager.js
+++ b/test/jobs/JobsManager.js
@@ -287,6 +287,15 @@ contract("JobsManager", accounts => {
             await expectThrow(jobsManager.verify(jobId, segmentSequenceNumber, utils.bufferToHex(d0), utils.bufferToHex(tD0), utils.bufferToHex(bSig0), proof, {from: accounts[0]}))
         })
 
+        it("should throw if segment not signed by broadcaster", async () => {
+            const jobId = 0
+            const segmentSequenceNumber = 0
+            const badBSig0 = utils.toBuffer(web3.eth.sign(accounts[3], utils.bufferToHex(s0)));
+            // Account 0 calls verify with job 0
+            // This should fail because badBSig0 is signed by Account 3 and not the broadcaster Account 2
+            await expectThrow(jobsManager.verify(jobId, segmentSequenceNumber, utils.bufferToHex(d0), utils.bufferToHex(tD0), utils.bufferToHex(badBSig0), proof, {from: accounts[0]}))
+        })
+
         it("should throw if submitted Merkle proof is invalid", async () => {
             const jobId = 0
             const segmentSequenceNumber = 0
@@ -300,6 +309,21 @@ contract("JobsManager", accounts => {
             const segmentSequenceNumber = 0
             // Account 0 calls verify with job 0
             await jobsManager.verify(jobId, segmentSequenceNumber, utils.bufferToHex(d0), utils.bufferToHex(tD0), utils.bufferToHex(bSig0), proof, {from: accounts[0]})
+        })
+    })
+
+    describe("receiveVerification", () => {
+        before(async () => {
+            await setup()
+        })
+
+        it("should throw if sender is not Verifier", async () => {
+            const jobId = 0
+            const segmentSequenceNumber = 0
+            const result = true
+
+            // Account 0 (not Verifier) calls receiveVerification
+            await expectThrow(jobsManager.receiveVerification(jobId, segmentSequenceNumber, result, {from: accounts[0]}))
         })
     })
 

--- a/test/jobs/JobsManager.js
+++ b/test/jobs/JobsManager.js
@@ -9,6 +9,7 @@ var LivepeerToken = artifacts.require("LivepeerToken")
 var BondingManager = artifacts.require("BondingManager")
 var RoundsManager = artifacts.require("RoundsManager")
 var JobsManager = artifacts.require("JobsManager")
+var IdentityVerifier = artifacts.require("IdentityVerifier")
 
 const ROUND_LENGTH = 50
 const NUM_ACTIVE_TRANSCODERS = 1
@@ -38,7 +39,9 @@ contract("JobsManager", accounts => {
         token.transferOwnership(bondingManager.address, {from: accounts[0]})
 
         roundsManager = await RoundsManager.new()
-        jobsManager = await JobsManager.new()
+
+        const verifier = await IdentityVerifier.new()
+        jobsManager = await JobsManager.new(verifier.address)
 
         const protocol = await LivepeerProtocol.new()
         const bondingManagerKey = await protocol.bondingManagerKey.call()


### PR DESCRIPTION
Addresses #27 

Things to note:

- We will need to keep track of how many failed verifications a transcoder has. One option is to update the state of a transcoder in `BondingManager` from `JobsManager`. Another option is to keep track of failed verifications separately in a `VerificationManager` which might handle state for verification and slashing. I lean toward the latter at the moment since it isolates verification logic, but will explore more as we implement a non-trivial `Verifier` contract (i.e. Oraclize) that will actually return `false` for failed verifications.