### PR TITLE
Transcoder earns share of reward as a delegator. Fixes #64

### DIFF
--- a/contracts/test/RoundsManagerMock.sol
+++ b/contracts/test/RoundsManagerMock.sol
@@ -25,6 +25,10 @@ contract RoundsManagerMock is IRoundsManager {
         return true;
     }
 
+    function setRoundsPerYear(uint256 _roundsPerYear) external returns (uint256) {
+        mockRoundsPerYear = _roundsPerYear;
+    }
+
     function initializeRound() external returns (bool) {
         return bondingManager.setActiveTranscoders();
     }


### PR DESCRIPTION
When a transcoder calls reward, it should receive not only the block reward cut, but also its sahre of the delegator rewards if it is bonded to itself. Calculate transcoder reward share as `(mintedTokens * blockRewardCut / 100)` + `delegatorRewardShare * transcoderBond / transcoderTotalStake` where `delegatorRewardShare = mintedTokens * (100 - blockRewardCut) / 100`.