### PR TITLE
Verifier checks commit hash defined as h(dataHash,transcodedDataHash)

### DIFF
--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -253,8 +253,8 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
      * @dev Submit transcode receipt and invoke transcoding verification
      * @param _jobId Job identifier
      * @param _segmentNumber Segment sequence number in stream
-     * @param _dataHash Content-addressed storage hash of segment data
-     * @param _transcodedDataHash Hash of transcoded segment data
+     * @param _dataStorageHash Content-addressed storage hash of segment data
+     * @param _dataHashes Hash of segment data and hash of transcoded segment data
      * @param _broadcasterSig Broadcaster's signature over segment hash
      * @param _proof Merkle proof for transcode receipt
      */
@@ -263,8 +263,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         uint256 _claimId,
         uint256 _segmentNumber,
         string _dataStorageHash,
-        bytes32 _dataHash,
-        bytes32 _transcodedDataHash,
+        bytes32[2] _dataHashes,
         bytes _broadcasterSig,
         bytes _proof
     )
@@ -288,15 +287,15 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         // Segment must be eligible for verification
         require(JobLib.shouldVerifySegment(_segmentNumber, claim.segmentRange, claim.claimBlock, verificationRate));
         // Segment must be signed by broadcaster
-        require(JobLib.validateBroadcasterSig(job.streamId, _segmentNumber, _dataHash, _broadcasterSig, job.broadcasterAddress));
+        require(JobLib.validateBroadcasterSig(job.streamId, _segmentNumber, _dataHashes[0], _broadcasterSig, job.broadcasterAddress));
         // Receipt must be valid
-        require(JobLib.validateReceipt(job.streamId, _segmentNumber, _dataHash, _transcodedDataHash, _broadcasterSig, _proof, claim.claimRoot));
+        require(JobLib.validateReceipt(job.streamId, _segmentNumber, _dataHashes[0], _dataHashes[1], _broadcasterSig, _proof, claim.claimRoot));
 
         // Mark segment as submitted for verification
         claim.segmentVerifications[_segmentNumber] = true;
 
         // Invoke transcoding verification. This is async and will result in a callback to receiveVerification() which is implemented by this contract
-        invokeVerification(_jobId, _claimId, _segmentNumber, _dataStorageHash, _transcodedDataHash);
+        invokeVerification(_jobId, _claimId, _segmentNumber, _dataStorageHash, _dataHashes);
 
         return true;
     }
@@ -307,14 +306,14 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
      * @param _claimId Claim identifier
      * @param _segmentNumber Segment sequence number in stream
      * @param _dataStorageHash Content addressable storage hash of segment data
-     * @param _transcodedDataHash Keccak256 hash of transcoded segment data
+     * @param _dataHashes Hash of segment data and hash of transcoded segment data
      */
     function invokeVerification(
         uint256 _jobId,
         uint256 _claimId,
         uint256 _segmentNumber,
         string _dataStorageHash,
-        bytes32 _transcodedDataHash
+        bytes32[2] _dataHashes
     )
         internal
         returns (bool)
@@ -325,9 +324,9 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
 
         // Send payment to verifier if price is greater than zero
         if (price > 0) {
-            return verifierContract.verify.value(price)(_jobId, _claimId, _segmentNumber, jobs[_jobId].transcodingOptions, _dataStorageHash, _transcodedDataHash);
+            return verifierContract.verify.value(price)(_jobId, _claimId, _segmentNumber, jobs[_jobId].transcodingOptions, _dataStorageHash, _dataHashes);
         } else {
-            return verifierContract.verify(_jobId, _claimId, _segmentNumber, jobs[_jobId].transcodingOptions, _dataStorageHash, _transcodedDataHash);
+            return verifierContract.verify(_jobId, _claimId, _segmentNumber, jobs[_jobId].transcodingOptions, _dataStorageHash, _dataHashes);
         }
     }
 

