### PR TITLE
Keep track of all registered transcoders

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -83,9 +83,6 @@ contract BondingManager is IBondingManager, Manager {
     mapping (address => Delegator) public delegators;
     mapping (address => Transcoder) public transcoders;
 
-    // Keep track of all transcoder addresses
-    address[] public registeredTranscoders;
-
     // Active and candidate transcoder pools
     TranscoderPools.TranscoderPools transcoderPools;
 
@@ -155,7 +152,9 @@ contract BondingManager is IBondingManager, Manager {
         t.pendingFeeShare = _feeShare;
         t.pendingPricePerSegment = _pricePerSegment;
 
-        registeredTranscoders.push(msg.sender);
+        if (!transcoderPools.isInPools(msg.sender)) {
+            transcoderPools.addTranscoder(msg.sender, 0);
+        }
 
         return true;
     }
@@ -630,10 +629,33 @@ contract BondingManager is IBondingManager, Manager {
     }
 
     /*
-     * @dev Return number of registered transcoders
+     * @dev Return current size of candidate transcoder pool
      */
-    function getTotalRegisteredTranscoders() public constant returns (uint256) {
-        return registeredTranscoders.length;
+    function getCandidatePoolSize() public constant returns (uint256) {
+        return transcoderPools.getCandidatePoolSize();
+    }
+
+    /*
+     * @dev Return current size of reserve transcoder pool
+     */
+    function getReservePoolSize() public constant returns (uint256) {
+        return transcoderPools.getReservePoolSize();
+    }
+
+    /*
+     * @dev Return candidate transcoder at position in candidate pool
+     * @param _position Position in candidate pool
+     */
+    function getCandidateTranscoderAtPosition(uint256 _position) public constant returns (address) {
+        return transcoderPools.getCandidateTranscoderAtPosition(_position);
+    }
+
+    /*
+     * @dev Return reserve transcoder at postiion in reserve pool
+     * @param _position Position in reserve pool
+     */
+    function getReserveTranscoderAtPosition(uint256 _position) public constant returns (address) {
+        return transcoderPools.getReserveTranscoderAtPosition(_position);
     }
 
      /*

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -281,11 +281,11 @@ contract BondingManager is IBondingManager, Manager {
         // Current round must be initialized
         require(roundsManager().currentRoundInitialized());
 
-        if (transcoderStatus(msg.sender) == TranscoderStatus.Unbonding) {
+        if (transcoderStatus(msg.sender) == TranscoderStatus.Unbonded) {
             token.transfer(msg.sender, transcoders[msg.sender].bondedAmount);
 
             delete transcoders[msg.sender];
-        } else if (delegatorStatus(msg.sender) == DelegatorStatus.Unbonding){
+        } else if (delegatorStatus(msg.sender) == DelegatorStatus.Unbonded){
             token.transfer(msg.sender, delegators[msg.sender].bondedAmount);
 
             delete delegators[msg.sender];
@@ -612,7 +612,7 @@ contract BondingManager is IBondingManager, Manager {
         } else if (del.startRound > roundsManager().currentRound()) {
             // Delegator round start is in the future
             return DelegatorStatus.Pending;
-        } else if (del.startRound <= roundsManager().currentRound()) {
+        } else if (del.startRound > 0 && del.startRound <= roundsManager().currentRound()) {
             // Delegator round start is now or in the past
             return DelegatorStatus.Bonded;
         } else {

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -83,6 +83,9 @@ contract BondingManager is IBondingManager, Manager {
     mapping (address => Delegator) public delegators;
     mapping (address => Transcoder) public transcoders;
 
+    // Keep track of all transcoder addresses
+    address[] public registeredTranscoders;
+
     // Active and candidate transcoder pools
     TranscoderPools.TranscoderPools transcoderPools;
 
@@ -151,6 +154,8 @@ contract BondingManager is IBondingManager, Manager {
         t.pendingBlockRewardCut = _blockRewardCut;
         t.pendingFeeShare = _feeShare;
         t.pendingPricePerSegment = _pricePerSegment;
+
+        registeredTranscoders.push(msg.sender);
 
         return true;
     }
@@ -625,6 +630,13 @@ contract BondingManager is IBondingManager, Manager {
     }
 
     /*
+     * @dev Return number of registered transcoders
+     */
+    function getTotalRegisteredTranscoders() public constant returns (uint256) {
+        return registeredTranscoders.length;
+    }
+
+     /*
      * @dev Computes token distribution for delegator since its last state transition
      * @param _delegator Address of delegator
      */

--- a/contracts/bonding/libraries/TranscoderPools.sol
+++ b/contracts/bonding/libraries/TranscoderPools.sol
@@ -46,6 +46,36 @@ library TranscoderPools {
     }
 
     /*
+     * Returns address of candidate transcoder at a position in the heap
+     * @param _position Position in candidate transcoder heap
+     */
+    function getCandidateTranscoderAtPosition(TranscoderPools storage self, uint256 _position) constant returns (address) {
+        return self.candidateTranscoders.nodes[_position].id;
+    }
+
+    /*
+     * Returns address of reserve transcoder at a position in the heap
+     * @param _position Position in reserve transcoder heap
+     */
+    function getReserveTranscoderAtPosition(TranscoderPools storage self, uint256 _position) constant returns (address) {
+        return self.reserveTranscoders.nodes[_position].id;
+    }
+
+    /*
+     * Returns current size of candidate pool
+     */
+    function getCandidatePoolSize(TranscoderPools storage self) constant returns (uint256) {
+        return self.candidateTranscoders.nodes.length;
+    }
+
+    /*
+     * Returns current size of reserve pool
+     */
+    function getReservePoolSize(TranscoderPools storage self) constant returns (uint256) {
+        return self.reserveTranscoders.nodes.length;
+    }
+
+    /*
      * Adds a transcoder to a pool. Throws if transcoder is already in a pool
      * @param _transcoder Address of transcoder
      * @param _amount The cumulative amount of LPT bonded to the transcoder

--- a/migrations/3_deploy_contracts.js
+++ b/migrations/3_deploy_contracts.js
@@ -4,7 +4,7 @@ const JobsManager = artifacts.require("JobsManager")
 const BondingManager = artifacts.require("BondingManager")
 const RoundsManager = artifacts.require("RoundsManager")
 const IdentityVerifier = artifacts.require("IdentityVerifier")
-const OraclizeVerifier = artifacts.require("OraclizeVerifier")
+// const OraclizeVerifier = artifacts.require("OraclizeVerifier")
 const LivepeerProtocol = artifacts.require("LivepeerProtocol")
 const LivepeerToken = artifacts.require("LivepeerToken")
 
@@ -16,14 +16,16 @@ module.exports = function(deployer, network) {
         if (network == "development") {
             return deployer.deploy(IdentityVerifier)
         } else {
-            return deployer.deploy(OraclizeVerifier)
+            return deployer.deploy(IdentityVerifier)
+            // return deployer.deploy(OraclizeVerifier)
         }
     }).then(() => {
         return deployer.deploy(
             JobsManager,
             LivepeerProtocol.address,
             LivepeerToken.address,
-            network == "development" ? IdentityVerifier.address : OraclizeVerifier.address,
+            IdentityVerifier.address,
+            // network == "development" ? IdentityVerifier.address : OraclizeVerifier.address,
             config.jobsManager.verificationRate,
             config.jobsManager.jobEndingPeriod,
             config.jobsManager.verificationPeriod,

--- a/test/bonding/BondingManager.js
+++ b/test/bonding/BondingManager.js
@@ -286,6 +286,9 @@ contract("BondingManager", accounts => {
             // Set active transcoders
             await roundsManager.initializeRound()
 
+            // Set current round so delegator is bonded
+            await roundsManager.setCurrentRound(7)
+
             // Call updateTranscoderFeePool via transaction from JobsManager
             await jobsManager.distributeFees()
         })


### PR DESCRIPTION
Added an array to keep track of addresses of all registered transcoders so a client can iterate through the array to retrieve addresses and then use the addresses to get transcoder stats from the `transcoders` map.

Also, defaulting to deploying with the `IdentityVerifier` for all networks for the time being until `OraclizeVerifier` + IPFS node integration is ready.