### PR TITLE
Restrictions on broadcaster withdrawals

### DIFF
--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -449,10 +449,10 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
      */
     function jobStatus(uint256 _jobId) public view returns (JobStatus) {
         if (jobs[_jobId].endBlock <= block.number) {
-            // A job is inactive if its end block is set and the current block is greater than or equal to the job's end block
+            // A job is inactive if the current block is greater than or equal to the job's end block
             return JobStatus.Inactive;
         } else {
-            // A job is active if it does not have an end block
+            // A job is active if the current block is less than the job's end block
             return JobStatus.Active;
         }
     }

--- a/contracts/jobs/libraries/JobLib.sol
+++ b/contracts/jobs/libraries/JobLib.sol
@@ -29,11 +29,9 @@ library JobLib {
 
     /*
      * Computes whether a segment is eligible for verification based on the last call to claimWork()
-     * @param _segmentSequenceNumber Sequence number of segment in stream
-     * @param _startSegmentSequenceNumber Sequence number of first segment claimed
-     * @param _endSegmentSequenceNumber Sequence number of last segment claimed
-     * @param _lastClaimedWorkBlock Block number when claimWork() was last called
-     * @param _lastClaimedWorkBlockHash Block hash when claimWork() was last called
+     * @param _segmentNumber Sequence number of segment in stream
+     * @param _segmentRange Range of segments claimed
+     * @param _claimBlock Block when claimWork() was called
      * @param _verificationRate Rate at which a particular segment should be verified
      */
     function shouldVerifySegment(
@@ -51,13 +49,23 @@ library JobLib {
             return false;
         }
 
-        if (uint256(keccak256(_claimBlock, block.blockhash(_claimBlock), _segmentNumber)) % _verificationRate == 0) {
+        // Use block hash and block number of the block after a claim to determine if a segment
+        // should be verified
+        if (uint256(keccak256(_claimBlock + 1, block.blockhash(_claimBlock + 1), _segmentNumber)) % _verificationRate == 0) {
             return true;
         } else {
             return false;
         }
     }
 
+    /*
+     * @dev Checks if a segment was signed by a broadcaster address
+     * @param _streamId Stream ID for the segment
+     * @param _segmentNumber Sequence number of segment in the stream
+     * @param _dataHash Hash of segment data
+     * @param _broadcasterSig Broadcaster signature over h(streamId, segmentNumber, dataHash)
+     * @param _broadcaster Broadcaster address
+     */
     function validateBroadcasterSig(
         string _streamId,
         uint256 _segmentNumber,
@@ -72,6 +80,15 @@ library JobLib {
         return ECRecovery.recover(personalSegmentHash(_streamId, _segmentNumber, _dataHash), _broadcasterSig) == _broadcaster;
     }
 
+    /*
+     * @dev Checks if a transcode receipt hash was included in a committed merkle root
+     * @param _streamId StreamID for the segment
+     * @param _segmentNumber Sequence number of segment in the stream
+     * @param _dataHash Hash of segment data
+     * @param _transcodedDataHash Hash of transcoded segment data
+     * @param _broadcasterSig Broadcaster signature over h(streamId, segmentNumber, dataHash)
+     * @param _broadcaster Broadcaster address
+     */
     function validateReceipt(
         string _streamId,
         uint256 _segmentNumber,

--- a/contracts/jobs/libraries/JobLib.sol
+++ b/contracts/jobs/libraries/JobLib.sol
@@ -38,6 +38,7 @@ library JobLib {
         uint256 _segmentNumber,
         uint256[2] _segmentRange,
         uint256 _claimBlock,
+        bytes32 _claimBlockHash,
         uint64 _verificationRate
     )
         public
@@ -51,7 +52,7 @@ library JobLib {
 
         // Use block hash and block number of the block after a claim to determine if a segment
         // should be verified
-        if (uint256(keccak256(_claimBlock + 1, block.blockhash(_claimBlock + 1), _segmentNumber)) % _verificationRate == 0) {
+        if (uint256(keccak256(_claimBlock, _claimBlockHash, _segmentNumber)) % _verificationRate == 0) {
             return true;
         } else {
             return false;

--- a/migrations/5_init_protocol.js
+++ b/migrations/5_init_protocol.js
@@ -58,7 +58,6 @@ module.exports = function(deployer, network) {
             bondingManager.initialize(config.bondingManager.numActiveTranscoders, config.bondingManager.unbondingPeriod),
             jobsManager.initialize(
                 config.jobsManager.verificationRate,
-                config.jobsManager.jobEndingPeriod,
                 config.jobsManager.verificationPeriod,
                 config.jobsManager.slashingPeriod,
                 config.jobsManager.failedVerificationSlashAmount,

--- a/migrations/migrations.config.js
+++ b/migrations/migrations.config.js
@@ -9,7 +9,6 @@ module.exports = {
     },
     jobsManager: {
         verificationRate: 1,
-        jobEndingPeriod: 50,
         verificationPeriod: 50,
         slashingPeriod: 50,
         failedVerificationSlashAmount: 20,

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-preset-stage-3": "^6.24.1",
     "babel-register": "^6.24.1",
     "bignumber.js": "^4.0.1",
+    "es6-promisify": "^5.0.0",
     "eslint": "^4.3.0",
     "eslint-config-google": "^0.9.1",
     "ethereumjs-abi": "^0.6.4",

--- a/test/unit/JobsManager.js
+++ b/test/unit/JobsManager.js
@@ -4,6 +4,7 @@ import MerkleTree from "../../utils/merkleTree"
 import batchTranscodeReceiptHashes from "../../utils/batchTranscodeReceipts"
 import {createTranscodingOptions} from "../../utils/videoProfile"
 import Segment from "../../utils/segment"
+import promisify from "es6-promisify"
 import ethUtil from "ethereumjs-util"
 
 const JobsManager = artifacts.require("JobsManager")
@@ -234,6 +235,7 @@ contract("JobsManager", accounts => {
 
             const claimId = 0
             const claimBlock = web3.eth.blockNumber
+            const blockHash = (await promisify(web3.eth.getBlock)(claimBlock - 1)).hash
             const verificationPeriod = await jobsManager.verificationPeriod.call()
             const slashingPeriod = await jobsManager.slashingPeriod.call()
 
@@ -246,11 +248,13 @@ contract("JobsManager", accounts => {
             assert.equal(cRoot, claimRoot, "claim root incorrect")
             const cBlock = cInfo[2]
             assert.equal(cBlock, claimBlock, "claim block incorrect")
-            const cEndVerificationBlock = cInfo[3]
+            const cBlockHash = cInfo[3]
+            assert.equal(cBlockHash, blockHash, "block hash incorrect")
+            const cEndVerificationBlock = cInfo[4]
             assert.equal(cEndVerificationBlock, claimBlock + verificationPeriod.toNumber(), "end verification block incorrect")
-            const cEndSlashingBlock = cInfo[4]
+            const cEndSlashingBlock = cInfo[5]
             assert.equal(cEndSlashingBlock, claimBlock + verificationPeriod.toNumber() + slashingPeriod.toNumber(), "end slashing block incorrect")
-            const cStatus = cInfo[5]
+            const cStatus = cInfo[6]
             assert.equal(cStatus, 0, "claim status incorrect")
         })
 
@@ -488,7 +492,7 @@ contract("JobsManager", accounts => {
             const jEscrow = jInfo[7]
             assert.equal(jEscrow, 0, "escrow is incorrect")
             const cInfo = await jobsManager.getClaim(jobId, claimId)
-            const cStatus = cInfo[5]
+            const cStatus = cInfo[6]
             assert.equal(cStatus, 2, "claim status is incorrect")
         })
 
@@ -591,10 +595,10 @@ contract("JobsManager", accounts => {
             assert.equal(jEscrow, 80, "escrow is incorrect")
 
             const cInfo0 = await jobsManager.getClaim(jobId, 0)
-            const cStatus0 = cInfo0[5]
+            const cStatus0 = cInfo0[6]
             assert.equal(cStatus0, 2, "claim 0 status incorrect")
             const cInfo1 = await jobsManager.getClaim(jobId, 1)
-            const cStatus1 = cInfo1[5]
+            const cStatus1 = cInfo1[6]
             assert.equal(cStatus1, 2, "claim 1 status incorrect")
         })
     })
@@ -709,7 +713,7 @@ contract("JobsManager", accounts => {
             const bDeposit = (await jobsManager.broadcasters.call(broadcaster))[0]
             assert.equal(bDeposit, 1000, "broadcaster deposit is incorrect")
             const cInfo = await jobsManager.getClaim(jobId, claimId)
-            const cStatus = cInfo[5]
+            const cStatus = cInfo[6]
             assert.equal(cStatus, 1, "claim status is incorrect")
         })
 

--- a/truffle.js
+++ b/truffle.js
@@ -40,5 +40,11 @@ module.exports = {
             enabled: true,
             runs: 200
         }
+    },
+    solc: {
+        optimizer: {
+            enabled: true,
+            runs: 200
+        }
     }
 }

--- a/truffle.js
+++ b/truffle.js
@@ -40,11 +40,5 @@ module.exports = {
             enabled: true,
             runs: 200
         }
-    },
-    solc: {
-        optimizer: {
-            enabled: true,
-            runs: 200
-        }
     }
 }


### PR DESCRIPTION
Current approach to restricting broadcaster deposit withdrawals:

The JobsManager keeps track of the number of active jobs for a broadcaster. A job can be in 3 states - `Active`, `Ended` and `Inactive`. When a job is created it becomes `Active`. When either a transcoder or broadcaster calls `endJob(jobId)` for a job, the job becomes `Ended` and an end block is set for the job. After a job's end block, it becomes `Inactive`. A broadcaster can only withdraw its deposit if it has 0 active jobs, and the latest end block for any of its ended jobs is less than or equal to the current block. A consequence of this is that a broadcaster must call `endJob` for all of its active jobs in order to withdraw its deposit which is not ideal from a UX/cost point of view, but let me know what you guys think.

As a solution to mitigate the possibility of a miner influencing the block hash used to determine which segments are challenged, we use the block hash of claimBlock + 1 which a miner can only influence if it wins the race to mine the block after the claimBlock.

Closes #76 #103