--- a/contracts/test/JobsManagerMock.sol
+++ b/contracts/test/JobsManagerMock.sol
@@ -17,7 +17,7 @@ contract JobsManagerMock is IJobsManager {
     uint256 public segmentNumber;
     string public transcodingOptions;
     string public dataStorageHash;
-    bytes32 public transcodedDataHash;
+    bytes32[2] public dataHashes;
     uint256 public fees;
     uint256 public claimBlock;
     uint256 public transcoderTotalStake;
@@ -38,13 +38,13 @@ contract JobsManagerMock is IJobsManager {
         verifier = IVerifier(_verifier);
     }
 
-    function setVerifyParams(uint256 _jobId, uint256 _claimId, uint256 _segmentNumber, string _transcodingOptions, string _dataStorageHash, bytes32 _transcodedDataHash) external {
+    function setVerifyParams(uint256 _jobId, uint256 _claimId, uint256 _segmentNumber, string _transcodingOptions, string _dataStorageHash, bytes32[2] _dataHashes) external {
         jobId = _jobId;
         claimId = _claimId;
         segmentNumber = _segmentNumber;
         transcodingOptions = _transcodingOptions;
         dataStorageHash = _dataStorageHash;
-        transcodedDataHash = _transcodedDataHash;
+        dataHashes = _dataHashes;
     }
 
     function setTranscoder(address _transcoder) external {
@@ -88,7 +88,7 @@ contract JobsManagerMock is IJobsManager {
     }
 
     function callVerify() external payable {
-        verifier.verify.value(msg.value)(jobId, claimId, segmentNumber, transcodingOptions, dataStorageHash, transcodedDataHash);
+        verifier.verify.value(msg.value)(jobId, claimId, segmentNumber, transcodingOptions, dataStorageHash, dataHashes);
     }
 
     function receiveVerification(uint256 _jobId, uint256 _claimId, uint256 _segmentNumber, bool _result) external returns (bool) {

--- a/contracts/test/VerifierMock.sol
+++ b/contracts/test/VerifierMock.sol
@@ -39,7 +39,7 @@ contract VerifierMock is IVerifier {
         uint256 _segmentNumber,
         string _transcodingOptions,
         string _dataStorageHash,
-        bytes32 _transcodedDataHash
+        bytes32[2] _dataHashes
     )
         external
         payable

--- a/contracts/verification/IVerifier.sol
+++ b/contracts/verification/IVerifier.sol
@@ -11,7 +11,7 @@ contract IVerifier {
         uint256 _segmentNumber,
         string _transcodingOptions,
         string _dataStorageHash,
-        bytes32 _transcodedDataHash
+        bytes32[2] _dataHashes
     ) external payable returns (bool);
 
     function getPrice() public constant returns (uint256);

--- a/contracts/verification/IdentityVerifier.sol
+++ b/contracts/verification/IdentityVerifier.sol
@@ -23,8 +23,7 @@ contract IdentityVerifier is Manager, IVerifier {
      * @param _segmentNumber Segment being verified for job
      * @param _code Content-addressed storage hash of binary to execute off-chain
      * @param _dataStorageHash Content-addressed storage hash of input data of segment
-     * @param _transcodedDataHash Hash of transcoded segment data
-     * @param _callbackContract Address of Verifiable contract to call back
+     * @param _dataHashes Hash of segment data and hash of transcoded segment data
      */
     function verify(
         uint256 _jobId,
@@ -32,7 +31,7 @@ contract IdentityVerifier is Manager, IVerifier {
         uint256 _segmentNumber,
         string _transcodingOptions,
         string _dataStorageHash,
-        bytes32 _transcodedDataHash
+        bytes32[2] _dataHashes
     )
         external
         onlyJobsManager

--- a/contracts/verification/LivepeerVerifier.sol
+++ b/contracts/verification/LivepeerVerifier.sol
@@ -35,7 +35,7 @@ contract LivepeerVerifier is Manager, IVerifier {
         _;
     }
 
-    event VerifyRequest(uint256 indexed requestId, uint256 indexed jobId, uint256 indexed claimId, uint256 segmentNumber, string transcodingOptions, string dataStorageHash, bytes32 transcodedDataHash);
+    event VerifyRequest(uint256 indexed requestId, uint256 indexed jobId, uint256 indexed claimId, uint256 segmentNumber, string transcodingOptions, string dataStorageHash, bytes32 dataHash, bytes32 transcodedDataHash);
     event Callback(uint256 indexed requestId, uint256 indexed jobId, uint256 indexed claimId, uint256 segmentNumber, bool result);
 
     function LivepeerVerifier(address _controller, address[] _solvers, string _verificationCodeHash) Manager(_controller) {
@@ -60,7 +60,7 @@ contract LivepeerVerifier is Manager, IVerifier {
         uint256 _segmentNumber,
         string _transcodingOptions,
         string _dataStorageHash,
-        bytes32 _transcodedDataHash
+        bytes32[2] _dataHashes
     )
         external
         payable
@@ -71,9 +71,9 @@ contract LivepeerVerifier is Manager, IVerifier {
         requests[requestCount].jobId = _jobId;
         requests[requestCount].claimId = _claimId;
         requests[requestCount].segmentNumber = _segmentNumber;
-        requests[requestCount].transcodedDataHash = _transcodedDataHash;
+        requests[requestCount].transcodedDataHash = _dataHashes[1];
 
-        VerifyRequest(requestCount, _jobId, _claimId, _segmentNumber, _transcodingOptions, _dataStorageHash, _transcodedDataHash);
+        VerifyRequest(requestCount, _jobId, _claimId, _segmentNumber, _transcodingOptions, _dataStorageHash, _dataHashes[0], _dataHashes[1]);
 
         // Update request count
         requestCount++;

--- a/contracts/verification/LivepeerVerifier.sol
+++ b/contracts/verification/LivepeerVerifier.sol
@@ -17,7 +17,7 @@ contract LivepeerVerifier is Manager, IVerifier {
         uint256 jobId;
         uint256 claimId;
         uint256 segmentNumber;
-        bytes32 transcodedDataHash;
+        bytes32 commitHash;
     }
 
     mapping (uint256 => Request) public requests;
@@ -71,7 +71,7 @@ contract LivepeerVerifier is Manager, IVerifier {
         requests[requestCount].jobId = _jobId;
         requests[requestCount].claimId = _claimId;
         requests[requestCount].segmentNumber = _segmentNumber;
-        requests[requestCount].transcodedDataHash = _dataHashes[1];
+        requests[requestCount].commitHash = keccak256(_dataHashes[0], _dataHashes[1]);
 
         VerifyRequest(requestCount, _jobId, _claimId, _segmentNumber, _transcodingOptions, _dataStorageHash, _dataHashes[0], _dataHashes[1]);
 
@@ -90,7 +90,7 @@ contract LivepeerVerifier is Manager, IVerifier {
         Request memory q = requests[_requestId];
 
         // Check if transcoded data hash returned by solver matches originally submitted transcoded data hash
-        if (q.transcodedDataHash == _result) {
+        if (q.commitHash == _result) {
             IVerifiable(controller.getContract(keccak256("JobsManager"))).receiveVerification(q.jobId, q.claimId, q.segmentNumber, true);
             Callback(_requestId, q.jobId, q.claimId, q.segmentNumber, true);
         } else {

--- a/test/jobs/JobsManager.js
+++ b/test/jobs/JobsManager.js
@@ -308,6 +308,7 @@ contract("JobsManager", accounts => {
         const dataStorageHash = "0x123"
         const correctDataHash = dataHashes[0]
         const correctTDataHash = tDataHashes[0]
+        const correctDataHashes = [correctDataHash, correctTDataHash]
         const correctSig = ethUtil.bufferToHex(segments[0].signedHash())
         const correctProof = merkleTree.getHexProof(tReceiptHashes[0])
 
@@ -345,55 +346,55 @@ contract("JobsManager", accounts => {
         it("should throw for insufficient payment for verification", async () => {
             await fixture.verifier.setPrice(10)
             // Transcoder calls verify with 0 payment
-            await expectThrow(jobsManager.verify(jobId, claimId, segmentNumber, dataStorageHash, correctDataHash, correctTDataHash, correctSig, correctProof, {from: electedTranscoder}))
+            await expectThrow(jobsManager.verify(jobId, claimId, segmentNumber, dataStorageHash, correctDataHashes, correctSig, correctProof, {from: electedTranscoder}))
         })
 
         it("should throw for invalid job id", async () => {
             const invalidJobId = 2
             // Transcoder calls verify with invalid job id
-            await expectThrow(jobsManager.verify(invalidJobId, claimId, segmentNumber, dataStorageHash, correctDataHash, correctTDataHash, correctSig, correctProof, {from: electedTranscoder}))
+            await expectThrow(jobsManager.verify(invalidJobId, claimId, segmentNumber, dataStorageHash, correctDataHashes, correctSig, correctProof, {from: electedTranscoder}))
         })
 
         it("should throw for invalid claim id", async () => {
             const invalidClaimId = 1
             // Transcoder calls verify with invalid claim id
-            await expectThrow(jobsManager.verify(jobId, invalidClaimId, segmentNumber, dataStorageHash, correctDataHash, correctTDataHash, correctSig, correctProof, {from: electedTranscoder}))
+            await expectThrow(jobsManager.verify(jobId, invalidClaimId, segmentNumber, dataStorageHash, correctDataHashes, correctSig, correctProof, {from: electedTranscoder}))
         })
 
         it("should throw for inactive job", async () => {
             const inactiveJobId = 1
             // Transcoder calls verify with inactive job
-            await expectThrow(jobsManager.verify(inactiveJobId, claimId, segmentNumber, dataStorageHash, correctDataHash, correctTDataHash, correctSig, correctProof, {from: electedTranscoder}))
+            await expectThrow(jobsManager.verify(inactiveJobId, claimId, segmentNumber, dataStorageHash, correctDataHashes, correctSig, correctProof, {from: electedTranscoder}))
         })
 
         it("should throw if sender is not elected transcoder", async () => {
             // Account 2 (not elected transcoder) calls verify
-            await expectThrow(jobsManager.verify(jobId, claimId, segmentNumber, dataStorageHash, correctDataHash, correctTDataHash, correctSig, correctProof, {from: accounts[2]}))
+            await expectThrow(jobsManager.verify(jobId, claimId, segmentNumber, dataStorageHash, correctDataHashes, correctSig, correctProof, {from: accounts[2]}))
         })
 
         it("should throw if segment is not eligible for verification", async () => {
             const invalidSegmentNumber = 99
             // Transcoder calls verify with invalid segment number
-            await expectThrow(jobsManager.verify(jobId, claimId, invalidSegmentNumber, dataStorageHash, correctDataHash, correctTDataHash, correctSig, correctProof, {from: electedTranscoder}))
+            await expectThrow(jobsManager.verify(jobId, claimId, invalidSegmentNumber, dataStorageHash, correctDataHashes, correctSig, correctProof, {from: electedTranscoder}))
         })
 
         it("should throw if segment not signed by broadcaster", async () => {
             const badSig = web3.eth.sign(accounts[3], ethUtil.bufferToHex(segments[0].hash()))
             // This should fail because badSig is signed by Account 3 and not the broadcaster
-            await expectThrow(jobsManager.verify(jobId, claimId, segmentNumber, dataStorageHash, correctDataHash, correctTDataHash, badSig, correctProof, {from: electedTranscoder}))
+            await expectThrow(jobsManager.verify(jobId, claimId, segmentNumber, dataStorageHash, correctDataHashes, badSig, correctProof, {from: electedTranscoder}))
         })
 
         it("should throw if submitted Merkle proof is invalid", async () => {
             const badSig = ethUtil.bufferToHex(segments[3].signedHash())
             // This should fail because badSig is the sig for segment 3 but the receipt being verified is for segment 0
-            await expectThrow(jobsManager.verify(jobId, claimId, segmentNumber, dataStorageHash, correctDataHash, correctTDataHash, badSig, correctProof, {from: electedTranscoder}))
+            await expectThrow(jobsManager.verify(jobId, claimId, segmentNumber, dataStorageHash, correctDataHashes, badSig, correctProof, {from: electedTranscoder}))
         })
 
         it("should not throw for successful verify call", async () => {
             // Set price to 100 wei
             await fixture.verifier.setPrice(100)
             // Transcoder calls verify with 100 wei payment
-            await jobsManager.verify(jobId, claimId, segmentNumber, dataStorageHash, correctDataHash, correctTDataHash, correctSig, correctProof, {from: electedTranscoder, value: 100})
+            await jobsManager.verify(jobId, claimId, segmentNumber, dataStorageHash, correctDataHashes, correctSig, correctProof, {from: electedTranscoder, value: 100})
         })
     })
 
@@ -628,6 +629,7 @@ contract("JobsManager", accounts => {
         const dataStorageHash = "0x123"
         const correctDataHash = dataHashes[0]
         const correctTDataHash = tDataHashes[0]
+        const correctDataHashes = [correctDataHash, correctTDataHash]
         const correctSig = ethUtil.bufferToHex(segments[0].signedHash())
         const correctProof = merkleTree.getHexProof(tReceiptHashes[0])
 
@@ -679,7 +681,7 @@ contract("JobsManager", accounts => {
 
         it("should throw if segment was verified", async () => {
             // Transcoder calls verify
-            await jobsManager.verify(jobId, claimId, segmentNumber, dataStorageHash, correctDataHash, correctTDataHash, correctSig, correctProof, {from: electedTranscoder})
+            await jobsManager.verify(jobId, claimId, segmentNumber, dataStorageHash, correctDataHashes, correctSig, correctProof, {from: electedTranscoder})
             // Fast foward through verification period
             const verificationPeriod = await jobsManager.verificationPeriod.call()
             await fixture.rpc.wait(verificationPeriod.toNumber())

--- a/truffle.js
+++ b/truffle.js
@@ -15,4 +15,4 @@ module.exports = {
             network_id: 777
         }
     }
-};
+}

--- a/verification_test/OraclizeVerifier.js
+++ b/verification_test/OraclizeVerifier.js
@@ -12,7 +12,7 @@ contract("OraclizeVerifier", accounts => {
     let verifier
 
     // IPFS hash of Dockerfile archive
-    const codeHash = "QmZmvi1BaYSdxM1Tgwhi2mURabh46xCkzuH9PWeAkAZZGc"
+    const codeHash = "QmXKxSKhUZnmjb53HzS94arpshet3N5Kmct8JBAsgm9umR"
 
     before(async () => {
         fixture = new Fixture(web3)
@@ -36,8 +36,12 @@ contract("OraclizeVerifier", accounts => {
         const transcodingOptions = "P720p60fps16x9,P720p30fps16x9"
         // IPFS hash of seg.ts
         const dataStorageHash = "QmR9BnJQisvevpCoSVWWKyownN58nydb2zQt9Z2VtnTnKe"
+        // Keccak256 hash of segment data
+        const dataHash = "0xcda2f677da4cdf85364c90a85a8ecfdaa8b5677aeca346efa2a5247654079a29"
         // Keccak256 hash of transcoded data
         const transcodedDataHash = "0x77903c5de84acf703524da5547df170612ab9308edfec742f5f22f5dc0cfb76a"
+
+        const dataHashes = [dataHash, transcodedDataHash]
 
         it("should trigger async callback from Oraclize", async () => {
             const e = verifier.OraclizeCallback({})
@@ -51,7 +55,7 @@ contract("OraclizeVerifier", accounts => {
                 assert.equal(result.args.result, true, "callback result incorrect")
             })
 
-            await fixture.jobsManager.setVerifyParams(jobId, claimId, segmentNumber, transcodingOptions, dataStorageHash, transcodedDataHash)
+            await fixture.jobsManager.setVerifyParams(jobId, claimId, segmentNumber, transcodingOptions, dataStorageHash, dataHashes)
 
             const price = await verifier.getPrice()
             await fixture.jobsManager.callVerify({from: accounts[0], value: price})


### PR DESCRIPTION
Previously, a verifier contract did not check if the dataHash submitted by a transcoder matches the data located at the dataStorageHash submitted. Now the off-chain computation (Oraclize, an off-chain solver, etc.) will download `data` using the dataStorageHash, and submit back on-chain `keccak256(keccak256(data),transcodedDataHash)`. The verifier contract will compare this result with `keccak256(dataHash,transcodedDataHash)` where `dataHash` and `transcodedDataHash` are submitted by the transcoder, which is defined as the commit hash. If the transcoder provides a `dataStorageHash` that does not contain the data that matches `dataHash`, then this check will fail.