### PR TITLE
ManagerProxy returns dynamic length data

### DIFF
--- a/contracts/ManagerProxy.sol
+++ b/contracts/ManagerProxy.sol
@@ -4,16 +4,12 @@ import "./ManagerProxyTarget.sol";
 
 
 contract ManagerProxy is ManagerProxyTarget {
-    function ManagerProxy(address _controller, bytes32 _targetContractId) Manager(_controller) {
+    function ManagerProxy(address _controller, bytes32 _targetContractId) public Manager(_controller) {
         targetContractId = _targetContractId;
     }
 
     // Based on https://github.com/AugurProject/augur-core/blob/develop/src/libraries/Delegator.sol
     function() public payable {
-        // Set size of method call result to 32 for now until
-        // we can use the RETURNDATACOPY and RETURNDATASIZE opcodes introduced
-        // in the Byzantium hard fork
-        uint32 size = 32;
         address target = controller.getContract(targetContractId);
         // Target contract must be registered
         require(target > 0);
@@ -21,31 +17,29 @@ contract ManagerProxy is ManagerProxyTarget {
         assembly {
             // Load the free memory pointer at 0x40
             let calldataMemoryOffset := mload(0x40)
-            // Set size of reserved memory space for calldata and method call results
-            // Reserved memory size = max(calldatasize, size) so we can always
-            // use the space for loading calldata and then reusing the space
-            // to load method call results
-            let reservedSize := 0
-            switch gt(calldatasize, size)
-            case 1 {
-                reservedSize := calldatasize
-            } default {
-                reservedSize := size
-            }
-            // Update free memory pointer to after memory space we reserve for calldata and method call results
-            mstore(0x40, add(calldataMemoryOffset, reservedSize))
-
+            // Update free memory pointer to after memory space we reserve for calldata
+            mstore(0x40, add(calldataMemoryOffset, calldatasize))
             // Copy method signature and params of the call to memory
             calldatacopy(calldataMemoryOffset, 0x0, calldatasize)
+
             // Call method on target contract and store result starting at calldataMemoryOffset
-            let ret := delegatecall(gas, target, calldataMemoryOffset, calldatasize, calldataMemoryOffset, size)
+            let ret := delegatecall(gas, target, calldataMemoryOffset, calldatasize, 0, 0)
+
+            // Load the free memory pointer at 0x40
+            let returndataOffset := mload(0x40)
+            // Update free memory pointer to after memory space we reserve for returndata
+            mstore(0x40, add(returndataOffset, returndatasize))
+            // Copy returndata to memory
+            returndatacopy(returndataOffset, 0, returndatasize)
+
             switch ret
             case 0 {
                 // Method call failed - revert
-                revert(0, 0)
+                // Return any error message contained in returndata
+                revert(returndataOffset, returndatasize)
             } default {
-                // Return result of method call stored in mem[calldataMemoryOffset..(calldataMemoryOffset + size)]
-                return(calldataMemoryOffset, size)
+                // Return result of method call stored in mem[returndataOffset..(returndataOffset + returndatasize)]
+                return(returndataOffset, returndatasize)
             }
         }
     }

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -654,20 +654,18 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     )
         public
         view
-        returns (uint256, uint256, uint8, uint8, uint256, uint8, uint8, uint256)
+        returns (uint256 delegatorWithdrawRound, uint256 lastRewardRound, uint8 blockRewardCut, uint8 feeShare, uint256 pricePerSegment, uint8 pendingBlockRewardCut, uint8 pendingFeeShare, uint256 pendingPricePerSegment)
     {
         Transcoder storage t = transcoders[_transcoder];
 
-        return (
-            t.delegatorWithdrawRound,
-            t.lastRewardRound,
-            t.blockRewardCut,
-            t.feeShare,
-            t.pricePerSegment,
-            t.pendingBlockRewardCut,
-            t.pendingFeeShare,
-            t.pendingPricePerSegment
-        );
+        delegatorWithdrawRound = t.delegatorWithdrawRound;
+        lastRewardRound = t.lastRewardRound;
+        blockRewardCut = t.blockRewardCut;
+        feeShare = t.feeShare;
+        pricePerSegment = t.pricePerSegment;
+        pendingBlockRewardCut = t.pendingBlockRewardCut;
+        pendingFeeShare = t.pendingFeeShare;
+        pendingPricePerSegment = t.pendingPricePerSegment;
     }
 
     /*
@@ -681,11 +679,14 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     )
         public
         view
-        returns (uint256, uint256, uint256, uint256)
+        returns (uint256 rewardPool, uint256 feePool, uint256 totalStake, uint256 usedStake)
     {
         TokenPools.Data storage tokenPools = transcoders[_transcoder].tokenPoolsPerRound[_round];
 
-        return (tokenPools.rewardPool, tokenPools.feePool, tokenPools.totalStake, tokenPools.usedStake);
+        rewardPool = tokenPools.rewardPool;
+        feePool = tokenPools.feePool;
+        totalStake = tokenPools.totalStake;
+        usedStake = tokenPools.usedStake;
     }
 
     /*
@@ -697,19 +698,17 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     )
         public
         view
-        returns (uint256, uint256, address, uint256, uint256, uint256, uint256)
+        returns (uint256 bondedAmount, uint256 unbondedAmount, address delegateAddress, uint256 delegatedAmount, uint256 startRound, uint256 withdrawRound, uint256 lastClaimTokenPoolsSharesRound)
     {
         Delegator storage del = delegators[_delegator];
 
-        return (
-            del.bondedAmount,
-            del.unbondedAmount,
-            del.delegateAddress,
-            del.delegatedAmount,
-            del.startRound,
-            del.withdrawRound,
-            del.lastClaimTokenPoolsSharesRound
-        );
+        bondedAmount = del.bondedAmount;
+        unbondedAmount = del.unbondedAmount;
+        delegateAddress = del.delegateAddress;
+        delegatedAmount = del.delegatedAmount;
+        startRound = del.startRound;
+        withdrawRound = del.withdrawRound;
+        lastClaimTokenPoolsSharesRound = del.lastClaimTokenPoolsSharesRound;
     }
 
     /*

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -645,84 +645,71 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         }
     }
 
-    // Transcoder getters
+    /*
+     * @dev Return transcoder information
+     * @param _transcoder Address of transcoder
+     */
+    function getTranscoder(
+        address _transcoder
+    )
+        public
+        view
+        returns (uint256, uint256, uint8, uint8, uint256, uint8, uint8, uint256)
+    {
+        Transcoder storage t = transcoders[_transcoder];
 
-    function getTranscoderDelegatorWithdrawRound(address _transcoder) public view returns (uint256) {
-        return transcoders[_transcoder].delegatorWithdrawRound;
+        return (
+            t.delegatorWithdrawRound,
+            t.lastRewardRound,
+            t.blockRewardCut,
+            t.feeShare,
+            t.pricePerSegment,
+            t.pendingBlockRewardCut,
+            t.pendingFeeShare,
+            t.pendingPricePerSegment
+        );
     }
 
-    function getTranscoderLastRewardRound(address _transcoder) public view returns (uint256) {
-        return transcoders[_transcoder].lastRewardRound;
+    /*
+     * @dev Return transcoder's token pools for a given round
+     * @param _transcoder Address of transcoder
+     * @param _round Round number
+     */
+    function getTranscoderTokenPoolsForRound(
+        address _transcoder,
+        uint256 _round
+    )
+        public
+        view
+        returns (uint256, uint256, uint256, uint256)
+    {
+        TokenPools.Data storage tokenPools = transcoders[_transcoder].tokenPoolsPerRound[_round];
+
+        return (tokenPools.rewardPool, tokenPools.feePool, tokenPools.totalStake, tokenPools.usedStake);
     }
 
-    function getTranscoderBlockRewardCut(address _transcoder) public view returns (uint8) {
-        return transcoders[_transcoder].blockRewardCut;
-    }
+    /*
+     * @dev Return delegator info
+     * @param _delegator Address of delegator
+     */
+    function getDelegator(
+        address _delegator
+    )
+        public
+        view
+        returns (uint256, uint256, address, uint256, uint256, uint256, uint256)
+    {
+        Delegator storage del = delegators[_delegator];
 
-    function getTranscoderFeeShare(address _transcoder) public view returns (uint8) {
-        return transcoders[_transcoder].feeShare;
-    }
-
-    function getTranscoderPricePerSegment(address _transcoder) public view returns (uint256) {
-        return transcoders[_transcoder].pricePerSegment;
-    }
-
-    function getTranscoderPendingBlockRewardCut(address _transcoder) public view returns (uint8) {
-        return transcoders[_transcoder].pendingBlockRewardCut;
-    }
-
-    function getTranscoderPendingFeeShare(address _transcoder) public view returns (uint8) {
-        return transcoders[_transcoder].pendingFeeShare;
-    }
-
-    function getTranscoderPendingPricePerSegment(address _transcoder) public view returns (uint256) {
-        return transcoders[_transcoder].pendingPricePerSegment;
-    }
-
-    function getTranscoderRewardPoolForRound(address _transcoder, uint256 _round) public view returns (uint256) {
-        return transcoders[_transcoder].tokenPoolsPerRound[_round].rewardPool;
-    }
-
-    function getTranscoderFeePoolForRound(address _transcoder, uint256 _round) public view returns (uint256) {
-        return transcoders[_transcoder].tokenPoolsPerRound[_round].feePool;
-    }
-
-    function getTranscoderTotalStakeForRound(address _transcoder, uint256 _round) public view returns (uint256) {
-        return transcoders[_transcoder].tokenPoolsPerRound[_round].totalStake;
-    }
-
-    function getTranscoderUsedStakeForRound(address _transcoder, uint256 _round) public view returns (uint256) {
-        return transcoders[_transcoder].tokenPoolsPerRound[_round].usedStake;
-    }
-
-    // Delegator getters
-
-    function getDelegatorBondedAmount(address _delegator) public view returns (uint256) {
-        return delegators[_delegator].bondedAmount;
-    }
-
-    function getDelegatorUnbondedAmount(address _delegator) public view returns (uint256) {
-        return delegators[_delegator].unbondedAmount;
-    }
-
-    function getDelegatorDelegateAddress(address _delegator) public view returns (address) {
-        return delegators[_delegator].delegateAddress;
-    }
-
-    function getDelegatorDelegatedAmount(address _delegator) public view returns (uint256) {
-        return delegators[_delegator].delegatedAmount;
-    }
-
-    function getDelegatorStartRound(address _delegator) public view returns (uint256) {
-        return delegators[_delegator].startRound;
-    }
-
-    function getDelegatorWithdrawRound(address _delegator) public view returns (uint256) {
-        return delegators[_delegator].withdrawRound;
-    }
-
-    function getDelegatorLastClaimTokenPoolsSharesRound(address _delegator) public view returns (uint256) {
-        return delegators[_delegator].lastClaimTokenPoolsSharesRound;
+        return (
+            del.bondedAmount,
+            del.unbondedAmount,
+            del.delegateAddress,
+            del.delegatedAmount,
+            del.startRound,
+            del.withdrawRound,
+            del.lastClaimTokenPoolsSharesRound
+        );
     }
 
     /*

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -458,72 +458,73 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         }
     }
 
-    // Job getters
+    /*
+     * @dev Return job info
+     * @param _jobId Job identifier
+     */
+    function getJob(
+        uint256 _jobId
+    )
+        public
+        view
+        returns (string, string, uint256, address, address, uint256, uint256, uint256, uint256)
+    {
+        Job storage job = jobs[_jobId];
 
-    function getJobStreamId(uint256 _jobId) public view returns (string) {
-        return jobs[_jobId].streamId;
+        return (
+            job.streamId,
+            job.transcodingOptions,
+            job.maxPricePerSegment,
+            job.broadcasterAddress,
+            job.transcoderAddress,
+            job.creationRound,
+            job.endBlock,
+            job.escrow,
+            job.claims.length
+        );
     }
 
-    function getJobTranscodingOptions(uint256 _jobId) public view returns (string) {
-        return jobs[_jobId].transcodingOptions;
+    /*
+     * @dev Return claim info
+     * @param _jobId Job identifier
+     * @param _claimId Claim identifier
+     */
+    function getClaim(
+        uint256 _jobId,
+        uint256 _claimId
+    )
+        public
+        view
+        returns (uint256[2], bytes32, uint256, uint256, uint256, ClaimStatus)
+    {
+        Claim storage claim = jobs[_jobId].claims[_claimId];
+
+        return (
+            claim.segmentRange,
+            claim.claimRoot,
+            claim.claimBlock,
+            claim.endVerificationBlock,
+            claim.endSlashingBlock,
+            claim.status
+        );
     }
 
-    function getJobMaxPricePerSegment(uint256 _jobId) public view returns (uint256) {
-        return jobs[_jobId].maxPricePerSegment;
-    }
-
-    function getJobBroadcasterAddress(uint256 _jobId) public view returns (address) {
-        return jobs[_jobId].broadcasterAddress;
-    }
-
-    function getJobTranscoderAddress(uint256 _jobId) public view returns (address) {
-        return jobs[_jobId].transcoderAddress;
-    }
-
-    function getJobCreationRound(uint256 _jobId) public view returns (uint256) {
-        return jobs[_jobId].creationRound;
-    }
-
-    function getJobEndBlock(uint256 _jobId) public view returns (uint256) {
-        return jobs[_jobId].endBlock;
-    }
-
-    function getJobEscrow(uint256 _jobId) public view returns (uint256) {
-        return jobs[_jobId].escrow;
-    }
-
-    function getJobTotalClaims(uint256 _jobId) public view returns (uint256) {
-        return jobs[_jobId].claims.length;
-    }
-
-    // Claim getters
-
-    function getClaimStartSegment(uint256 _jobId, uint256 _claimId) public view returns (uint256) {
-        return jobs[_jobId].claims[_claimId].segmentRange[0];
-    }
-
-    function getClaimEndSegment(uint256 _jobId, uint256 _claimId) public view returns (uint256) {
-        return jobs[_jobId].claims[_claimId].segmentRange[1];
-    }
-
-    function getClaimRoot(uint256 _jobId, uint256 _claimId) public view returns (bytes32) {
-        return jobs[_jobId].claims[_claimId].claimRoot;
-    }
-
-    function getClaimBlock(uint256 _jobId, uint256 _claimId) public view returns (uint256) {
-        return jobs[_jobId].claims[_claimId].claimBlock;
-    }
-
-    function getClaimEndVerificationBlock(uint256 _jobId, uint256 _claimId) public view returns (uint256) {
-        return jobs[_jobId].claims[_claimId].endVerificationBlock;
-    }
-
-    function getClaimEndSlashingBlock(uint256 _jobId, uint256 _claimId) public view returns (uint256) {
-        return jobs[_jobId].claims[_claimId].endSlashingBlock;
-    }
-
-    function getClaimStatus(uint256 _jobId, uint256 _claimId) public view returns (ClaimStatus) {
-        return jobs[_jobId].claims[_claimId].status;
+    /*
+     * @dev Return whether a segment was verified for a claim
+     * @param _jobId Job identifier
+     * @param _claimId Claim identifier
+     * @param _segmentNumber Segment number
+     */
+    function isClaimSegmentVerified(
+        uint256 _jobId,
+        uint256 _claimId,
+        uint256 _segmentNumber
+    )
+        public
+        view
+        returns (bool)
+    {
+        return jobs[_jobId].claims[_claimId].segmentVerifications[_segmentNumber];
     }
 
     /*

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -467,21 +467,19 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
     )
         public
         view
-        returns (string, string, uint256, address, address, uint256, uint256, uint256, uint256)
+        returns (string streamId, string transcodingOptions, uint256 maxPricePerSegment, address broadcasterAddress, address transcoderAddress, uint256 creationRound, uint256 endBlock, uint256 escrow, uint256 totalClaims)
     {
         Job storage job = jobs[_jobId];
 
-        return (
-            job.streamId,
-            job.transcodingOptions,
-            job.maxPricePerSegment,
-            job.broadcasterAddress,
-            job.transcoderAddress,
-            job.creationRound,
-            job.endBlock,
-            job.escrow,
-            job.claims.length
-        );
+        streamId = job.streamId;
+        transcodingOptions = job.transcodingOptions;
+        maxPricePerSegment = job.maxPricePerSegment;
+        broadcasterAddress = job.broadcasterAddress;
+        transcoderAddress = job.transcoderAddress;
+        creationRound = job.creationRound;
+        endBlock = job.endBlock;
+        escrow = job.escrow;
+        totalClaims = job.claims.length;
     }
 
     /*
@@ -495,18 +493,16 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
     )
         public
         view
-        returns (uint256[2], bytes32, uint256, uint256, uint256, ClaimStatus)
+        returns (uint256[2] segmentRange, bytes32 claimRoot, uint256 claimBlock, uint256 endVerificationBlock, uint256 endSlashingBlock, ClaimStatus status)
     {
         Claim storage claim = jobs[_jobId].claims[_claimId];
 
-        return (
-            claim.segmentRange,
-            claim.claimRoot,
-            claim.claimBlock,
-            claim.endVerificationBlock,
-            claim.endSlashingBlock,
-            claim.status
-        );
+        segmentRange = claim.segmentRange;
+        claimRoot = claim.claimRoot;
+        claimBlock = claim.claimBlock;
+        endVerificationBlock = claim.endVerificationBlock;
+        endSlashingBlock = claim.endSlashingBlock;
+        status = claim.status;
     }
 
     /*

--- a/contracts/test/ManagerProxyTargetMockV1.sol
+++ b/contracts/test/ManagerProxyTargetMockV1.sol
@@ -10,6 +10,11 @@ contract ManagerProxyTargetMockV1 is ManagerProxyTarget {
     uint256 public uint256Value;
     bytes32 public bytes32Value;
     address public addressValue;
+    string public stringValue;
+    bytes public bytesValue;
+    uint256 public tupleValue1;
+    uint256 public tupleValue2;
+    bytes32 public tupleValue3;
 
     function ManagerProxyTargetMockV1(address _controller) Manager(_controller) {}
 
@@ -37,5 +42,23 @@ contract ManagerProxyTargetMockV1 is ManagerProxyTarget {
 
     function setAddress(address _value) external afterInitialization {
         addressValue = _value;
+    }
+
+    function setString(string _value) external afterInitialization {
+        stringValue = _value;
+    }
+
+    function setBytes(bytes _value) external afterInitialization {
+        bytesValue = _value;
+    }
+
+    function setTuple(uint256 _value1, uint256 _value2, bytes32 _value3) external afterInitialization {
+        tupleValue1 = _value1;
+        tupleValue2 = _value2;
+        tupleValue3 = _value3;
+    }
+
+    function getTuple() external view returns (uint256, uint256, bytes32) {
+        return (tupleValue1, tupleValue2, tupleValue3);
     }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "^4.3.0",
     "eslint-config-google": "^0.9.1",
     "ethereumjs-abi": "^0.6.4",
-    "ethereumjs-testrpc": "^4.1.1",
+    "ethereumjs-testrpc": "^5.0.1",
     "ethereumjs-util": "^5.1.2",
     "solium": "github:AugurProject/Solium",
     "zeppelin-solidity": "^1.3.0"

--- a/test/ManagerProxy.js
+++ b/test/ManagerProxy.js
@@ -77,7 +77,7 @@ contract("ManagerProxy", accounts => {
             await expectThrow(managerProxy.setUint256(6))
         })
 
-        it("should set a uint64", async () => {
+        it("should set a uint256", async () => {
             await managerProxy.initialize(3)
             await managerProxy.setUint256(6)
 
@@ -93,7 +93,7 @@ contract("ManagerProxy", accounts => {
             await expectThrow(managerProxy.setBytes32(hash))
         })
 
-        it("should set a uint64", async () => {
+        it("should set a bytes32", async () => {
             await managerProxy.initialize(3)
             await managerProxy.setBytes32(hash)
 
@@ -109,12 +109,64 @@ contract("ManagerProxy", accounts => {
             await expectThrow(managerProxy.setAddress(addr))
         })
 
-        it("should set a uint64", async () => {
+        it("should set an address", async () => {
             await managerProxy.initialize(3)
             await managerProxy.setAddress(addr)
 
             const value = await managerProxy.addressValue.call()
             assert.equal(value, addr, "address value incorrect")
+        })
+    })
+
+    describe("setting and getting string", () => {
+        const str = "hello"
+
+        it("should fail if not initialized", async () => {
+            await expectThrow(managerProxy.setString(str))
+        })
+
+        it("should set a string", async () => {
+            await managerProxy.initialize(3)
+            await managerProxy.setString(str)
+
+            const value = await managerProxy.stringValue.call()
+            assert.equal(value, str, "string value incorrect")
+        })
+    })
+
+    describe("setting and getting bytes", () => {
+        const h = web3.sha3("hello")
+
+        it("should fail if not initialized", async () => {
+            await expectThrow(managerProxy.setBytes(h))
+        })
+
+        it("should set a bytes", async () => {
+            await managerProxy.initialize(3)
+            await managerProxy.setBytes(h)
+
+            const value = await managerProxy.bytesValue.call()
+            assert.equal(value, h, "bytes value incorrect")
+        })
+    })
+
+    describe("setting and getting a tuple", () => {
+        const v1 = 5
+        const v2 = 6
+        const v3 = web3.sha3("hello")
+
+        it("should fail if not initialized", async () => {
+            await expectThrow(managerProxy.setTuple(v1, v2, v3))
+        })
+
+        it("should set a tuple", async () => {
+            await managerProxy.initialize(3)
+            await managerProxy.setTuple(v1, v2, v3)
+
+            const values = await managerProxy.getTuple()
+            assert.equal(values[0], v1, "tuple value 1 incorrect")
+            assert.equal(values[1], v2, "tuple value 2 incorrect")
+            assert.equal(values[2], v3, "tuple value 3 incorrect")
         })
     })
 

--- a/test/helpers/expectThrow.js
+++ b/test/helpers/expectThrow.js
@@ -10,8 +10,9 @@ export default async promise => {
         //       we distinguish this from an actual out of gas event? (The
         //       testrpc log actually show an 'invalid jump' event.)
         const outOfGas = error.message.search("out of gas") >= 0
+        const revert = error.message.search("revert") >= 0
         assert(
-            invalidOpcode || outOfGas,
+            invalidOpcode || outOfGas || revert,
             "Expected throw, got '" + error + "' instead",
         )
         return


### PR DESCRIPTION
ManagerProxy now uses RETURNDATACOPY and RETURNDATASIZE opcodes to return dynamic length data from a target contract. As a result, we can use getter functions in BondingManager and JobsManager to return tuples rather than define a getter function for each individual field for a transcoder, delegator, job, claim, etc. We can also now directly retrieve streamId and transcodingOptions values directly from the JobsManager without relying on events. Using ethereumjs-testrpc v5.0.1@beta which includes the new opcodes. 

Closes #88 