### PR TITLE
Unbonded fee payouts + delayed computation of transcoder bonded/unbonded amounts

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -108,7 +108,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         if (delegatorStatus(msg.sender) == DelegatorStatus.Bonded && transcoderStatus(del.delegateAddress) == TranscoderStatus.Registered) {
             uint256 rewardsAndFees = delegatorTokenPoolsShare(del);
             del.bondedAmount = del.bondedAmount.add(rewardsAndFees);
-            delegators[del.delegateAddress].delegatedAmount = delegators[del.delegateAddress].delegatedAmount.add(rewardsAndFees);
         }
 
         del.lastStakeUpdateRound = roundsManager().currentRound();

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -700,7 +700,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         rewardPool.rewards = rewardPool.rewards.add(_rewards.sub(transcoderRewardShare));
 
         if (rewardPool.transcoderTotalStake == 0) {
-            rewardPool.transcoderTotalStake = transcoderTotalStake(_transcoder);
+            rewardPool.transcoderTotalStake = activeTranscoderTotalStake(_transcoder);
         }
 
         increaseTranscoderStake(_transcoder, _rewards, transcoderRewardShare, _round);

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -273,18 +273,20 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         autoClaimTokenPoolsShares
         returns (bool)
     {
+        // Delegator must either have unbonded tokens or be in the unbonded state
+        require(delegators[msg.sender].unbondedAmount > 0 || delegatorStatus(msg.sender) == DelegatorStatus.Unbonded);
+
         uint256 amount = 0;
 
         if (delegators[msg.sender].unbondedAmount > 0) {
             // Withdraw unbonded amount
-            amount = delegators[msg.sender].unbondedAmount;
+            amount = amount.add(delegators[msg.sender].unbondedAmount);
             delegators[msg.sender].unbondedAmount = 0;
-        } else {
-            // Delegator must be unbonded if there is not unbonded tokens to withdraw
-            require(delegatorStatus(msg.sender) == DelegatorStatus.Unbonded);
+        }
 
+        if (delegatorStatus(msg.sender) == DelegatorStatus.Unbonded) {
             // Withdraw bonded amount which is now unbonded
-            amount = delegators[msg.sender].bondedAmount;
+            amount = amount.add(delegators[msg.sender].bondedAmount);
             delete delegators[msg.sender];
         }
 

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -8,9 +8,9 @@ pragma solidity ^0.4.13;
 contract IBondingManager {
     // External functions
     function setActiveTranscoders() external returns (bool);
-    function updateTranscoderFeePool(address _transcoder, uint256 _fees, uint256 _claimBlock, uint256 _transcoderTotalStake) external returns (bool);
+    function updateTranscoderFeePool(address _transcoder, uint256 _fees, uint256 _round) external returns (bool);
     function slashTranscoder(address _transcoder, address _finder, uint64 _slashAmount, uint64 _finderFee) external returns (bool);
-    function electActiveTranscoder(uint256 _maxPricePerSegment) external constant returns (address);
+    function electActiveTranscoder(uint256 _maxPricePerSegment) external returns (address);
 
     // Public functions
     function transcoderTotalStake(address _transcoder) public constant returns (uint256);

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -8,7 +8,7 @@ pragma solidity ^0.4.13;
 contract IBondingManager {
     // External functions
     function setActiveTranscoders() external returns (bool);
-    function updateTranscoderFeePool(address _transcoder, uint256 _fees, uint256 _round) external returns (bool);
+    function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external returns (bool);
     function slashTranscoder(address _transcoder, address _finder, uint64 _slashAmount, uint64 _finderFee) external returns (bool);
     function electActiveTranscoder(uint256 _maxPricePerSegment) external returns (address);
 

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -14,4 +14,5 @@ contract IBondingManager {
 
     // Public functions
     function transcoderTotalStake(address _transcoder) public constant returns (uint256);
+    function activeTranscoderTotalStake(address _transcoder) public constant returns (uint256);
 }

--- a/contracts/bonding/libraries/TokenPools.sol
+++ b/contracts/bonding/libraries/TokenPools.sol
@@ -1,0 +1,75 @@
+pragma solidity ^0.4.13;
+
+import "zeppelin-solidity/contracts/math/SafeMath.sol";
+
+
+library TokenPools {
+    using SafeMath for uint256;
+
+    // Represents rewards and fees to be distributed to delegators
+    struct Data {
+        uint256 rewardPool;      // Reward tokens in the pool. (totalStake - stakeUsed) / totalStake = % of claimable rewards in the pool
+        uint256 feePool;         // Fee tokens in the pool. (totalStake - stakeUsed) / totalStake = % of claimable fees in the pool
+        uint256 totalStake;      // Transcoder's total stake during the pool's round
+        uint256 usedStake;       // Staked used to claim from fee and reward pools
+        uint8 blockRewardCut;    // Block reward cut for the reward pool
+        uint8 feeShare;          // Fee share for the fee pool
+        bool transcoderClaimed;  // Tracks if a transcoder claimed its share
+    }
+
+    function addClaimableFees(TokenPools.Data storage tokenPools, uint256 _fees) internal returns (uint256) {
+        uint256 delegatorsFeeShare = _fees.mul(tokenPools.feeShare).div(100);
+        uint256 transcoderFeeShare = _fees.sub(delegatorsFeeShare);
+        uint256 claimableDelegatorFees = delegatorsFeeShare.mul(tokenPools.totalStake.sub(tokenPools.usedStake)).div(tokenPools.totalStake);
+        uint256 claimableFees = claimableDelegatorFees.add(transcoderFeeShare);
+        tokenPools.feePool = tokenPools.feePool.add(claimableFees);
+
+        return claimableFees;
+    }
+
+    function addClaimableRewards(TokenPools.Data storage tokenPools, uint256 _rewards) internal returns (uint256) {
+        uint256 transcoderRewardShare = _rewards.mul(tokenPools.blockRewardCut).div(100);
+        uint256 delegatorsRewardShare = _rewards.sub(transcoderRewardShare);
+        uint256 claimableDelegatorRewards = delegatorsRewardShare.mul(tokenPools.totalStake.sub(tokenPools.usedStake)).div(tokenPools.totalStake);
+        uint256 claimableRewards = claimableDelegatorRewards.add(transcoderRewardShare);
+        tokenPools.rewardPool = tokenPools.rewardPool.add(claimableRewards);
+
+        return claimableRewards;
+    }
+
+    function transcoderFeePoolShare(TokenPools.Data storage tokenPools, uint256 _stake) internal constant returns (uint256) {
+        uint256 delegatorFees = delegatorFeePoolShare(tokenPools, _stake);
+        return delegatorFees.add(tokenPools.feePool.mul(uint256(100).sub(tokenPools.feeShare)).div(100));
+    }
+
+    function delegatorFeePoolShare(TokenPools.Data storage tokenPools, uint256 _stake) internal constant returns (uint256) {
+        if (tokenPools.feePool == 0) {
+            return 0;
+        } else {
+            if (tokenPools.transcoderClaimed) {
+                return tokenPools.feePool.mul(_stake).div(tokenPools.totalStake.sub(tokenPools.usedStake));
+            } else {
+                uint256 delegatorFees = tokenPools.feePool.mul(tokenPools.feeShare).div(100);
+                return delegatorFees.mul(_stake).div(tokenPools.totalStake.sub(tokenPools.usedStake));
+            }
+        }
+    }
+
+    function transcoderRewardPoolShare(TokenPools.Data storage tokenPools, uint256 _stake) internal constant returns (uint256) {
+        uint256 delegatorRewards = delegatorRewardPoolShare(tokenPools, _stake);
+        return delegatorRewards.add(tokenPools.rewardPool.mul(tokenPools.blockRewardCut).div(100));
+    }
+
+    function delegatorRewardPoolShare(TokenPools.Data storage tokenPools, uint256 _stake) internal constant returns (uint256) {
+        if (tokenPools.rewardPool == 0) {
+            return 0;
+        } else {
+            if (tokenPools.transcoderClaimed) {
+                return tokenPools.rewardPool.mul(_stake).div(tokenPools.totalStake.sub(tokenPools.usedStake));
+            } else {
+                uint256 delegatorRewards = tokenPools.rewardPool.mul(uint256(100).sub(tokenPools.blockRewardCut)).div(100);
+                return delegatorRewards.mul(_stake).div(tokenPools.totalStake.sub(tokenPools.usedStake));
+            }
+        }
+    }
+}

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -436,7 +436,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         // Deduct fees from escrow
         job.escrow = job.escrow.sub(fees);
         // Add fees to transcoder's fee pool
-        bondingManager().updateTranscoderFeePool(msg.sender, fees, job.creationRound);
+        bondingManager().updateTranscoderWithFees(msg.sender, fees, job.creationRound);
 
         // Set claim as complete
         claim.status = ClaimStatus.Complete;

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -52,7 +52,6 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         address broadcasterAddress;           // Address of broadcaster that requestes a transcoding job
         address transcoderAddress;            // Address of transcoder selected for the job
         uint256 creationRound;                // Round that a job is created
-        uint256 transcoderTotalStake;         // Transcoder's total stake at the time of job assignment
         uint256 endBlock;                     // Block at which the job is ended and considered inactive
         Claim[] claims;                       // Claims submitted for this job
         uint256 escrow;                       // Claim fees before verification and slashing periods are complete
@@ -178,7 +177,6 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         job.broadcasterAddress = msg.sender;
         job.transcoderAddress = electedTranscoder;
         job.creationRound = roundsManager().currentRound();
-        job.transcoderTotalStake = bondingManager().activeTranscoderTotalStake(electedTranscoder);
 
         NewJob(electedTranscoder, msg.sender, numJobs, _streamId, _transcodingOptions);
 
@@ -438,7 +436,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         // Deduct fees from escrow
         job.escrow = job.escrow.sub(fees);
         // Add fees to transcoder's fee pool
-        bondingManager().updateTranscoderFeePool(msg.sender, fees, job.creationRound, job.transcoderTotalStake);
+        bondingManager().updateTranscoderFeePool(msg.sender, fees, job.creationRound);
 
         // Set claim as complete
         claim.status = ClaimStatus.Complete;
@@ -484,10 +482,6 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
 
     function getJobCreationRound(uint256 _jobId) public constant returns (uint256) {
         return jobs[_jobId].creationRound;
-    }
-
-    function getJobTranscoderTotalStake(uint256 _jobId) public constant returns (uint256) {
-        return jobs[_jobId].transcoderTotalStake;
     }
 
     function getJobEndBlock(uint256 _jobId) public constant returns (uint256) {

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -178,7 +178,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         job.broadcasterAddress = msg.sender;
         job.transcoderAddress = electedTranscoder;
         job.creationRound = roundsManager().currentRound();
-        job.transcoderTotalStake = bondingManager().transcoderTotalStake(electedTranscoder);
+        job.transcoderTotalStake = bondingManager().activeTranscoderTotalStake(electedTranscoder);
 
         NewJob(electedTranscoder, msg.sender, numJobs, _streamId, _transcodingOptions);
 

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -6,6 +6,7 @@ import "./libraries/JobLib.sol";
 import "../token/ILivepeerToken.sol";
 import "../token/IMinter.sol";
 import "../bonding/IBondingManager.sol";
+import "../rounds/IRoundsManager.sol";
 import "../verification/IVerifiable.sol";
 import "../verification/IVerifier.sol";
 
@@ -50,6 +51,8 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         uint256 maxPricePerSegment;           // Max price (in LPT base units) per segment of a stream
         address broadcasterAddress;           // Address of broadcaster that requestes a transcoding job
         address transcoderAddress;            // Address of transcoder selected for the job
+        uint256 creationRound;                // Round that a job is created
+        uint256 transcoderTotalStake;         // Transcoder's total stake at the time of job assignment
         uint256 endBlock;                     // Block at which the job is ended and considered inactive
         Claim[] claims;                       // Claims submitted for this job
         uint256 escrow;                       // Claim fees before verification and slashing periods are complete
@@ -66,7 +69,6 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         uint256 claimBlock;                                // Block number that claim was submitted
         uint256 endVerificationBlock;                      // End of verification period for this claim
         uint256 endSlashingBlock;                          // End of slashing period for this claim
-        uint256 transcoderTotalStake;                      // Transcoder's total stake at the time of claim
         mapping (uint256 => bool) segmentVerifications;    // Mapping segment number => whether segment was submitted for verification
         ClaimStatus status;                                // Status of claim (pending, slashed, complete)
     }
@@ -175,6 +177,8 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         job.maxPricePerSegment = _maxPricePerSegment;
         job.broadcasterAddress = msg.sender;
         job.transcoderAddress = electedTranscoder;
+        job.creationRound = roundsManager().currentRound();
+        job.transcoderTotalStake = bondingManager().transcoderTotalStake(electedTranscoder);
 
         NewJob(electedTranscoder, msg.sender, numJobs, _streamId, _transcodingOptions);
 
@@ -227,7 +231,6 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         broadcasterDeposits[job.broadcasterAddress] = broadcasterDeposits[job.broadcasterAddress].sub(fees);
         job.escrow = job.escrow.add(fees);
 
-        uint256 transcoderTotalStake = bondingManager().transcoderTotalStake(msg.sender);
         uint256 endVerificationBlock = block.number.add(verificationPeriod);
         uint256 endSlashingBlock = endVerificationBlock.add(slashingPeriod);
 
@@ -237,7 +240,6 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
                 segmentRange: _segmentRange,
                 claimRoot: _claimRoot,
                 claimBlock: block.number,
-                transcoderTotalStake: transcoderTotalStake,
                 endVerificationBlock: endVerificationBlock,
                 endSlashingBlock: endSlashingBlock,
                 status: ClaimStatus.Pending
@@ -436,7 +438,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         // Deduct fees from escrow
         job.escrow = job.escrow.sub(fees);
         // Add fees to transcoder's fee pool
-        bondingManager().updateTranscoderFeePool(msg.sender, fees, claim.claimBlock, claim.transcoderTotalStake);
+        bondingManager().updateTranscoderFeePool(msg.sender, fees, job.creationRound, job.transcoderTotalStake);
 
         // Set claim as complete
         claim.status = ClaimStatus.Complete;
@@ -480,6 +482,14 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         return jobs[_jobId].transcoderAddress;
     }
 
+    function getJobCreationRound(uint256 _jobId) public constant returns (uint256) {
+        return jobs[_jobId].creationRound;
+    }
+
+    function getJobTranscoderTotalStake(uint256 _jobId) public constant returns (uint256) {
+        return jobs[_jobId].transcoderTotalStake;
+    }
+
     function getJobEndBlock(uint256 _jobId) public constant returns (uint256) {
         return jobs[_jobId].endBlock;
     }
@@ -516,10 +526,6 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
 
     function getClaimEndSlashingBlock(uint256 _jobId, uint256 _claimId) public constant returns (uint256) {
         return jobs[_jobId].claims[_claimId].endSlashingBlock;
-    }
-
-    function getClaimTranscoderTotalStake(uint256 _jobId, uint256 _claimId) public constant returns (uint256) {
-        return jobs[_jobId].claims[_claimId].transcoderTotalStake;
     }
 
     function getClaimStatus(uint256 _jobId, uint256 _claimId) public constant returns (ClaimStatus) {
@@ -562,6 +568,13 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
      */
     function bondingManager() internal constant returns (IBondingManager) {
         return IBondingManager(controller.getContract(keccak256("BondingManager")));
+    }
+
+    /*
+     * @dev Returns RoundsManager
+     */
+    function roundsManager() internal constant returns (IRoundsManager) {
+        return IRoundsManager(controller.getContract(keccak256("RoundsManager")));
     }
 
     /*

--- a/contracts/rounds/RoundsManager.sol
+++ b/contracts/rounds/RoundsManager.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.13;
 import "../ManagerProxyTarget.sol";
 import "./IRoundsManager.sol";
 import "../bonding/IBondingManager.sol";
+import "../token/IMinter.sol";
 
 import "zeppelin-solidity/contracts/math/SafeMath.sol";
 
@@ -44,6 +45,7 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
         lastInitializedRound = currentRound();
 
         bondingManager().setActiveTranscoders();
+        minter().setCurrentRewardTokens();
 
         return true;
     }
@@ -82,5 +84,9 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
      */
     function bondingManager() internal constant returns (IBondingManager) {
         return IBondingManager(controller.getContract(keccak256("BondingManager")));
+    }
+
+    function minter() internal constant returns (IMinter) {
+        return IMinter(controller.getContract(keccak256("Minter")));
     }
 }

--- a/contracts/test/BondingManagerMock.sol
+++ b/contracts/test/BondingManagerMock.sol
@@ -43,7 +43,7 @@ contract BondingManagerMock is IBondingManager {
         return true;
     }
 
-    function updateTranscoderFeePool(address _transcoder, uint256 _fees, uint256 _round) external returns (bool) {
+    function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external returns (bool) {
         return true;
     }
 

--- a/contracts/test/BondingManagerMock.sol
+++ b/contracts/test/BondingManagerMock.sol
@@ -36,26 +36,34 @@ contract BondingManagerMock is IBondingManager {
     }
 
     function reward() external {
-        minter.mint(activeStake, totalActiveStake);
+        minter.createReward(activeStake, totalActiveStake);
     }
 
     function setActiveTranscoders() external returns (bool) {
         return true;
     }
 
-    function updateTranscoderFeePool(address _transcoder, uint256 _fees, uint256 _claimblock, uint256 _transcoderTotalStake) external returns (bool) {
+    function updateTranscoderFeePool(address _transcoder, uint256 _fees, uint256 _round) external returns (bool) {
         return true;
+    }
+
+    function callAddToRedistributionPool(uint256 _amount) external {
+        minter.addToRedistributionPool(_amount);
     }
 
     function slashTranscoder(address _transcoder, address _finder, uint64 _slashAmount, uint64 _finderFee) external returns (bool) {
         return true;
     }
 
-    function electActiveTranscoder(uint256 _maxPricePerSegment) external constant returns (address) {
+    function electActiveTranscoder(uint256 _maxPricePerSegment) external returns (address) {
         return transcoder;
     }
 
     function transcoderTotalStake(address _transcoder) public constant returns (uint256) {
+        return activeStake;
+    }
+
+    function activeTranscoderTotalStake(address _transcoder) public constant returns (uint256) {
         return activeStake;
     }
 }

--- a/contracts/test/JobsManagerMock.sol
+++ b/contracts/test/JobsManagerMock.sol
@@ -48,11 +48,10 @@ contract JobsManagerMock is IJobsManager {
         dataHashes = _dataHashes;
     }
 
-    function setDistributeFeesParams(address _transcoder, uint256 _fees, uint256 _round, uint256 _transcoderTotalStake) external {
+    function setDistributeFeesParams(address _transcoder, uint256 _fees, uint256 _round) external {
         transcoder = _transcoder;
         fees = _fees;
         round = _round;
-        transcoderTotalStake = _transcoderTotalStake;
     }
 
     function setTranscoder(address _transcoder) external {
@@ -84,7 +83,7 @@ contract JobsManagerMock is IJobsManager {
     }
 
     function distributeFees() public returns (bool) {
-        return bondingManager.updateTranscoderFeePool(transcoder, fees, round, transcoderTotalStake);
+        return bondingManager.updateTranscoderFeePool(transcoder, fees, round);
     }
 
     function missedVerificationSlash() public returns (bool) {
@@ -101,5 +100,9 @@ contract JobsManagerMock is IJobsManager {
 
     function receiveVerification(uint256 _jobId, uint256 _claimId, uint256 _segmentNumber, bool _result) external returns (bool) {
         return true;
+    }
+
+    function callElectActiveTranscoder(uint256 _maxPricePerSegment) external {
+        bondingManager.electActiveTranscoder(_maxPricePerSegment);
     }
 }

--- a/contracts/test/JobsManagerMock.sol
+++ b/contracts/test/JobsManagerMock.sol
@@ -83,7 +83,7 @@ contract JobsManagerMock is IJobsManager {
     }
 
     function distributeFees() public returns (bool) {
-        return bondingManager.updateTranscoderFeePool(transcoder, fees, round);
+        return bondingManager.updateTranscoderWithFees(transcoder, fees, round);
     }
 
     function missedVerificationSlash() public returns (bool) {

--- a/contracts/test/JobsManagerMock.sol
+++ b/contracts/test/JobsManagerMock.sol
@@ -19,6 +19,7 @@ contract JobsManagerMock is IJobsManager {
     string public dataStorageHash;
     bytes32[2] public dataHashes;
     uint256 public fees;
+    uint256 public round;
     uint256 public claimBlock;
     uint256 public transcoderTotalStake;
     uint256 public withdrawAmount;
@@ -45,6 +46,13 @@ contract JobsManagerMock is IJobsManager {
         transcodingOptions = _transcodingOptions;
         dataStorageHash = _dataStorageHash;
         dataHashes = _dataHashes;
+    }
+
+    function setDistributeFeesParams(address _transcoder, uint256 _fees, uint256 _round, uint256 _transcoderTotalStake) external {
+        transcoder = _transcoder;
+        fees = _fees;
+        round = _round;
+        transcoderTotalStake = _transcoderTotalStake;
     }
 
     function setTranscoder(address _transcoder) external {
@@ -76,7 +84,7 @@ contract JobsManagerMock is IJobsManager {
     }
 
     function distributeFees() public returns (bool) {
-        return bondingManager.updateTranscoderFeePool(transcoder, fees, claimBlock, transcoderTotalStake);
+        return bondingManager.updateTranscoderFeePool(transcoder, fees, round, transcoderTotalStake);
     }
 
     function missedVerificationSlash() public returns (bool) {

--- a/contracts/test/MinterMock.sol
+++ b/contracts/test/MinterMock.sol
@@ -4,17 +4,25 @@ import "../token/IMinter.sol";
 
 
 contract MinterMock is IMinter {
-    uint256 mintedTokens;
+    uint256 reward;
 
-    function setMintedTokens(uint256 _amount) external {
-        mintedTokens = _amount;
+    function setReward(uint256 _amount) external {
+        reward = _amount;
     }
 
-    function mint(uint256 _activeStake, uint256 _totalActiveStake) external returns (uint256) {
-        return mintedTokens;
+    function createReward(uint256 _fracNum, uint256 _fracDenom) external returns (uint256) {
+        return reward;
     }
 
     function transferTokens(address _to, uint256 _amount) external returns (bool) {
+        return true;
+    }
+
+    function addToRedistributionPool(uint256 _amount) external returns (bool) {
+        return true;
+    }
+
+    function setCurrentRewardTokens() external returns (bool) {
         return true;
     }
 }

--- a/contracts/test/RoundsManagerMock.sol
+++ b/contracts/test/RoundsManagerMock.sol
@@ -2,10 +2,12 @@ pragma solidity ^0.4.13;
 
 import "../rounds/IRoundsManager.sol";
 import "../bonding/IBondingManager.sol";
+import "../token/IMinter.sol";
 
 
 contract RoundsManagerMock is IRoundsManager {
     IBondingManager bondingManager;
+    IMinter minter;
 
     uint256 public currentRound;
     uint256 public currentRoundStartBlock;
@@ -14,6 +16,10 @@ contract RoundsManagerMock is IRoundsManager {
 
     function setBondingManager(address _bondingManager) external {
         bondingManager = IBondingManager(_bondingManager);
+    }
+
+    function setMinter(address _minter) external {
+        minter = IMinter(_minter);
     }
 
     function setCurrentRound(uint256 _round) external {
@@ -30,6 +36,10 @@ contract RoundsManagerMock is IRoundsManager {
 
     function initializeRound() external returns (bool) {
         return bondingManager.setActiveTranscoders();
+    }
+
+    function callSetCurrentRewardTokens() external {
+        minter.setCurrentRewardTokens();
     }
 
     function currentRound() public constant returns (uint256) {

--- a/contracts/token/IMinter.sol
+++ b/contracts/token/IMinter.sol
@@ -2,6 +2,8 @@ pragma solidity ^0.4.13;
 
 
 contract IMinter {
-    function mint(uint256 _activeStake, uint256 _totalActiveStake) external returns (uint256);
+    function createReward(uint256 _fracNum, uint256 _fracDenom) external returns (uint256);
     function transferTokens(address _to, uint256 _amount) external returns (bool);
+    function addToRedistributionPool(uint256 _amount) external returns (bool);
+    function setCurrentRewardTokens() external returns (bool);
 }

--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -15,6 +15,18 @@ contract Minter is Manager, IMinter {
     uint256 public initialTokenSupply;
     // Upper bound yearly inflation rate
     uint8 public yearlyInflation;
+    // Tokens that are redistributed as a part of rewards
+    uint256 public redistributionPool;
+    // Current number of mintable tokens. Reset every round
+    uint256 public currentMintableTokens;
+    // Current number of redistributable tokens. Reset every round
+    uint256 public currentRedistributableTokens;
+
+    // Sender must be RoundsManager
+    modifier onlyRoundsManager() {
+        require(msg.sender == controller.getContract(keccak256("RoundsManager")));
+        _;
+    }
 
     // Sender must be BondingManager
     modifier onlyBondingManager() {
@@ -34,15 +46,25 @@ contract Minter is Manager, IMinter {
     }
 
     /*
-     * @dev Mint new tokens based on the active stake proportional to the total active stake
-     * @param _activeStake Stake of active transcoder
-     * @param _totalActiveStake Total stake of all active transcoders
+     * @dev Create reward based on a fractional portion of the mintable tokens and redistributable funds for a round
+     * @param _fracNum Numerator of fraction
+     * @param _fracDenom Denominator of fraction
      */
-    function mint(uint256 _activeStake, uint256 _totalActiveStake) external onlyBondingManager returns (uint256) {
-        uint256 amount = mintedTokensPerRound().mul(_activeStake).div(_totalActiveStake);
-        livepeerToken().mint(this, amount);
+    function createReward(uint256 _fracNum, uint256 _fracDenom) external onlyBondingManager returns (uint256) {
+        // Compute fraction of redistributable tokens to include in reward
+        uint256 redistributeAmount = currentRedistributableTokens.mul(_fracNum).div(_fracDenom);
+        // Update amount of redistributable tokens for round
+        currentRedistributableTokens = currentRedistributableTokens.sub(redistributeAmount);
+        redistributionPool = redistributionPool.sub(redistributeAmount);
 
-        return amount;
+        // Compute and mint fraction of mintable tokens to include in reward
+        uint256 mintAmount = currentMintableTokens.mul(_fracNum).div(_fracDenom);
+        // Update amount of mintable tokens for round
+        currentMintableTokens = currentMintableTokens.sub(mintAmount);
+        livepeerToken().mint(this, mintAmount);
+
+        // Reward = minted tokens + redistributed tokens
+        return mintAmount.add(redistributeAmount);
     }
 
     /*
@@ -52,6 +74,26 @@ contract Minter is Manager, IMinter {
      */
     function transferTokens(address _to, uint256 _amount) external onlyBondingManagerOrJobsManager returns (bool) {
         return livepeerToken().transfer(_to, _amount);
+    }
+
+    /*
+     * @dev Set the reward token amounts for the round. Only callable by the RoundsManager
+     */
+    function setCurrentRewardTokens() external onlyRoundsManager returns (bool) {
+        currentMintableTokens = mintedTokensPerRound();
+        currentRedistributableTokens = redistributableTokensPerRound();
+
+        return true;
+    }
+
+    /*
+     * @dev Add funds to the redistribution pool
+     * @param _amount Amount of funds to add to the redistribution pool
+     */
+    function addToRedistributionPool(uint256 _amount) external onlyBondingManager returns (bool) {
+        redistributionPool = redistributionPool.add(_amount);
+
+        return true;
     }
 
     /*
@@ -69,6 +111,13 @@ contract Minter is Manager, IMinter {
      */
     function mintedTokensPerRound() internal constant returns (uint256) {
         return initialTokenSupply.mul(yearlyInflation).div(100).div(roundsManager().roundsPerYear());
+    }
+
+    /*
+     * @dev Return funds to be redistributed per round based on the total funds available for redistribution and the number of rounds per year
+     */
+    function redistributableTokensPerRound() internal constant returns (uint256) {
+        return redistributionPool.div(roundsManager().roundsPerYear());
     }
 
     /*

--- a/migrations/2_deploy_libraries.js
+++ b/migrations/2_deploy_libraries.js
@@ -2,6 +2,7 @@ const Node = artifacts.require("Node")
 const MinHeap = artifacts.require("MinHeap")
 const MaxHeap = artifacts.require("MaxHeap")
 const TranscoderPools = artifacts.require("TranscoderPools")
+const TokenPools = artifacts.require("TokenPools")
 const MerkleProof = artifacts.require("MerkleProof")
 const ECRecovery = artifacts.require("ECRecovery")
 const JobLib = artifacts.require("JobLib")
@@ -37,6 +38,9 @@ module.exports = function(deployer) {
 
     deployer.deploy(TranscoderPools)
     deployer.link(TranscoderPools, BondingManager)
+
+    deployer.deploy(TokenPools)
+    deployer.link(TokenPools, BondingManager)
 
     deployer.deploy(MerkleProof)
     deployer.link(MerkleProof, JobLib)

--- a/migrations/4_deploy_faucet.js
+++ b/migrations/4_deploy_faucet.js
@@ -1,11 +1,14 @@
 const config = require("./migrations.config.js")
 const BigNumber = require("bignumber.js")
+const ethUtil = require("ethereumjs-util")
+const ethAbi = require("ethereumjs-abi")
 
+const Controller = artifacts.require("Controller")
 const LivepeerToken = artifacts.require("LivepeerToken")
 const LivepeerTokenFaucet = artifacts.require("LivepeerTokenFaucet")
 
 module.exports = function(deployer, network, accounts) {
-    if (network == "development") {
+    if (network == "lpTestNet") {
         deployer.deploy(
             LivepeerTokenFaucet,
             LivepeerToken.address,
@@ -21,6 +24,10 @@ module.exports = function(deployer, network, accounts) {
             return Promise.all(config.faucet.whitelist.map(addr => {
                 return faucet.addToWhitelist(addr)
             }))
+        }).then(() => {
+            return Controller.deployed()
+        }).then(controller => {
+            return controller.setContract(ethUtil.bufferToHex(ethAbi.soliditySHA3(["string"], ["LivepeerTokenFaucet"])), LivepeerTokenFaucet.address)
         })
     }
 }

--- a/migrations/5_init_protocol.js
+++ b/migrations/5_init_protocol.js
@@ -66,7 +66,7 @@ module.exports = function(deployer, network) {
             controller.setContract(ethUtil.bufferToHex(ethAbi.soliditySHA3(["string"], ["RoundsManager"])), roundsManagerProxy.address)
         ])
     }).then(() => {
-        // Cast proxiy contracts into target contracts
+        // Cast proxy contracts into target contracts
         return Promise.all([
             BondingManager.at(bondingManagerProxy.address),
             JobsManager.at(jobsManagerProxy.address),

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "eslint": "./node_modules/eslint/bin/eslint.js util/** scripts/** test/**",
     "solium": "./node_modules/solium/bin/solium.js --dir ./contracts",
     "test": "npm run lint; truffle test",
-    "testrpc": "testrpc"
+    "testrpc": "testrpc -l 0x663BE0"
   },
   "repository": {
     "type": "git",

--- a/test/bonding/BondingManager.js
+++ b/test/bonding/BondingManager.js
@@ -582,7 +582,11 @@ contract("BondingManager", accounts => {
 
             // Set active transcoders
             await fixture.roundsManager.initializeRound()
+            // Set current round so delegator is bonded
             await fixture.roundsManager.setCurrentRound(jobCreationRound)
+        })
+
+        it("should withdraw unbonded amount", async () => {
             await fixture.jobsManager.callElectActiveTranscoder(pricePerSegment)
 
             await fixture.jobsManager.setDistributeFeesParams(tAddr, fees, jobCreationRound)
@@ -592,9 +596,7 @@ contract("BondingManager", accounts => {
 
             // Call updateTranscoderWithFees via transaction from JobsManager
             await fixture.jobsManager.distributeFees()
-        })
 
-        it("should withdraw unbonded amount", async () => {
             const delegatorsFeeShare = Math.floor((fees * feeShare) / 100)
             const delegatorFeeShare = Math.floor((2000 * delegatorsFeeShare) / transcoderTotalStake)
             const expWithdrawAmount = delegatorFeeShare
@@ -612,8 +614,6 @@ contract("BondingManager", accounts => {
 
         it("should withdraw bonded tokens that are now unbonded", async () => {
             await bondingManager.unbond({from: dAddr})
-            // Withdraw unbonded amount first
-            await bondingManager.withdraw({from: dAddr})
             const unbondingPeriod = await bondingManager.unbondingPeriod.call()
             await fixture.roundsManager.setCurrentRound(7 + unbondingPeriod.toNumber())
             const expWithdrawAmount = 2000

--- a/test/bonding/BondingManager.js
+++ b/test/bonding/BondingManager.js
@@ -189,16 +189,13 @@ contract("BondingManager", accounts => {
             assert.equal(tDelegatedAmount, 100, "delegated amount incorrect")
         })
 
-        it("should update start round and delegate block when moving bond", async () => {
+        it("should update start round when moving bond", async () => {
             await bondingManager.bond(100, tAddr0, {from: dAddr})
             await fixture.roundsManager.setCurrentRound(100)
 
             await bondingManager.bond(0, tAddr1, {from: dAddr})
             const dStartRound = await bondingManager.getDelegatorStartRound(dAddr)
             assert.equal(dStartRound, 101, "start round incorrect")
-            const delegateBlock = web3.eth.blockNumber
-            const dDelegateBlock = await bondingManager.getDelegatorDelegateBlock(dAddr)
-            assert.equal(dDelegateBlock, delegateBlock, "delegate block incorrect")
         })
     })
 
@@ -268,9 +265,9 @@ contract("BondingManager", accounts => {
         const feeShare = 5
         const pricePerSegment = 10
 
-        // Mock fees params
+        // Mock distribute fees params
         const fees = 300
-        const claimBlock = web3.eth.blockNumber + 1000
+        const jobCreationRound = 6
         const transcoderTotalStake = 4000
 
         beforeEach(async () => {
@@ -289,10 +286,7 @@ contract("BondingManager", accounts => {
             // Delegator bonds to transcoder
             await bondingManager.bond(2000, tAddr, {from: dAddr})
 
-            await fixture.jobsManager.setTranscoder(tAddr)
-            await fixture.jobsManager.setFees(fees)
-            await fixture.jobsManager.setClaimBlock(claimBlock)
-            await fixture.jobsManager.setTranscoderTotalStake(transcoderTotalStake)
+            await fixture.jobsManager.setDistributeFeesParams(tAddr, fees, jobCreationRound, transcoderTotalStake)
 
             // Set active transcoders
             await fixture.roundsManager.initializeRound()
@@ -308,7 +302,7 @@ contract("BondingManager", accounts => {
             const delegatorsFeeShare = Math.floor((fees * feeShare) / 100)
             const delegatorFeeShare = Math.floor((2000 * delegatorsFeeShare) / transcoderTotalStake)
             const delegatorStake = await bondingManager.delegatorStake(dAddr)
-            assert.equal(delegatorStake.toString(), add(2000, delegatorFeeShare))
+            assert.equal(delegatorStake.toString(), add(2000, delegatorFeeShare).toString())
         })
     })
 })

--- a/test/jobs/JobsManager.js
+++ b/test/jobs/JobsManager.js
@@ -137,6 +137,12 @@ contract("JobsManager", accounts => {
         })
 
         it("should create a new job", async () => {
+            const creationRound = 100
+            await fixture.roundsManager.setCurrentRound(creationRound)
+
+            const transcoderTotalStake = 100
+            await fixture.bondingManager.setActiveTranscoder(accounts[1], 0, transcoderTotalStake, 0)
+
             await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, {from: broadcaster})
 
             const jMaxPricePerSegment = await jobsManager.getJobMaxPricePerSegment(0)
@@ -145,6 +151,10 @@ contract("JobsManager", accounts => {
             assert.equal(jBroadcasterAddress, broadcaster, "broadcaster address incorrect")
             const jTranscoderAddress = await jobsManager.getJobTranscoderAddress(0)
             assert.equal(jTranscoderAddress, electedTranscoder, "transcoder address incorrect")
+            const jCreationRound = await jobsManager.getJobCreationRound(0)
+            assert.equal(jCreationRound, creationRound, "creation round incorrect")
+            const jTranscoderTotalStake = await jobsManager.getJobTranscoderTotalStake(0)
+            assert.equal(jTranscoderTotalStake, transcoderTotalStake, "transcoder total stake incorrect")
             const jEndBlock = await jobsManager.getJobEndBlock(0)
             assert.equal(jEndBlock, 0, "end block incorrect")
             const jEscrow = await jobsManager.getJobEscrow(0)
@@ -233,7 +243,6 @@ contract("JobsManager", accounts => {
             const claimBlock = web3.eth.blockNumber
             const verificationPeriod = await jobsManager.verificationPeriod.call()
             const slashingPeriod = await jobsManager.slashingPeriod.call()
-            const transcoderTotalStake = await fixture.bondingManager.transcoderTotalStake(accounts[1])
 
             const cStartSegment = await jobsManager.getClaimStartSegment(jobId, claimId)
             assert.equal(cStartSegment, segmentRange[0], "segment range start incorrect")
@@ -247,8 +256,6 @@ contract("JobsManager", accounts => {
             assert.equal(cEndVerificationBlock, claimBlock + verificationPeriod.toNumber(), "end verification block incorrect")
             const cEndSlashingBlock = await jobsManager.getClaimEndSlashingBlock(jobId, claimId)
             assert.equal(cEndSlashingBlock, claimBlock + verificationPeriod.toNumber() + slashingPeriod.toNumber(), "end slashing block incorrect")
-            const cTranscoderStake = await jobsManager.getClaimTranscoderTotalStake(jobId, claimId)
-            assert.equal(cTranscoderStake, transcoderTotalStake.toNumber(), "transcoder total stake incorrect")
         })
 
         it("should update broadcaster deposit", async () => {

--- a/test/jobs/JobsManager.js
+++ b/test/jobs/JobsManager.js
@@ -153,8 +153,6 @@ contract("JobsManager", accounts => {
             assert.equal(jTranscoderAddress, electedTranscoder, "transcoder address incorrect")
             const jCreationRound = await jobsManager.getJobCreationRound(0)
             assert.equal(jCreationRound, creationRound, "creation round incorrect")
-            const jTranscoderTotalStake = await jobsManager.getJobTranscoderTotalStake(0)
-            assert.equal(jTranscoderTotalStake, transcoderTotalStake, "transcoder total stake incorrect")
             const jEndBlock = await jobsManager.getJobEndBlock(0)
             assert.equal(jEndBlock, 0, "end block incorrect")
             const jEscrow = await jobsManager.getJobEscrow(0)

--- a/test/token/Minter.js
+++ b/test/token/Minter.js
@@ -18,13 +18,15 @@ contract("Minter", accounts => {
         fixture = new Fixture(web3)
         await fixture.deployController()
         await fixture.deployMocks()
-
         fixture.token = await fixture.deployAndRegister(LivepeerToken, "LivepeerToken")
+
         minter = await Minter.new(fixture.controller.address, INITIAL_TOKEN_SUPPLY, INITIAL_YEARLY_INFLATION)
+
         await fixture.token.mint(minter.address, minterBalance)
         await fixture.token.transferOwnership(minter.address)
         await fixture.bondingManager.setMinter(minter.address)
         await fixture.jobsManager.setMinter(minter.address)
+        await fixture.roundsManager.setMinter(minter.address)
     })
 
     beforeEach(async () => {
@@ -35,15 +37,21 @@ contract("Minter", accounts => {
         await fixture.tearDown()
     })
 
-    describe("mint", () => {
+    describe("computeRewards", () => {
         it("should throw if sender is not bonding manager", async () => {
-            await expectThrow(minter.mint(10, 100))
+            await expectThrow(minter.createReward(10, 100))
         })
 
-        it("should mint tokens and update its own token balance", async () => {
+        it("should compute rewards when redistributionPool = 0", async () => {
             await fixture.roundsManager.setRoundsPerYear(100)
+
+            // Set up current reward tokens via RoundsManager
+            await fixture.roundsManager.callSetCurrentRewardTokens()
+
+            // Set up reward call via BondingManager
             await fixture.bondingManager.setActiveTranscoder(accounts[1], 0, 10, 100)
             await fixture.bondingManager.reward()
+
             const supply = await minter.initialTokenSupply.call()
             const inflation = await minter.yearlyInflation.call()
             const mintedTokens = supply.mul(inflation).div(100).floor().div(100).floor()
@@ -51,6 +59,32 @@ contract("Minter", accounts => {
 
             const balance = await fixture.token.balanceOf(minter.address)
             assert.equal(balance.toString(), expBalance, "minter token balance is incorrect")
+        })
+
+        it("should compute rewards and update the redistributionPool when redistributionPool > 0", async () => {
+            await fixture.roundsManager.setRoundsPerYear(100)
+
+            // Set up current reward tokens via RoundsManager
+            await fixture.bondingManager.callAddToRedistributionPool(100000)
+            await fixture.roundsManager.callSetCurrentRewardTokens()
+
+            // Set up reward call via BondingManager
+            await fixture.bondingManager.setActiveTranscoder(accounts[1], 0, 10, 100)
+            await fixture.bondingManager.reward()
+
+            const supply = await minter.initialTokenSupply.call()
+            const inflation = await minter.yearlyInflation.call()
+            const mintedTokens = supply.mul(inflation).div(100).floor().div(100).floor()
+            const expBalance = add(minterBalance, mintedTokens.mul(10).div(100).floor()).toString()
+
+            const balance = await fixture.token.balanceOf(minter.address)
+            assert.equal(balance.toString(), expBalance, "minter token balance is incorrect")
+
+            const redistributedTokens = ((100000 / 100) * 10) / 100
+            const expRedistributionPool = 100000 - redistributedTokens
+
+            const redistributionPool = await minter.redistributionPool.call()
+            assert.equal(redistributionPool, expRedistributionPool, "redistribution pool incorrect")
         })
     })
 

--- a/truffle.js
+++ b/truffle.js
@@ -7,7 +7,7 @@ module.exports = {
             host: "localhost",
             port: 8545,
             network_id: "*", // Match any network id
-            gas: 99999999
+            gas: 6700000
         },
         lpTestNet: {
             from: "0x0161e041aad467a890839d5b08b138c1e6373072",

--- a/truffle.js
+++ b/truffle.js
@@ -6,7 +6,8 @@ module.exports = {
         development: {
             host: "localhost",
             port: 8545,
-            network_id: "*" // Match any network id
+            network_id: "*", // Match any network id
+            gas: 99999999
         },
         lpTestNet: {
             from: "0x0161e041aad467a890839d5b08b138c1e6373072",


### PR DESCRIPTION
This is an implementation of a solution to our current gas limit vulnerabilities in looping through rounds to update a delegator's stake and looping through claims within a round to update a delegator's stake with fees that the delegator is eligible for.

This PR includes:
- Fees are paid out unbonded. Delegators claim their fee shares from fee pools during the rounds since their lastClaimTokenPoolsShareRound
- Transcoders claim their blockRewardCut and feeShare when they claim their reward and fee shares from token pools during the rounds since their lastClaimTokenPoolsShareRound as a delegator
- Transcoders calculate unclaimable fees and rewards when adding rewards and fees to token pools. The unclaimable fees and rewards go to a redistribution pool managed by the Minter
- When initializeRound is called in RoundsManager it sets the mintable tokens and redistributable tokens for a round in the Minter