### PR TITLE
Use job creation block as psuedorandom seed for assigning a transcoder

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -475,7 +475,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * Returns address of elected active transcoder and its price per segment
      * @param _maxPricePerSegment Max price (in LPT base units) per segment of a stream
      */
-    function electActiveTranscoder(uint256 _maxPricePerSegment) external returns (address) {
+    function electActiveTranscoder(uint256 _maxPricePerSegment, uint256 _block) external view returns (address) {
         uint256 activeSetSize = Math.min256(numActiveTranscoders, transcoderPool.getSize());
         // Create array to store available transcoders charging an acceptable price per segment
         address[] memory availableTranscoders = new address[](activeSetSize);
@@ -501,7 +501,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             address electedTranscoder = availableTranscoders[numAvailableTranscoders - 1];
 
             // Pseudorandomly pick an available transcoder weighted by its stake relative to the total stake of all available transcoders
-            uint256 r = uint256(block.blockhash(block.number - 1)) % totalAvailableTranscoderStake;
+            uint256 r = uint256(block.blockhash(_block)) % totalAvailableTranscoderStake;
             uint256 s = 0;
 
             for (uint256 j = 0; j < numAvailableTranscoders; j++) {

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -10,9 +10,9 @@ contract IBondingManager {
     function setActiveTranscoders() external returns (bool);
     function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external returns (bool);
     function slashTranscoder(address _transcoder, address _finder, uint64 _slashAmount, uint64 _finderFee) external returns (bool);
-    function electActiveTranscoder(uint256 _maxPricePerSegment, uint256 _block) external view returns (address);
+    function electActiveTranscoder(uint256 _maxPricePerSegment, uint256 _block, uint256 _round) external view returns (address);
 
     // Public functions
     function transcoderTotalStake(address _transcoder) public view returns (uint256);
-    function activeTranscoderTotalStake(address _transcoder) public view returns (uint256);
+    function activeTranscoderTotalStake(address _transcoder, uint256 _round) public view returns (uint256);
 }

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -10,7 +10,7 @@ contract IBondingManager {
     function setActiveTranscoders() external returns (bool);
     function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external returns (bool);
     function slashTranscoder(address _transcoder, address _finder, uint64 _slashAmount, uint64 _finderFee) external returns (bool);
-    function electActiveTranscoder(uint256 _maxPricePerSegment) external returns (address);
+    function electActiveTranscoder(uint256 _maxPricePerSegment, uint256 _block) external view returns (address);
 
     // Public functions
     function transcoderTotalStake(address _transcoder) public view returns (uint256);

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -233,8 +233,8 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
             require(job.transcoderAddress == msg.sender);
         } else {
             // If transcoder is not already assigned, check if sender
-            // should be assigned and that it has been <= 256 blocks since the job creation block
-            require(block.number <= job.creationBlock + 256 && bondingManager().electActiveTranscoder(job.maxPricePerSegment, job.creationBlock + 1) == msg.sender);
+            // should be assigned and that job creation block + 1 has been mined and it has been <= 256 blocks since the job creation block
+            require(block.number > job.creationBlock + 1 && block.number <= job.creationBlock + 256 && bondingManager().electActiveTranscoder(job.maxPricePerSegment, job.creationBlock + 1) == msg.sender);
             job.transcoderAddress = msg.sender;
         }
 

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -57,6 +57,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         address broadcasterAddress;           // Address of broadcaster that requestes a transcoding job
         address transcoderAddress;            // Address of transcoder selected for the job
         uint256 creationRound;                // Round that a job is created
+        uint256 creationBlock;                // Block that a job is created
         uint256 endBlock;                     // Block at which the job is ended and considered inactive
         Claim[] claims;                       // Claims submitted for this job
         uint256 escrow;                       // Claim fees before verification and slashing periods are complete
@@ -104,7 +105,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
     }
 
     // Events
-    event NewJob(address indexed transcoder, address indexed broadcaster, uint256 jobId, string streamId, string transcodingOptions);
+    event NewJob(address indexed broadcaster, uint256 jobId, string streamId, string transcodingOptions, uint256 maxPricePerSegment, uint256 creationBlock);
     event NewClaim(address indexed transcoder, uint256 indexed jobId, uint256 claimId);
     event ReceivedVerification(uint256 indexed jobId, uint256 indexed claimId, uint256 segmentNumber, bool result);
 
@@ -182,21 +183,17 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         // End block must be in the future
         require(_endBlock > block.number);
 
-        address electedTranscoder = bondingManager().electActiveTranscoder(_maxPricePerSegment);
-        // There must be an elected transcoder
-        require(electedTranscoder != address(0));
-
         Job storage job = jobs[numJobs];
         job.jobId = numJobs;
         job.streamId = _streamId;
         job.transcodingOptions = _transcodingOptions;
         job.maxPricePerSegment = _maxPricePerSegment;
         job.broadcasterAddress = msg.sender;
-        job.transcoderAddress = electedTranscoder;
         job.creationRound = roundsManager().currentRound();
+        job.creationBlock = block.number;
         job.endBlock = _endBlock;
 
-        NewJob(electedTranscoder, msg.sender, numJobs, _streamId, _transcodingOptions);
+        NewJob(msg.sender, numJobs, _streamId, _transcodingOptions, _maxPricePerSegment, block.number);
 
         // Increment number of created jobs
         numJobs = numJobs.add(1);
@@ -227,10 +224,19 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
 
         // Job cannot be inactive
         require(jobStatus(_jobId) != JobStatus.Inactive);
-        // Sender must be elected transcoder
-        require(job.transcoderAddress == msg.sender);
         // Segment range must be valid
         require(_segmentRange[1] >= _segmentRange[0]);
+
+        if (job.transcoderAddress != address(0)) {
+            // If transcoder already assigned, check if sender is
+            // the assigned transcoder
+            require(job.transcoderAddress == msg.sender);
+        } else {
+            // If transcoder is not already assigned, check if sender
+            // should be assigned and that it has been <= 256 blocks since the job creation block
+            require(block.number <= job.creationBlock + 256 && bondingManager().electActiveTranscoder(job.maxPricePerSegment, job.creationBlock + 1) == msg.sender);
+            job.transcoderAddress = msg.sender;
+        }
 
         // Move fees from broadcaster deposit to escrow
         uint256 fees = JobLib.calcFees(_segmentRange[1].sub(_segmentRange[0]).add(1), job.transcodingOptions, job.maxPricePerSegment);
@@ -518,7 +524,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
     )
         public
         view
-        returns (string streamId, string transcodingOptions, uint256 maxPricePerSegment, address broadcasterAddress, address transcoderAddress, uint256 creationRound, uint256 endBlock, uint256 escrow, uint256 totalClaims)
+        returns (string streamId, string transcodingOptions, uint256 maxPricePerSegment, address broadcasterAddress, address transcoderAddress, uint256 creationRound, uint256 creationBlock, uint256 endBlock, uint256 escrow, uint256 totalClaims)
     {
         Job storage job = jobs[_jobId];
 
@@ -528,6 +534,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         broadcasterAddress = job.broadcasterAddress;
         transcoderAddress = job.transcoderAddress;
         creationRound = job.creationRound;
+        creationBlock = job.creationBlock;
         endBlock = job.endBlock;
         escrow = job.escrow;
         totalClaims = job.claims.length;

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -233,8 +233,8 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
             require(job.transcoderAddress == msg.sender);
         } else {
             // If transcoder is not already assigned, check if sender
-            // should be assigned and that job creation block + 1 has been mined and it has been <= 256 blocks since the job creation block
-            require(block.number > job.creationBlock + 1 && block.number <= job.creationBlock + 256 && bondingManager().electActiveTranscoder(job.maxPricePerSegment, job.creationBlock + 1) == msg.sender);
+            // should be assigned and that job creation block has been mined and it has been <= 256 blocks since the job creation block
+            require(block.number > job.creationBlock && block.number <= job.creationBlock + 256 && bondingManager().electActiveTranscoder(job.maxPricePerSegment, job.creationBlock, job.creationRound) == msg.sender);
             job.transcoderAddress = msg.sender;
         }
 

--- a/contracts/test/BondingManagerMock.sol
+++ b/contracts/test/BondingManagerMock.sol
@@ -55,7 +55,7 @@ contract BondingManagerMock is IBondingManager {
         return true;
     }
 
-    function electActiveTranscoder(uint256 _maxPricePerSegment) external returns (address) {
+    function electActiveTranscoder(uint256 _maxPricePerSegment, uint256 _block) external view returns (address) {
         return transcoder;
     }
 

--- a/contracts/test/BondingManagerMock.sol
+++ b/contracts/test/BondingManagerMock.sol
@@ -55,7 +55,7 @@ contract BondingManagerMock is IBondingManager {
         return true;
     }
 
-    function electActiveTranscoder(uint256 _maxPricePerSegment, uint256 _block) external view returns (address) {
+    function electActiveTranscoder(uint256 _maxPricePerSegment, uint256 _block, uint256 _round) external view returns (address) {
         return transcoder;
     }
 
@@ -63,7 +63,7 @@ contract BondingManagerMock is IBondingManager {
         return activeStake;
     }
 
-    function activeTranscoderTotalStake(address _transcoder) public view returns (uint256) {
+    function activeTranscoderTotalStake(address _transcoder, uint256 _round) public view returns (uint256) {
         return activeStake;
     }
 }

--- a/contracts/test/JobsManagerMock.sol
+++ b/contracts/test/JobsManagerMock.sol
@@ -101,8 +101,4 @@ contract JobsManagerMock is IJobsManager {
     function receiveVerification(uint256 _jobId, uint256 _claimId, uint256 _segmentNumber, bool _result) external returns (bool) {
         return true;
     }
-
-    function callElectActiveTranscoder(uint256 _maxPricePerSegment) external {
-        bondingManager.electActiveTranscoder(_maxPricePerSegment);
-    }
 }

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -193,7 +193,6 @@ contract("BondingManager", accounts => {
             await bondingManager.bond(100, tAddr0, {from: dAddr})
 
             const fees = 300
-            const pricePerSegment = 10
             const jobCreationRound = 6
             const currentRound = 7
 
@@ -202,7 +201,6 @@ contract("BondingManager", accounts => {
             // Set active transcoders
             await fixture.roundsManager.setCurrentRound(jobCreationRound)
             await fixture.roundsManager.initializeRound()
-            await fixture.jobsManager.callElectActiveTranscoder(pricePerSegment)
             await fixture.roundsManager.setCurrentRound(currentRound)
 
             // Call updateTranscoderWithFees via transaction from JobsManager
@@ -259,7 +257,6 @@ contract("BondingManager", accounts => {
             // Set active transcoders
             await fixture.roundsManager.setCurrentRound(jobCreationRound)
             await fixture.roundsManager.initializeRound()
-            await fixture.jobsManager.callElectActiveTranscoder(pricePerSegment)
             await fixture.roundsManager.setCurrentRound(currentRound)
         })
 
@@ -313,11 +310,9 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.initializeRound()
             await fixture.roundsManager.setCurrentRound(6)
             await fixture.roundsManager.initializeRound()
-            // // Set the current round to jobCreationRound
+            // Set the current round to jobCreationRound
             await fixture.roundsManager.setCurrentRound(jobCreationRound)
             await fixture.roundsManager.initializeRound()
-            // Set the totalStake for the fee pool at jobCreationRound
-            await fixture.jobsManager.callElectActiveTranscoder(pricePerSegment)
 
             // Set params for distribute fees
             await fixture.jobsManager.setDistributeFeesParams(tAddr, fees, jobCreationRound)
@@ -393,8 +388,6 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setCurrentRound(jobCreationRound2)
             // Set active transcoders
             await fixture.roundsManager.initializeRound()
-            // Set the totalStake for the fee pool at jobCreationRound2
-            await fixture.jobsManager.callElectActiveTranscoder(pricePerSegment)
 
             // Set params for distribute fees
             await fixture.jobsManager.setDistributeFeesParams(tAddr, fees2, jobCreationRound2)
@@ -530,7 +523,6 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.initializeRound()
             await fixture.roundsManager.setCurrentRound(jobCreationRound)
             await fixture.roundsManager.initializeRound()
-            await fixture.jobsManager.callElectActiveTranscoder(pricePerSegment)
 
             await fixture.jobsManager.setDistributeFeesParams(tAddr, fees, jobCreationRound)
 
@@ -649,8 +641,6 @@ contract("BondingManager", accounts => {
         })
 
         it("should withdraw unbonded amount", async () => {
-            await fixture.jobsManager.callElectActiveTranscoder(pricePerSegment)
-
             await fixture.jobsManager.setDistributeFeesParams(tAddr, fees, jobCreationRound)
 
             // Call updateTranscoderWithFees via transaction from JobsManager
@@ -688,8 +678,6 @@ contract("BondingManager", accounts => {
         })
 
         it("should withdraw both bonded and unbonded tokens", async () => {
-            await fixture.jobsManager.callElectActiveTranscoder(pricePerSegment)
-
             await fixture.jobsManager.setDistributeFeesParams(tAddr, fees, jobCreationRound)
 
             // Call updateTranscoderWithFees via transaction from JobsManager

--- a/test/unit/JobsManager.js
+++ b/test/unit/JobsManager.js
@@ -126,7 +126,6 @@ contract("JobsManager", accounts => {
             e.watch(async (err, result) => {
                 e.stopWatching()
 
-                assert.equal(result.args.transcoder, electedTranscoder, "elected transcoder incorrect")
                 assert.equal(result.args.broadcaster, broadcaster, "broadcaster incorrect")
                 assert.equal(result.args.jobId, 0, "new job id incorrect")
                 assert.equal(result.args.streamId, streamId, "stream id incorrect")
@@ -145,6 +144,7 @@ contract("JobsManager", accounts => {
             await fixture.bondingManager.setActiveTranscoder(accounts[1], 0, transcoderTotalStake, 0)
 
             const endBlock = web3.eth.blockNumber + 500
+            const creationBlock = web3.eth.blockNumber + 1
             await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, endBlock, {from: broadcaster})
 
             const jInfo = await jobsManager.getJob(0)
@@ -152,15 +152,15 @@ contract("JobsManager", accounts => {
             assert.equal(jMaxPricePerSegment, maxPricePerSegment, "max price per segment incorrect")
             const jBroadcasterAddress = jInfo[3]
             assert.equal(jBroadcasterAddress, broadcaster, "broadcaster address incorrect")
-            const jTranscoderAddress = jInfo[4]
-            assert.equal(jTranscoderAddress, electedTranscoder, "transcoder address incorrect")
             const jCreationRound = jInfo[5]
             assert.equal(jCreationRound, creationRound, "creation round incorrect")
-            const jEndBlock = jInfo[6]
+            const jCreationBlock = jInfo[6]
+            assert.equal(jCreationBlock, creationBlock, "creation block incorrect")
+            const jEndBlock = jInfo[7]
             assert.equal(jEndBlock, endBlock, "end block incorrect")
-            const jEscrow = jInfo[7]
+            const jEscrow = jInfo[8]
             assert.equal(jEscrow, 0, "escrow incorrect")
-            const jTotalClaims = jInfo[8]
+            const jTotalClaims = jInfo[9]
             assert.equal(jTotalClaims, 0, "total claims incorrect")
         })
     })
@@ -193,7 +193,7 @@ contract("JobsManager", accounts => {
             // Broadcaster deposits fees
             await jobsManager.deposit(deposit, {from: broadcaster})
 
-            const endBlock0 = web3.eth.blockNumber + 50
+            const endBlock0 = web3.eth.blockNumber + 400
             // Broadcaster creates job 0
             await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, endBlock0, {from: broadcaster})
             const endBlock1 = web3.eth.blockNumber + 20
@@ -216,7 +216,21 @@ contract("JobsManager", accounts => {
             await expectThrow(jobsManager.claimWork(inactiveJobId, segmentRange, claimRoot, {from: electedTranscoder}))
         })
 
-        it("should fail if sender is not elected transcoder", async () => {
+        it("should fail if the transcoder is assigned and the sender is not the assigned transcoder", async () => {
+            await jobsManager.claimWork(jobId, segmentRange, claimRoot, {from: electedTranscoder})
+
+            // Account 2 (not elected transcoder) claims work
+            await expectThrow(jobsManager.claimWork(jobId, segmentRange, claimRoot, {from: accounts[2]}))
+        })
+
+        it("should fail if the transcoder is not assigned and it has been more than 256 blocks since the job creation block", async () => {
+            const creationBlock = (await jobsManager.getJob(jobId))[6]
+            await fixture.rpc.wait(256 - (web3.eth.blockNumber - creationBlock.toNumber()))
+
+            await expectThrow(jobsManager.claimWork(jobId, segmentRange, claimRoot, {from: electedTranscoder}))
+        })
+
+        it("should fail if the sender should not be assigned the job", async () => {
             // Account 2 (not elected transcoder) claims work
             await expectThrow(jobsManager.claimWork(jobId, segmentRange, claimRoot, {from: accounts[2]}))
         })
@@ -267,7 +281,7 @@ contract("JobsManager", accounts => {
             const fees = maxPricePerSegment * 2 * (segmentRange[1] - segmentRange[0] + 1)
 
             const jInfo = await jobsManager.getJob(jobId)
-            const jEscrow = jInfo[7]
+            const jEscrow = jInfo[8]
             assert.equal(jEscrow, fees, "escrow is incorrect")
         })
 
@@ -497,7 +511,7 @@ contract("JobsManager", accounts => {
             await jobsManager.distributeFees(jobId, claimId, {from: electedTranscoder})
 
             const jInfo = await jobsManager.getJob(jobId)
-            const jEscrow = jInfo[7]
+            const jEscrow = jInfo[8]
             assert.equal(jEscrow, 0, "escrow is incorrect")
             const cInfo = await jobsManager.getClaim(jobId, claimId)
             const cStatus = cInfo[5]
@@ -601,7 +615,7 @@ contract("JobsManager", accounts => {
             await jobsManager.batchDistributeFees(jobId, claimIds, {from: electedTranscoder})
 
             const jInfo = await jobsManager.getJob(jobId)
-            const jEscrow = jInfo[7]
+            const jEscrow = jInfo[8]
             assert.equal(jEscrow, 80, "escrow is incorrect")
 
             const cInfo0 = await jobsManager.getClaim(jobId, 0)
@@ -722,7 +736,7 @@ contract("JobsManager", accounts => {
             await jobsManager.missedVerificationSlash(jobId, claimId, segmentNumber, {from: accounts[2]})
 
             const jInfo = await jobsManager.getJob(jobId)
-            const jEscrow = jInfo[7]
+            const jEscrow = jInfo[8]
             assert.equal(jEscrow, 0, "escrow is incorrect")
             const bDeposit = (await jobsManager.broadcasters.call(broadcaster))[0]
             assert.equal(bDeposit, 1000, "broadcaster deposit is incorrect")
@@ -791,7 +805,7 @@ contract("JobsManager", accounts => {
             await jobsManager.doubleClaimSegmentSlash(0, 0, 1, 3, {from: accounts[3]})
 
             const jInfo = await jobsManager.getJob(jobId)
-            const jEscrow = jInfo[7]
+            const jEscrow = jInfo[8]
             assert.equal(jEscrow, 0, "escrow is incorrect")
             const bDeposit = (await jobsManager.broadcasters.call(broadcaster))[0]
             assert.equal(bDeposit, 1000, "broadcaster deposit is incorrect")

--- a/test/unit/JobsManager.js
+++ b/test/unit/JobsManager.js
@@ -223,13 +223,6 @@ contract("JobsManager", accounts => {
             await expectThrow(jobsManager.claimWork(jobId, segmentRange, claimRoot, {from: accounts[2]}))
         })
 
-        it("should fail if the transcoder is not assigned and job creation block + 1 has not been mined", async () => {
-            const endBlock = web3.eth.blockNumber + 100
-            await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, endBlock, {from: broadcaster})
-
-            await expectThrow(jobsManager.claimWork(2, segmentRange, claimRoot, {from: electedTranscoder}))
-        })
-
         it("should fail if the transcoder is not assigned and it has been more than 256 blocks since the job creation block", async () => {
             const creationBlock = (await jobsManager.getJob(jobId))[6]
             await fixture.rpc.wait(256 - (web3.eth.blockNumber - creationBlock.toNumber()))

--- a/test/unit/JobsManager.js
+++ b/test/unit/JobsManager.js
@@ -223,6 +223,13 @@ contract("JobsManager", accounts => {
             await expectThrow(jobsManager.claimWork(jobId, segmentRange, claimRoot, {from: accounts[2]}))
         })
 
+        it("should fail if the transcoder is not assigned and job creation block + 1 has not been mined", async () => {
+            const endBlock = web3.eth.blockNumber + 100
+            await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, endBlock, {from: broadcaster})
+
+            await expectThrow(jobsManager.claimWork(2, segmentRange, claimRoot, {from: electedTranscoder}))
+        })
+
         it("should fail if the transcoder is not assigned and it has been more than 256 blocks since the job creation block", async () => {
             const creationBlock = (await jobsManager.getJob(jobId))[6]
             await fixture.rpc.wait(256 - (web3.eth.blockNumber - creationBlock.toNumber()))
@@ -454,6 +461,9 @@ contract("JobsManager", accounts => {
             // Broadcaster creates job 0
             await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, endBlock, {from: broadcaster})
 
+            // Wait for job creation block + 1 to be mined
+            await fixture.rpc.wait(1)
+
             const segmentRange = [0, 3]
             const claimRoot = "0x1000000000000000000000000000000000000000000000000000000000000000"
             // Account 1 (transcoder) claims work for job 0
@@ -594,6 +604,9 @@ contract("JobsManager", accounts => {
             // Broadcaster creates job 0
             await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, endBlock, {from: broadcaster})
 
+            // Wait for job creation block + 1 to be mined
+            await fixture.rpc.wait(1)
+
             const segmentRange0 = [0, 3]
             const claimRoot = "0x1000000000000000000000000000000000000000000000000000000000000000"
             // Transcoder submits claim 0
@@ -688,12 +701,12 @@ contract("JobsManager", accounts => {
             // Broadcaster creates job 0
             await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, endBlock, {from: broadcaster})
 
+            // Wait for job creation block + 1 to be mined
+            await fixture.rpc.wait(1)
+
             const segmentRange = [0, 3]
             // Account 1 (transcoder) claims work for job 0
             await jobsManager.claimWork(jobId, segmentRange, merkleTree.getHexRoot(), {from: electedTranscoder})
-
-            // Fast forward so that claimBlock + 1 is mined
-            // await fixture.rpc.wait(1)
         })
 
         it("should throw if verification period is not over", async () => {
@@ -783,6 +796,9 @@ contract("JobsManager", accounts => {
             const endBlock = web3.eth.blockNumber + 500
             // Broadcaster creates job 0
             await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, endBlock, {from: broadcaster})
+
+            // Wait for job creation block + 1 to be mined
+            await fixture.rpc.wait(1)
 
             const segmentRange1 = [0, 3]
             const segmentRange2 = [2, 5]


### PR DESCRIPTION
This uses the block hash of job creation block + 1 as the pseudorandom seed for assigning a transcoder to a job instead of the block hash of job creation block - 1 (which is known ahead of time). A consequence of this jobs are not immediately assigned to a transcoder at the time of creation. Instead, transcoders have to watch for all job creation events and check off-chain which jobs should be assigned to them. Changes will need to be made in the client accordingly.

When calling `claimWork` for the first time for a job, the contract will verify that the caller should be assigned the job based on the block hash of job creation block + 1. Note that since we use `block.blockhash()` to get the block hash for a block, we are limited to the past 256 blocks which means that a transcoder must call `claimWork` to assign itself the job within 256 blocks of the job creation block - at the moment, transcoders simply lose the ability to claim work for the job after those 256 blocks. Also, transcoders need to wait for job creation block + 1 to be mined before it can call `claimWork`. For subsequent calls to `claimWork`, the assigned transcoder is stored for the job, so the contract just checks if the caller is the stored assigned transcoder.

Closes #120 