### PR TITLE
Calculate fees based on number of video profiles

### DIFF
--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -223,7 +223,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         require(_segmentRange[1] >= _segmentRange[0]);
 
         // Move fees from broadcaster deposit to escrow
-        uint256 fees = _segmentRange[1].sub(_segmentRange[0]).add(1).mul(job.maxPricePerSegment);
+        uint256 fees = JobLib.calcFees(_segmentRange[1].sub(_segmentRange[0]).add(1), job.transcodingOptions, job.maxPricePerSegment);
         broadcasterDeposits[job.broadcasterAddress] = broadcasterDeposits[job.broadcasterAddress].sub(fees);
         job.escrow = job.escrow.add(fees);
 
@@ -432,7 +432,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         // Slashing period must be over for claim
         require(claim.endSlashingBlock < block.number);
 
-        uint256 fees = claim.segmentRange[1].sub(claim.segmentRange[0]).add(1).mul(job.maxPricePerSegment);
+        uint256 fees = JobLib.calcFees(claim.segmentRange[1].sub(claim.segmentRange[0]).add(1), job.transcodingOptions, job.maxPricePerSegment);
         // Deduct fees from escrow
         job.escrow = job.escrow.sub(fees);
         // Add fees to transcoder's fee pool
@@ -536,7 +536,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         Claim storage claim = job.claims[_claimId];
 
         // Return escrowed fees for claim
-        uint256 fees = claim.segmentRange[1].sub(claim.segmentRange[0]).add(1).mul(job.maxPricePerSegment);
+        uint256 fees = JobLib.calcFees(claim.segmentRange[1].sub(claim.segmentRange[0]).add(1), job.transcodingOptions, job.maxPricePerSegment);
         job.escrow = job.escrow.sub(fees);
         broadcasterDeposits[job.broadcasterAddress] = broadcasterDeposits[job.broadcasterAddress].add(fees);
 

--- a/test/jobs/JobsManager.js
+++ b/test/jobs/JobsManager.js
@@ -2,6 +2,7 @@ import Fixture from "../helpers/fixture"
 import expectThrow from "../helpers/expectThrow"
 import MerkleTree from "../../utils/merkleTree"
 import batchTranscodeReceiptHashes from "../../utils/batchTranscodeReceipts"
+import {createTranscodingOptions} from "../../utils/videoProfile"
 import Segment from "../../utils/segment"
 import ethUtil from "ethereumjs-util"
 
@@ -103,7 +104,7 @@ contract("JobsManager", accounts => {
         const broadcaster = accounts[0]
         const electedTranscoder = accounts[1]
         const streamId = "1"
-        const transcodingOptions = "0x123"
+        const transcodingOptions = createTranscodingOptions(["foo", "bar"])
         const maxPricePerSegment = 100
 
         beforeEach(async () => {
@@ -159,7 +160,7 @@ contract("JobsManager", accounts => {
 
         const electedTranscoder = accounts[1]
         const streamId = "1"
-        const transcodingOptions = "0x123"
+        const transcodingOptions = createTranscodingOptions(["foo", "bar"])
         const maxPricePerSegment = 10
         const jobId = 0
         const segmentRange = [0, 3]
@@ -253,7 +254,7 @@ contract("JobsManager", accounts => {
         it("should update broadcaster deposit", async () => {
             await jobsManager.claimWork(jobId, segmentRange, claimRoot, {from: electedTranscoder})
 
-            const fees = maxPricePerSegment * (segmentRange[1] - segmentRange[0] + 1)
+            const fees = maxPricePerSegment * 2 * (segmentRange[1] - segmentRange[0] + 1)
 
             const jEscrow = await jobsManager.getJobEscrow(jobId)
             assert.equal(jEscrow, fees, "escrow is incorrect")
@@ -262,7 +263,7 @@ contract("JobsManager", accounts => {
         it("should update job escrow", async () => {
             await jobsManager.claimWork(jobId, segmentRange, claimRoot, {from: electedTranscoder})
 
-            const fees = maxPricePerSegment * (segmentRange[1] - segmentRange[0] + 1)
+            const fees = maxPricePerSegment * 2 * (segmentRange[1] - segmentRange[0] + 1)
             const expDeposit = deposit - fees
 
             const newDeposit = await jobsManager.broadcasterDeposits.call(broadcaster)
@@ -421,7 +422,7 @@ contract("JobsManager", accounts => {
             await jobsManager.deposit(1000, {from: broadcaster})
 
             const streamId = "1"
-            const transcodingOptions = "0x123"
+            const transcodingOptions = createTranscodingOptions(["foo", "bar"])
             // Broadcaster creates job 0
             await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, {from: broadcaster})
 
@@ -558,7 +559,7 @@ contract("JobsManager", accounts => {
             await jobsManager.deposit(1000, {from: broadcaster})
 
             const streamId = "1"
-            const transcodingOptions = "0x123"
+            const transcodingOptions = createTranscodingOptions(["foo", "bar"])
             // Broadcaster creates job 0
             await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, {from: broadcaster})
 
@@ -583,7 +584,7 @@ contract("JobsManager", accounts => {
             await jobsManager.batchDistributeFees(jobId, claimIds, {from: electedTranscoder})
 
             const jEscrow = await jobsManager.getJobEscrow(jobId)
-            assert.equal(jEscrow, 40, "escrow is incorrect")
+            assert.equal(jEscrow, 80, "escrow is incorrect")
 
             const cStatus0 = await jobsManager.getClaimStatus(jobId, 0)
             assert.equal(cStatus0, 2, "claim 0 status incorrect")
@@ -648,7 +649,7 @@ contract("JobsManager", accounts => {
 
             await jobsManager.deposit(1000, {from: broadcaster})
 
-            const transcodingOptions = "0x123"
+            const transcodingOptions = createTranscodingOptions(["foo", "bar"])
             // Broadcaster creates job 0
             await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, {from: broadcaster})
 

--- a/utils/videoProfile.js
+++ b/utils/videoProfile.js
@@ -1,0 +1,11 @@
+import ethUtil from "ethereumjs-util"
+
+export const videoProfileId = name => {
+    return ethUtil.sha3(name).slice(0, 4).toString("hex")
+}
+
+export const createTranscodingOptions = names => {
+    return names.map(name => {
+        return videoProfileId(name)
+    }).join("")
+}


### PR DESCRIPTION
- Video profile identifiers calculated as `bytes4(keccak256(PROFILE_NAME))`
- We keep `transcodingOptions` as a string so the identifiers can be easily parsed by the Docker application that Oraclize passes the string to as a parameter
- Since we keep `transcodingOptions` as a utf8 encoded string, we actually use 8 bytes to store the utf8 encoded representation of the first 4 bytes of the keccak hash of a video profile name (4 bytes  * 2 characters per byte)

Fixes #78 