### PR TITLE
Double claim segment slashing condition. claimBlock + 1 for challenged segments

### DIFF
--- a/contracts/jobs/libraries/JobLib.sol
+++ b/contracts/jobs/libraries/JobLib.sol
@@ -44,14 +44,15 @@ library JobLib {
         view
         returns (bool)
     {
+        // Claim block + 1 must be within the last 256 blocks from the current block
+        require(_claimBlock + 1 > block.number - 256);
         // Segment must be in segment range
         if (_segmentNumber < _segmentRange[0] || _segmentNumber > _segmentRange[1]) {
             return false;
         }
 
         // Use block hash and block number of the block after a claim to determine if a segment
-        // should be verified. Note: this check will only work if _claimBlock + 1 is within
-        // the last 256 blocks from the current block
+        // should be verified
         if (uint256(keccak256(_claimBlock + 1, block.blockhash(_claimBlock + 1), _segmentNumber)) % _verificationRate == 0) {
             return true;
         } else {

--- a/contracts/jobs/libraries/JobLib.sol
+++ b/contracts/jobs/libraries/JobLib.sol
@@ -38,7 +38,6 @@ library JobLib {
         uint256 _segmentNumber,
         uint256[2] _segmentRange,
         uint256 _claimBlock,
-        bytes32 _claimBlockHash,
         uint64 _verificationRate
     )
         public
@@ -51,8 +50,9 @@ library JobLib {
         }
 
         // Use block hash and block number of the block after a claim to determine if a segment
-        // should be verified
-        if (uint256(keccak256(_claimBlock, _claimBlockHash, _segmentNumber)) % _verificationRate == 0) {
+        // should be verified. Note: this check will only work if _claimBlock + 1 is within
+        // the last 256 blocks from the current block
+        if (uint256(keccak256(_claimBlock + 1, block.blockhash(_claimBlock + 1), _segmentNumber)) % _verificationRate == 0) {
             return true;
         } else {
             return false;

--- a/contracts/jobs/libraries/JobLib.sol
+++ b/contracts/jobs/libraries/JobLib.sol
@@ -45,7 +45,7 @@ library JobLib {
         returns (bool)
     {
         // Claim block + 1 must be within the last 256 blocks from the current block
-        require(_claimBlock + 1 > block.number - 256);
+        require(block.number < 256 || _claimBlock + 1 >= block.number - 256);
         // Segment must be in segment range
         if (_segmentNumber < _segmentRange[0] || _segmentNumber > _segmentRange[1]) {
             return false;

--- a/migrations/5_init_protocol.js
+++ b/migrations/5_init_protocol.js
@@ -62,6 +62,7 @@ module.exports = function(deployer, network) {
                 config.jobsManager.slashingPeriod,
                 config.jobsManager.failedVerificationSlashAmount,
                 config.jobsManager.missedVerificationSlashAmount,
+                config.jobsManager.doubleClaimSegmentSlashAmount,
                 config.jobsManager.finderFee
             ),
             roundsManager.initialize(config.roundsManager.blockTime, config.roundsManager.roundLength)

--- a/migrations/migrations.config.js
+++ b/migrations/migrations.config.js
@@ -13,6 +13,7 @@ module.exports = {
         slashingPeriod: 50,
         failedVerificationSlashAmount: 20,
         missedVerificationSlashAmount: 30,
+        doubleClaimSegmentSlashAmount: 40,
         finderFee: 4
     },
     roundsManager: {

--- a/test/unit/JobsManager.js
+++ b/test/unit/JobsManager.js
@@ -242,7 +242,6 @@ contract("JobsManager", accounts => {
 
             const claimId = 0
             const claimBlock = web3.eth.blockNumber
-            const blockHash = (await promisify(web3.eth.getBlock)(claimBlock - 1)).hash
             const verificationPeriod = await jobsManager.verificationPeriod.call()
             const slashingPeriod = await jobsManager.slashingPeriod.call()
 
@@ -255,13 +254,11 @@ contract("JobsManager", accounts => {
             assert.equal(cRoot, claimRoot, "claim root incorrect")
             const cBlock = cInfo[2]
             assert.equal(cBlock, claimBlock, "claim block incorrect")
-            const cBlockHash = cInfo[3]
-            assert.equal(cBlockHash, blockHash, "block hash incorrect")
-            const cEndVerificationBlock = cInfo[4]
+            const cEndVerificationBlock = cInfo[3]
             assert.equal(cEndVerificationBlock, claimBlock + verificationPeriod.toNumber(), "end verification block incorrect")
-            const cEndSlashingBlock = cInfo[5]
+            const cEndSlashingBlock = cInfo[4]
             assert.equal(cEndSlashingBlock, claimBlock + verificationPeriod.toNumber() + slashingPeriod.toNumber(), "end slashing block incorrect")
-            const cStatus = cInfo[6]
+            const cStatus = cInfo[5]
             assert.equal(cStatus, 0, "claim status incorrect")
         })
 
@@ -501,7 +498,7 @@ contract("JobsManager", accounts => {
             const jEscrow = jInfo[7]
             assert.equal(jEscrow, 0, "escrow is incorrect")
             const cInfo = await jobsManager.getClaim(jobId, claimId)
-            const cStatus = cInfo[6]
+            const cStatus = cInfo[5]
             assert.equal(cStatus, 2, "claim status is incorrect")
         })
 
@@ -606,10 +603,10 @@ contract("JobsManager", accounts => {
             assert.equal(jEscrow, 80, "escrow is incorrect")
 
             const cInfo0 = await jobsManager.getClaim(jobId, 0)
-            const cStatus0 = cInfo0[6]
+            const cStatus0 = cInfo0[5]
             assert.equal(cStatus0, 2, "claim 0 status incorrect")
             const cInfo1 = await jobsManager.getClaim(jobId, 1)
-            const cStatus1 = cInfo1[6]
+            const cStatus1 = cInfo1[5]
             assert.equal(cStatus1, 2, "claim 1 status incorrect")
         })
     })
@@ -725,7 +722,7 @@ contract("JobsManager", accounts => {
             const bDeposit = (await jobsManager.broadcasters.call(broadcaster))[0]
             assert.equal(bDeposit, 1000, "broadcaster deposit is incorrect")
             const cInfo = await jobsManager.getClaim(jobId, claimId)
-            const cStatus = cInfo[6]
+            const cStatus = cInfo[5]
             assert.equal(cStatus, 1, "claim status is incorrect")
         })
 
@@ -794,10 +791,10 @@ contract("JobsManager", accounts => {
             const bDeposit = (await jobsManager.broadcasters.call(broadcaster))[0]
             assert.equal(bDeposit, 1000, "broadcaster deposit is incorrect")
             const c1Info = await jobsManager.getClaim(jobId, 0)
-            const c1Status = c1Info[6]
+            const c1Status = c1Info[5]
             assert.equal(c1Status, 1, "claim 1 status is incorrect")
             const c2Info = await jobsManager.getClaim(jobId, 1)
-            const c2Status = c2Info[6]
+            const c2Status = c2Info[5]
             assert.equal(c2Status, 1, "claim 2 status is incorrect")
         })
     })

--- a/test/unit/JobsManager.js
+++ b/test/unit/JobsManager.js
@@ -353,6 +353,9 @@ contract("JobsManager", accounts => {
             const segmentRange = [0, 3]
             // Account 1 (transcoder) claims work for job 0
             await jobsManager.claimWork(jobId, segmentRange, merkleTree.getHexRoot(), {from: electedTranscoder})
+
+            // Fast forward so that claimBlock + 1 is mined
+            await fixture.rpc.wait(1)
         })
 
         it("should throw for insufficient payment for verification", async () => {
@@ -675,6 +678,9 @@ contract("JobsManager", accounts => {
             const segmentRange = [0, 3]
             // Account 1 (transcoder) claims work for job 0
             await jobsManager.claimWork(jobId, segmentRange, merkleTree.getHexRoot(), {from: electedTranscoder})
+
+            // Fast forward so that claimBlock + 1 is mined
+            // await fixture.rpc.wait(1)
         })
 
         it("should throw if verification period is not over", async () => {


### PR DESCRIPTION
Added a double claim segment slashing condition to prevent transcoders from claiming a segment more than once. Watchers can trigger this slashing condition and earn a finder's fee.

Triggering this slashing condition kicks out the transcoder and fully refunds a broadcaster for the job which I think makes sense. There needs to be some work done on the logic for the failed verification and missed verification slashing conditions which currently only refund a broadcaster for a claim, but also kick out the transcoder (meaning there are funds stuck in escrow) - I'll track that in a separate issue

Using `block.blockhash(claimBlock + 1)` for challenging segments - acknowledging the limitations of using this value and placing restrictions on the total length of the verification and slashing period.

Closes #106 