### PR TITLE
More events. Remove unnecessary bool return values

### DIFF
--- a/contracts/Controller.sol
+++ b/contracts/Controller.sol
@@ -20,10 +20,10 @@ contract Controller is Pausable, IController {
      * @param _id Contract id (keccak256 hash of contract name)
      * @param _contract Contract address
      */
-    function setContract(bytes32 _id, address _contract) external onlyOwner returns (bool) {
+    function setContract(bytes32 _id, address _contract) external onlyOwner {
         registry[_id] = _contract;
 
-        return true;
+        SetContract(_id, _contract);
     }
 
     /*
@@ -31,7 +31,7 @@ contract Controller is Pausable, IController {
      * @param _id Contract id (keccak256 hash of contract name)
      * @param _controller Controller address
      */
-    function updateController(bytes32 _id, address _controller) external onlyOwner returns (bool) {
+    function updateController(bytes32 _id, address _controller) external onlyOwner {
         return IManager(registry[_id]).setController(_controller);
     }
 

--- a/contracts/IController.sol
+++ b/contracts/IController.sol
@@ -4,7 +4,9 @@ import "zeppelin-solidity/contracts/lifecycle/Pausable.sol";
 
 
 contract IController is Pausable {
-    function setContract(bytes32 _id, address _contract) external returns (bool);
-    function updateController(bytes32 _id, address _controller) external returns (bool);
-    function getContract(bytes32 _id) public constant returns (address);
+    event SetContract(bytes32 id, address contractAddr);
+
+    function setContract(bytes32 _id, address _contract) external;
+    function updateController(bytes32 _id, address _controller) external;
+    function getContract(bytes32 _id) public view returns (address);
 }

--- a/contracts/IManager.sol
+++ b/contracts/IManager.sol
@@ -2,5 +2,8 @@ pragma solidity ^0.4.17;
 
 
 contract IManager {
-    function setController(address _controller) external returns (bool);
+    event SetController(address controller);
+    event ParameterUpdate(string param);
+
+    function setController(address _controller) external;
 }

--- a/contracts/Manager.sol
+++ b/contracts/Manager.sol
@@ -35,7 +35,7 @@ contract Manager is IManager {
         _;
     }
 
-    function Manager(address _controller) {
+    function Manager(address _controller) public {
         controller = IController(_controller);
     }
 
@@ -43,9 +43,9 @@ contract Manager is IManager {
      * @dev Set controller. Only callable by current controller
      * @param _controller Controller contract address
      */
-    function setController(address _controller) external onlyController returns (bool) {
+    function setController(address _controller) external onlyController {
         controller = IController(_controller);
 
-        return true;
+        SetController(_controller);
     }
 }

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -10,15 +10,15 @@ contract Migrations {
             _;
     }
 
-    function Migrations() {
+    function Migrations() public {
         owner = msg.sender;
     }
 
-    function setCompleted(uint completed) restricted {
+    function setCompleted(uint completed) public restricted {
         last_completed_migration = completed;
     }
 
-    function upgrade(address new_address) restricted {
+    function upgrade(address new_address) public restricted {
         Migrations upgraded = Migrations(new_address);
         upgraded.setCompleted(last_completed_migration);
     }

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -172,7 +172,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         t.pendingFeeShare = _feeShare;
         t.pendingPricePerSegment = _pricePerSegment;
 
-        uint256 currentRound = roundsManager().currentRound();
         uint256 delegatedAmount = delegators[msg.sender].delegatedAmount;
 
         // Check if transcoder is not already registered
@@ -185,14 +184,14 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
                     // Kick out last transcoder pool
                     transcoderPool.remove(lastTranscoder);
 
-                    TranscoderEvicted(lastTranscoder, currentRound);
+                    TranscoderEvicted(lastTranscoder);
                 }
             }
 
             transcoderPool.insert(msg.sender, delegatedAmount, address(0), address(0));
         }
 
-        TranscoderUpdate(msg.sender, _blockRewardCut, _feeShare, _pricePerSegment, currentRound);
+        TranscoderUpdate(msg.sender, _blockRewardCut, _feeShare, _pricePerSegment);
     }
 
     /*
@@ -215,7 +214,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         // Remove transcoder from pools
         transcoderPool.remove(msg.sender);
 
-        TranscoderResigned(msg.sender, currentRound);
+        TranscoderResigned(msg.sender);
     }
 
     /**
@@ -292,7 +291,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             }
         }
 
-        Bond(_to, msg.sender, currentRound);
+        Bond(_to, msg.sender);
     }
 
     /*
@@ -325,7 +324,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             transcoderPool.updateKey(del.delegateAddress, transcoderPool.getKey(del.delegateAddress).sub(del.bondedAmount), address(0), address(0));
         }
 
-        Unbond(del.delegateAddress, msg.sender, currentRound);
+        Unbond(del.delegateAddress, msg.sender);
 
         // Delegator no longer bonded to anyone
         del.delegateAddress = address(0);
@@ -361,6 +360,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         }
 
         minter().transferTokens(msg.sender, amount);
+
+        Withdraw(msg.sender);
     }
 
     /*
@@ -421,7 +422,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
         updateTranscoderWithRewards(msg.sender, rewardTokens, currentRound);
 
-        Reward(msg.sender, rewardTokens, currentRound);
+        Reward(msg.sender, rewardTokens);
     }
 
     /*
@@ -514,7 +515,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             minter().addToRedistributionPool(redistributedAmount);
         }
 
-        TranscoderSlashed(_transcoder, penalty, currentRound);
+        TranscoderSlashed(_transcoder, penalty);
     }
 
     /*

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -111,6 +111,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
         transcoderPool.setMaxSize(_numTranscoders);
         numActiveTranscoders = _numActiveTranscoders;
+
+        ParameterUpdate("all");
     }
 
     /*
@@ -119,6 +121,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      */
     function setUnbondingPeriod(uint64 _unbondingPeriod) external onlyControllerOwner {
         unbondingPeriod = _unbondingPeriod;
+
+        ParameterUpdate("unbondingPeriod");
     }
 
     /*
@@ -130,6 +134,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         require(_numTranscoders >= numActiveTranscoders);
 
         transcoderPool.setMaxSize(_numTranscoders);
+
+        ParameterUpdate("numTranscoders");
     }
 
     /*
@@ -141,6 +147,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         require(_numActiveTranscoders <= transcoderPool.getMaxSize());
 
         numActiveTranscoders = _numActiveTranscoders;
+
+        ParameterUpdate("numActiveTranscoders");
     }
 
     /*
@@ -153,7 +161,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         external
         whenSystemNotPaused
         currentRoundInitialized
-        returns (bool)
     {
         // Block reward cut must be a valid percentage
         require(_blockRewardCut <= PERC_DIVISOR);
@@ -165,6 +172,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         t.pendingFeeShare = _feeShare;
         t.pendingPricePerSegment = _pricePerSegment;
 
+        uint256 currentRound = roundsManager().currentRound();
         uint256 delegatedAmount = delegators[msg.sender].delegatedAmount;
 
         // Check if transcoder is not already registered
@@ -176,13 +184,15 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
                     // More stake than the last transcoder in the pool
                     // Kick out last transcoder pool
                     transcoderPool.remove(lastTranscoder);
+
+                    TranscoderEvicted(lastTranscoder, currentRound);
                 }
             }
 
             transcoderPool.insert(msg.sender, delegatedAmount, address(0), address(0));
         }
 
-        return true;
+        TranscoderUpdate(msg.sender, _blockRewardCut, _feeShare, _pricePerSegment, currentRound);
     }
 
     /*
@@ -192,7 +202,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         external
         whenSystemNotPaused
         currentRoundInitialized
-        returns (bool)
     {
         // Sender must be registered transcoder
         require(transcoderStatus(msg.sender) == TranscoderStatus.Registered);
@@ -206,7 +215,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         // Remove transcoder from pools
         transcoderPool.remove(msg.sender);
 
-        return true;
+        TranscoderResigned(msg.sender, currentRound);
     }
 
     /**
@@ -222,14 +231,15 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         whenSystemNotPaused
         currentRoundInitialized
         autoClaimTokenPoolsShares
-        returns (bool)
     {
         Delegator storage del = delegators[msg.sender];
+
+        uint256 currentRound = roundsManager().currentRound();
 
         if (delegatorStatus(msg.sender) == DelegatorStatus.Unbonded) {
             // New delegate
             // Set start round
-            del.startRound = roundsManager().currentRound().add(1);
+            del.startRound = currentRound.add(1);
         }
 
         // Amount to delegate
@@ -238,7 +248,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         if (del.delegateAddress != address(0) && _to != del.delegateAddress) {
             // Changing delegate
             // Set start round
-            del.startRound = roundsManager().currentRound().add(1);
+            del.startRound = currentRound.add(1);
             // Update amount to delegate with previous delegation amount
             delegationAmount = delegationAmount.add(del.bondedAmount);
             // Decrease old delegate's delegated amount
@@ -282,7 +292,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             }
         }
 
-        return true;
+        Bond(_to, msg.sender, currentRound);
     }
 
     /*
@@ -294,15 +304,16 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         whenSystemNotPaused
         currentRoundInitialized
         autoClaimTokenPoolsShares
-        returns (bool)
     {
         // Sender must be in bonded state
         require(delegatorStatus(msg.sender) == DelegatorStatus.Bonded);
 
         Delegator storage del = delegators[msg.sender];
 
+        uint256 currentRound = roundsManager().currentRound();
+
         // Transition to unbonding phase
-        del.withdrawRound = roundsManager().currentRound().add(unbondingPeriod);
+        del.withdrawRound = currentRound.add(unbondingPeriod);
         // Decrease delegate's delegated amount
         delegators[del.delegateAddress].delegatedAmount = delegators[del.delegateAddress].delegatedAmount.sub(del.bondedAmount);
         // Update total bonded tokens
@@ -314,12 +325,12 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             transcoderPool.updateKey(del.delegateAddress, transcoderPool.getKey(del.delegateAddress).sub(del.bondedAmount), address(0), address(0));
         }
 
+        Unbond(del.delegateAddress, msg.sender, currentRound);
+
         // Delegator no longer bonded to anyone
         del.delegateAddress = address(0);
         // Unbonding delegator does not have a start round
         del.startRound = 0;
-
-        return true;
     }
 
     /**
@@ -330,7 +341,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         whenSystemNotPaused
         currentRoundInitialized
         autoClaimTokenPoolsShares
-        returns (bool)
     {
         // Delegator must either have unbonded tokens or be in the unbonded state
         require(delegators[msg.sender].unbondedAmount > 0 || delegatorStatus(msg.sender) == DelegatorStatus.Unbonded);
@@ -351,14 +361,12 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         }
 
         minter().transferTokens(msg.sender, amount);
-
-        return true;
     }
 
     /*
      * @dev Set active transcoder set for the current round
      */
-    function setActiveTranscoders() external whenSystemNotPaused onlyRoundsManager returns (bool) {
+    function setActiveTranscoders() external whenSystemNotPaused onlyRoundsManager {
         uint256 currentRound = roundsManager().currentRound();
         uint256 activeSetSize = Math.min256(numActiveTranscoders, transcoderPool.getSize());
 
@@ -390,15 +398,13 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
         // Update total stake of all active transcoders
         activeTranscoderSet[currentRound].totalStake = totalStake;
-
-        return true;
     }
 
     /*
      * @dev Distribute the token rewards to transcoder and delegates.
      * Active transcoders call this once per cycle when it is their turn.
      */
-    function reward() external whenSystemNotPaused currentRoundInitialized returns (bool) {
+    function reward() external whenSystemNotPaused currentRoundInitialized {
         uint256 currentRound = roundsManager().currentRound();
 
         // Sender must be an active transcoder
@@ -415,7 +421,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
         updateTranscoderWithRewards(msg.sender, rewardTokens, currentRound);
 
-        return true;
+        Reward(msg.sender, rewardTokens, currentRound);
     }
 
     /*
@@ -431,7 +437,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         external
         whenSystemNotPaused
         onlyJobsManager
-        returns (bool)
     {
         // Transcoder must be registered
         require(transcoderStatus(_transcoder) == TranscoderStatus.Registered);
@@ -447,8 +452,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         if (unclaimableFees > 0) {
             minter().addToRedistributionPool(unclaimableFees);
         }
-
-        return true;
     }
 
     /*
@@ -467,31 +470,23 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         external
         whenSystemNotPaused
         onlyJobsManager
-        returns (bool)
     {
         // Transcoder must be valid
         require(transcoderStatus(_transcoder) == TranscoderStatus.Registered);
 
         uint256 penalty = delegators[_transcoder].bondedAmount.mul(_slashAmount).div(PERC_DIVISOR);
+        if (penalty > del.bondedAmount) {
+            penalty = del.bondedAmount;
+        }
 
         Delegator storage del = delegators[_transcoder];
 
-        if (penalty > del.bondedAmount) {
-            // Decrease delegate's delegated amount
-            delegators[del.delegateAddress].delegatedAmount = delegators[del.delegateAddress].delegatedAmount.sub(del.bondedAmount);
-            // Update total bonded tokens
-            totalBonded = totalBonded.sub(del.bondedAmount);
-            // Set transcoder's bond to 0 since
-            // the penalty is greater than its stake
-            del.bondedAmount = 0;
-        } else {
-            // Decrease delegate's delegated amount
-            delegators[del.delegateAddress].delegatedAmount = delegators[del.delegateAddress].delegatedAmount.sub(penalty);
-            // Update total bonded tokens
-            totalBonded = totalBonded.sub(penalty);
-            // Decrease transcoder's stake
-            del.bondedAmount = del.bondedAmount.sub(penalty);
-        }
+        // Decrease delegate's delegated amount
+        delegators[del.delegateAddress].delegatedAmount = delegators[del.delegateAddress].delegatedAmount.sub(penalty);
+        // Update total bonded tokens
+        totalBonded = totalBonded.sub(penalty);
+        // Decrease transcoder's stake
+        del.bondedAmount = del.bondedAmount.sub(penalty);
 
         uint256 currentRound = roundsManager().currentRound();
 
@@ -519,7 +514,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             minter().addToRedistributionPool(redistributedAmount);
         }
 
-        return true;
+        TranscoderSlashed(_transcoder, penalty, currentRound);
     }
 
     /*
@@ -573,10 +568,10 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * @dev Claim token pools shares for a delegator from its lastClaimTokenPoolsSharesRound through the end round
      * @param _endRound The last round for which to claim token pools shares for a delegator
      */
-    function claimTokenPoolsShares(uint256 _endRound) external returns (bool) {
+    function claimTokenPoolsShares(uint256 _endRound) external {
         require(delegators[msg.sender].lastClaimTokenPoolsSharesRound < _endRound);
 
-        return updateDelegatorWithTokenPoolsShares(msg.sender, _endRound);
+        updateDelegatorWithTokenPoolsShares(msg.sender, _endRound);
     }
 
     /*
@@ -791,7 +786,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * @param _rewards Amount of rewards
      * @param _round Round that transcoder is updated
      */
-    function updateTranscoderWithRewards(address _transcoder, uint256 _rewards, uint256 _round) internal returns (bool) {
+    function updateTranscoderWithRewards(address _transcoder, uint256 _rewards, uint256 _round) internal {
         Transcoder storage t = transcoders[_transcoder];
         Delegator storage del = delegators[_transcoder];
 
@@ -812,8 +807,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         if (unclaimableRewards > 0) {
             minter().addToRedistributionPool(unclaimableRewards);
         }
-
-        return true;
     }
 
     /*
@@ -821,7 +814,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * @param _delegator Delegator address
      * @param _endRound The last round for which to update a delegator's stake with token pools shares
      */
-    function updateDelegatorWithTokenPoolsShares(address _delegator, uint256 _endRound) internal returns (bool) {
+    function updateDelegatorWithTokenPoolsShares(address _delegator, uint256 _endRound) internal {
         Delegator storage del = delegators[_delegator];
 
         uint256 currentBondedAmount = del.bondedAmount;
@@ -847,8 +840,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         del.unbondedAmount = currentUnbondedAmount;
 
         del.lastClaimTokenPoolsSharesRound = _endRound;
-
-        return true;
     }
 
     /*

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -6,10 +6,18 @@ pragma solidity ^0.4.17;
  * TODO: switch to interface type
  */
 contract IBondingManager {
+    event TranscoderUpdate(address transcoder, uint256 pendingBlockRewardCut, uint256 pendingFeeShare, uint256 pendingPricePerSegment, uint256 round);
+    event TranscoderEvicted(address transcoder, uint256 round);
+    event TranscoderResigned(address transcoder, uint256 round);
+    event TranscoderSlashed(address transcoder, uint256 penalty, uint256 round);
+    event Reward(address transcoder, uint256 amount, uint256 round);
+    event Bond(address indexed delegate, address indexed delegator, uint256 round);
+    event Unbond(address indexed delegate, address indexed delegator, uint256 round);
+
     // External functions
-    function setActiveTranscoders() external returns (bool);
-    function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external returns (bool);
-    function slashTranscoder(address _transcoder, address _finder, uint256 _slashAmount, uint256 _finderFee) external returns (bool);
+    function setActiveTranscoders() external;
+    function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external;
+    function slashTranscoder(address _transcoder, address _finder, uint256 _slashAmount, uint256 _finderFee) external;
     function electActiveTranscoder(uint256 _maxPricePerSegment, uint256 _block, uint256 _round) external view returns (address);
 
     // Public functions

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -6,13 +6,14 @@ pragma solidity ^0.4.17;
  * TODO: switch to interface type
  */
 contract IBondingManager {
-    event TranscoderUpdate(address transcoder, uint256 pendingBlockRewardCut, uint256 pendingFeeShare, uint256 pendingPricePerSegment, uint256 round);
-    event TranscoderEvicted(address transcoder, uint256 round);
-    event TranscoderResigned(address transcoder, uint256 round);
-    event TranscoderSlashed(address transcoder, uint256 penalty, uint256 round);
-    event Reward(address transcoder, uint256 amount, uint256 round);
-    event Bond(address indexed delegate, address indexed delegator, uint256 round);
-    event Unbond(address indexed delegate, address indexed delegator, uint256 round);
+    event TranscoderUpdate(address indexed transcoder, uint256 pendingBlockRewardCut, uint256 pendingFeeShare, uint256 pendingPricePerSegment);
+    event TranscoderEvicted(address indexed transcoder);
+    event TranscoderResigned(address indexed transcoder);
+    event TranscoderSlashed(address indexed transcoder, uint256 penalty);
+    event Reward(address indexed transcoder, uint256 amount);
+    event Bond(address indexed delegate, address indexed delegator);
+    event Unbond(address indexed delegate, address indexed delegator);
+    event Withdraw(address indexed delegator);
 
     // External functions
     function setActiveTranscoders() external;

--- a/contracts/bonding/libraries/TokenPools.sol
+++ b/contracts/bonding/libraries/TokenPools.sol
@@ -18,12 +18,10 @@ library TokenPools {
         uint256 transcoderFeeShare;        // Fee share for the fee pool
     }
 
-    function init(TokenPools.Data storage tokenPools, uint256 _stake, uint256 _blockRewardCut, uint256 _feeShare) internal returns (bool) {
+    function init(TokenPools.Data storage tokenPools, uint256 _stake, uint256 _blockRewardCut, uint256 _feeShare) internal {
         tokenPools.totalStake = _stake;
         tokenPools.transcoderBlockRewardCut = _blockRewardCut;
         tokenPools.transcoderFeeShare = _feeShare;
-
-        return true;
     }
 
     function unclaimableFees(TokenPools.Data storage tokenPools, uint256 _fees) internal view returns (uint256) {

--- a/contracts/jobs/IJobsManager.sol
+++ b/contracts/jobs/IJobsManager.sol
@@ -6,9 +6,12 @@ pragma solidity ^0.4.17;
  * TODO: switch to interface type
  */
 contract IJobsManager {
+    event Deposit(address indexed broadcaster, uint256 amount);
+    event Withdraw(address indexed broadcaster);
     event NewJob(address indexed broadcaster, uint256 jobId, string streamId, string transcodingOptions, uint256 maxPricePerSegment, uint256 creationBlock);
     event NewClaim(address indexed transcoder, uint256 indexed jobId, uint256 claimId);
     event Verify(address indexed transcoder, uint256 indexed jobId, uint256 indexed claimId, uint256 segmentNumber);
-    event DistributeFees(address indexed transcoder, uint256 indexed jobId, uint256 indexed claimid, uint256 fees);
-    event ReceivedVerification(uint256 indexed jobId, uint256 indexed claimId, uint256 segmentNumber, bool result);
+    event DistributeFees(address indexed transcoder, uint256 indexed jobId, uint256 indexed claimId, uint256 fees);
+    event PassedVerification(address indexed transcoder, uint256 indexed jobId, uint256 indexed claimId, uint256 segmentNumber);
+    event FailedVerification(address indexed transcoder, uint256 indexed jobId, uint256 indexed claimId, uint256 segmentNumber);
 }

--- a/contracts/jobs/IJobsManager.sol
+++ b/contracts/jobs/IJobsManager.sol
@@ -6,5 +6,9 @@ pragma solidity ^0.4.17;
  * TODO: switch to interface type
  */
 contract IJobsManager {
-    // External functions
+    event NewJob(address indexed broadcaster, uint256 jobId, string streamId, string transcodingOptions, uint256 maxPricePerSegment, uint256 creationBlock);
+    event NewClaim(address indexed transcoder, uint256 indexed jobId, uint256 claimId);
+    event Verify(address indexed transcoder, uint256 indexed jobId, uint256 indexed claimId, uint256 segmentNumber);
+    event DistributeFees(address indexed transcoder, uint256 indexed jobId, uint256 indexed claimid, uint256 fees);
+    event ReceivedVerification(uint256 indexed jobId, uint256 indexed claimId, uint256 segmentNumber, bool result);
 }

--- a/contracts/rounds/IRoundsManager.sol
+++ b/contracts/rounds/IRoundsManager.sol
@@ -5,11 +5,13 @@ pragma solidity ^0.4.17;
  * @title Interface for RoundsManager
  */
 contract IRoundsManager {
+    event NewRound(uint256 round);
+
     // External functions
-    function initializeRound() external returns (bool);
+    function initializeRound() external;
 
     // Public functions
-    function currentRound() public constant returns (uint256);
-    function currentRoundStartBlock() public constant returns (uint256);
-    function currentRoundInitialized() public constant returns (bool);
+    function currentRound() public view returns (uint256);
+    function currentRoundStartBlock() public view returns (uint256);
+    function currentRoundInitialized() public view returns (bool);
 }

--- a/contracts/test/BondingManagerMock.sol
+++ b/contracts/test/BondingManagerMock.sol
@@ -48,21 +48,15 @@ contract BondingManagerMock is IBondingManager {
         minter.createReward(activeStake, totalActiveStake);
     }
 
-    function setActiveTranscoders() external returns (bool) {
-        return true;
-    }
+    function setActiveTranscoders() external {}
 
-    function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external returns (bool) {
-        return true;
-    }
+    function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external {}
 
     function callAddToRedistributionPool(uint256 _amount) external {
         minter.addToRedistributionPool(_amount);
     }
 
-    function slashTranscoder(address _transcoder, address _finder, uint256 _slashAmount, uint256 _finderFee) external returns (bool) {
-        return true;
-    }
+    function slashTranscoder(address _transcoder, address _finder, uint256 _slashAmount, uint256 _finderFee) external {}
 
     function electActiveTranscoder(uint256 _maxPricePerSegment, uint256 _block, uint256 _round) external view returns (address) {
         return transcoder;

--- a/contracts/test/JobsManagerMock.sol
+++ b/contracts/test/JobsManagerMock.sol
@@ -31,11 +31,11 @@ contract JobsManagerMock is IJobsManager {
         minter = IMinter(_minter);
     }
 
-    function setBondingManager(address _bondingManager) {
+    function setBondingManager(address _bondingManager) external {
         bondingManager = IBondingManager(_bondingManager);
     }
 
-    function setVerifier(address _verifier) {
+    function setVerifier(address _verifier) external {
         verifier = IVerifier(_verifier);
     }
 
@@ -82,11 +82,11 @@ contract JobsManagerMock is IJobsManager {
         withdrawAmount = _amount;
     }
 
-    function distributeFees() public returns (bool) {
+    function distributeFees() external {
         return bondingManager.updateTranscoderWithFees(transcoder, fees, round);
     }
 
-    function missedVerificationSlash() public returns (bool) {
+    function missedVerificationSlash() external {
         return bondingManager.slashTranscoder(transcoder, finder, slashAmount, finderFee);
     }
 
@@ -98,7 +98,5 @@ contract JobsManagerMock is IJobsManager {
         verifier.verify.value(msg.value)(jobId, claimId, segmentNumber, transcodingOptions, dataStorageHash, dataHashes);
     }
 
-    function receiveVerification(uint256 _jobId, uint256 _claimId, uint256 _segmentNumber, bool _result) external returns (bool) {
-        return true;
-    }
+    function receiveVerification(uint256 _jobId, uint256 _claimId, uint256 _segmentNumber, bool _result) external {}
 }

--- a/contracts/test/ManagerProxyTargetMockV1.sol
+++ b/contracts/test/ManagerProxyTargetMockV1.sol
@@ -16,7 +16,7 @@ contract ManagerProxyTargetMockV1 is ManagerProxyTarget {
     uint256 public tupleValue2;
     bytes32 public tupleValue3;
 
-    function ManagerProxyTargetMockV1(address _controller) Manager(_controller) {}
+    function ManagerProxyTargetMockV1(address _controller) public Manager(_controller) {}
 
     function setUint8(uint8 _value) external {
         uint8Value = _value;

--- a/contracts/test/ManagerProxyTargetMockV2.sol
+++ b/contracts/test/ManagerProxyTargetMockV2.sol
@@ -11,7 +11,7 @@ contract ManagerProxyTargetMockV2 is ManagerProxyTarget {
     bytes32 public bytes32Value;
     address public addressValue;
 
-    function ManagerProxyTargetMockV2(address _controller) Manager(_controller) {}
+    function ManagerProxyTargetMockV2(address _controller) public Manager(_controller) {}
 
     function setUint8(uint8 _value) external {
         uint8Value = _value + 5;

--- a/contracts/test/ManagerProxyTargetMockV3.sol
+++ b/contracts/test/ManagerProxyTargetMockV3.sol
@@ -12,7 +12,7 @@ contract ManagerProxyTargetMockV3 is ManagerProxyTarget {
     address public addressValue;
     mapping (uint256 => uint256) public kvMap;
 
-    function ManagerProxyTargetMockV3(address _controller) Manager(_controller) {}
+    function ManagerProxyTargetMockV3(address _controller) public Manager(_controller) {}
 
     function setUint8(uint8 _value) external {
         uint8Value = _value;

--- a/contracts/test/MinterMock.sol
+++ b/contracts/test/MinterMock.sol
@@ -14,15 +14,9 @@ contract MinterMock is IMinter {
         return reward;
     }
 
-    function transferTokens(address _to, uint256 _amount) external returns (bool) {
-        return true;
-    }
+    function transferTokens(address _to, uint256 _amount) external {}
 
-    function addToRedistributionPool(uint256 _amount) external returns (bool) {
-        return true;
-    }
+    function addToRedistributionPool(uint256 _amount) external {}
 
-    function setCurrentRewardTokens() external returns (bool) {
-        return true;
-    }
+    function setCurrentRewardTokens() external {}
 }

--- a/contracts/test/RoundsManagerMock.sol
+++ b/contracts/test/RoundsManagerMock.sol
@@ -29,8 +29,8 @@ contract RoundsManagerMock is IRoundsManager {
         currentRoundInitialized = _initialized;
     }
 
-    function initializeRound() external returns (bool) {
-        return bondingManager.setActiveTranscoders();
+    function initializeRound() external {
+        bondingManager.setActiveTranscoders();
     }
 
     function callSetCurrentRewardTokens() external {

--- a/contracts/test/VerifiableMock.sol
+++ b/contracts/test/VerifiableMock.sol
@@ -4,8 +4,7 @@ import "../verification/IVerifiable.sol";
 
 
 contract VerifiableMock is IVerifiable {
-    function receiveVerification(uint256 _jobId, uint256 _segmentSequenceNumber, bool _result) external returns (bool) {
+    function receiveVerification(uint256 _jobId, uint256 _segmentSequenceNumber, bool _result) external {
         // Stubbed for tests
-        return true;
     }
 }

--- a/contracts/test/VerifierMock.sol
+++ b/contracts/test/VerifierMock.sol
@@ -43,10 +43,7 @@ contract VerifierMock is IVerifier {
     )
         external
         payable
-        returns (bool)
-    {
-        return true;
-    }
+    {}
 
     function getPrice() public view returns (uint256) {
         return price;

--- a/contracts/token/IMinter.sol
+++ b/contracts/token/IMinter.sol
@@ -2,8 +2,8 @@ pragma solidity ^0.4.17;
 
 
 contract IMinter {
-    event NewInflation(uint256 inflation, uint256 round);
-    event SetCurrentRewardTokens(uint256 mintableTokens, uint256 redistributableTokens, uint256 round);
+    event NewInflation(uint256 inflation);
+    event SetCurrentRewardTokens(uint256 mintableTokens, uint256 redistributableTokens);
 
     function createReward(uint256 _fracNum, uint256 _fracDenom) external returns (uint256);
     function transferTokens(address _to, uint256 _amount) external;

--- a/contracts/token/IMinter.sol
+++ b/contracts/token/IMinter.sol
@@ -2,8 +2,11 @@ pragma solidity ^0.4.17;
 
 
 contract IMinter {
+    event NewInflation(uint256 inflation, uint256 round);
+    event SetCurrentRewardTokens(uint256 mintableTokens, uint256 redistributableTokens, uint256 round);
+
     function createReward(uint256 _fracNum, uint256 _fracDenom) external returns (uint256);
-    function transferTokens(address _to, uint256 _amount) external returns (bool);
-    function addToRedistributionPool(uint256 _amount) external returns (bool);
-    function setCurrentRewardTokens() external returns (bool);
+    function transferTokens(address _to, uint256 _amount) external;
+    function addToRedistributionPool(uint256 _amount) external;
+    function setCurrentRewardTokens() external;
 }

--- a/contracts/token/LivepeerToken.sol
+++ b/contracts/token/LivepeerToken.sol
@@ -5,17 +5,8 @@ import "zeppelin-solidity/contracts/token/MintableToken.sol";
 
 // Livepeer Token
 contract LivepeerToken is MintableToken {
-
     string public name = "Livepeer Token";
     uint8 public decimals = 18;
     string public symbol = "LPT";
     string public version = "0.1";
-
-    function LivepeerToken() {}
-
-    /* Don't accept random ETH sent to this contract */
-    function () {
-        revert();
-    }
-
 }

--- a/contracts/token/LivepeerTokenFaucet.sol
+++ b/contracts/token/LivepeerTokenFaucet.sol
@@ -48,26 +48,22 @@ contract LivepeerTokenFaucet is Ownable {
      * @dev Add an address to the whitelist
      * @param _addr Address to be whitelisted
      */
-    function addToWhitelist(address _addr) external onlyOwner returns (bool) {
+    function addToWhitelist(address _addr) external onlyOwner {
         isWhitelisted[_addr] = true;
-
-        return true;
     }
 
     /*
      * @dev Remove an address from the whitelist
      * @param _addr Address to be removed from whitelist
      */
-    function removeFromWhitelist(address _addr) external onlyOwner returns (bool) {
+    function removeFromWhitelist(address _addr) external onlyOwner {
         isWhitelisted[_addr] = false;
-
-        return true;
     }
 
     /*
      * @dev Request an amount of token to be sent to sender
      */
-    function request() external validRequest returns (bool) {
+    function request() external validRequest {
         if (!isWhitelisted[msg.sender]) {
             nextValidRequest[msg.sender] = block.timestamp + requestWait * 1 hours;
         }
@@ -75,7 +71,5 @@ contract LivepeerTokenFaucet is Ownable {
         token.transfer(msg.sender, requestAmount);
 
         Request(msg.sender, requestAmount);
-
-        return true;
     }
 }

--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -119,7 +119,7 @@ contract Minter is Manager, IMinter {
         currentRedistributableTokens = redistributableTokensPerRound();
         currentRedistributedTokens = 0;
 
-        SetCurrentRewardTokens(currentMintableTokens, currentRedistributableTokens, roundsManager().currentRound());
+        SetCurrentRewardTokens(currentMintableTokens, currentRedistributableTokens);
     }
 
     /*
@@ -140,7 +140,7 @@ contract Minter is Manager, IMinter {
             }
         }
 
-        NewInflation(inflation, roundsManager().currentRound());
+        NewInflation(inflation);
     }
 
     /*

--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -68,6 +68,8 @@ contract Minter is Manager, IMinter {
         require(_targetBondingRate <= PERC_DIVISOR);
 
         targetBondingRate = _targetBondingRate;
+
+        ParameterUpdate("targetBondingRate");
     }
 
     /*
@@ -102,14 +104,14 @@ contract Minter is Manager, IMinter {
      * @param _to Recipient address
      * @param _amount Amount of tokens
      */
-    function transferTokens(address _to, uint256 _amount) external onlyBondingManagerOrJobsManager whenSystemNotPaused returns (bool) {
-        return livepeerToken().transfer(_to, _amount);
+    function transferTokens(address _to, uint256 _amount) external onlyBondingManagerOrJobsManager whenSystemNotPaused {
+        livepeerToken().transfer(_to, _amount);
     }
 
     /*
      * @dev Set the reward token amounts for the round. Only callable by the RoundsManager
      */
-    function setCurrentRewardTokens() external onlyRoundsManager whenSystemNotPaused returns (bool) {
+    function setCurrentRewardTokens() external onlyRoundsManager whenSystemNotPaused {
         setInflation();
 
         currentMintableTokens = mintedTokensPerRound();
@@ -117,7 +119,7 @@ contract Minter is Manager, IMinter {
         currentRedistributableTokens = redistributableTokensPerRound();
         currentRedistributedTokens = 0;
 
-        return true;
+        SetCurrentRewardTokens(currentMintableTokens, currentRedistributableTokens, roundsManager().currentRound());
     }
 
     /*
@@ -137,16 +139,16 @@ contract Minter is Manager, IMinter {
                 inflation -= inflationChange;
             }
         }
+
+        NewInflation(inflation, roundsManager().currentRound());
     }
 
     /*
      * @dev Add funds to the redistribution pool
      * @param _amount Amount of funds to add to the redistribution pool
      */
-    function addToRedistributionPool(uint256 _amount) external onlyBondingManager whenSystemNotPaused returns (bool) {
+    function addToRedistributionPool(uint256 _amount) external onlyBondingManager whenSystemNotPaused {
         redistributionPool = redistributionPool.add(_amount);
-
-        return true;
     }
 
     /*

--- a/contracts/verification/IVerifiable.sol
+++ b/contracts/verification/IVerifiable.sol
@@ -12,5 +12,5 @@ contract IVerifiable {
         uint256 _claimId,
         uint256 _segmentNumber,
         bool _result
-    ) external returns (bool);
+    ) external;
 }

--- a/contracts/verification/IVerifier.sol
+++ b/contracts/verification/IVerifier.sol
@@ -12,7 +12,7 @@ contract IVerifier {
         string _transcodingOptions,
         string _dataStorageHash,
         bytes32[2] _dataHashes
-    ) external payable returns (bool);
+    ) external payable;
 
     function getPrice() public view returns (uint256);
 }

--- a/contracts/verification/IdentityVerifier.sol
+++ b/contracts/verification/IdentityVerifier.sol
@@ -36,13 +36,10 @@ contract IdentityVerifier is Manager, IVerifier {
         onlyJobsManager
         whenSystemNotPaused
         payable
-        returns (bool)
     {
         // Check if receiveVerification on callback contract succeeded
         IVerifiable verifiableContract = IVerifiable(msg.sender);
         verifiableContract.receiveVerification(_jobId, _claimId, _segmentNumber, true);
-
-        return true;
     }
 
     /*

--- a/contracts/verification/LivepeerVerifier.sol
+++ b/contracts/verification/LivepeerVerifier.sol
@@ -38,7 +38,7 @@ contract LivepeerVerifier is Manager, IVerifier {
         _;
     }
 
-    function LivepeerVerifier(address _controller, address[] _solvers, string _verificationCodeHash) Manager(_controller) {
+    function LivepeerVerifier(address _controller, address[] _solvers, string _verificationCodeHash) public Manager(_controller) {
         // Set solvers
         for (uint256 i = 0; i < _solvers.length; i++) {
             // Address must not already be a solver and must not be a null address
@@ -70,7 +70,6 @@ contract LivepeerVerifier is Manager, IVerifier {
         payable
         onlyJobsManager
         whenSystemNotPaused
-        returns (bool)
     {
         // Store request parameters
         requests[requestCount].jobId = _jobId;
@@ -82,8 +81,6 @@ contract LivepeerVerifier is Manager, IVerifier {
 
         // Update request count
         requestCount++;
-
-        return true;
     }
 
     /*
@@ -91,7 +88,7 @@ contract LivepeerVerifier is Manager, IVerifier {
      * @param _requestId Request identifier
      * @param _result Result of verification computation - keccak256 hash of transcoded segment data
      */
-    function __callback(uint256 _requestId, bytes32 _result) external onlySolvers whenSystemNotPaused returns (bool) {
+    function __callback(uint256 _requestId, bytes32 _result) external onlySolvers whenSystemNotPaused {
         Request memory q = requests[_requestId];
 
         // Check if transcoded data hash returned by solver matches originally submitted transcoded data hash
@@ -105,8 +102,6 @@ contract LivepeerVerifier is Manager, IVerifier {
 
         // Remove request
         delete requests[_requestId];
-
-        return true;
     }
 
     /*

--- a/contracts/verification/OraclizeVerifier.sol
+++ b/contracts/verification/OraclizeVerifier.sol
@@ -86,7 +86,6 @@ contract OraclizeVerifier is Manager, usingOraclize, IVerifier {
         onlyJobsManager
         whenSystemNotPaused
         sufficientPayment
-        returns (bool)
     {
         // Create Oraclize query
         string memory codeHashQuery = strConcat("binary(", verificationCodeHash, ").unhexlify()");
@@ -97,8 +96,6 @@ contract OraclizeVerifier is Manager, usingOraclize, IVerifier {
         oraclizeQueries[queryId].claimId = _claimId;
         oraclizeQueries[queryId].segmentNumber = _segmentNumber;
         oraclizeQueries[queryId].commitHash = keccak256(_dataHashes[0], _dataHashes[1]);
-
-        return true;
     }
 
     /*


### PR DESCRIPTION
- Added more events that I thought might be useful for a client interacting with the contracts
- Removed unnecessary bool returns values for state mutating functions. Since our convention is to fail hard and fail early by reverting transactions upon any type of error, bool return values are never useful. There are some cases that a bool return value might be useful even if we're reverting, but I don't believe there are any cases of that in our code right now.
- Removed the constructor and fallback function from LivepeerToken because they shouldn't be needed - no ETH can be sent to the contract if the fallback function is not payable and the fallback function is non-payable by default

Current list of events (excluding LivepeerVerifier and LivepeerToken):

ParameterUpdate
SetContract
SetController
TranscoderUpdate
TranscoderEvicted
TranscoderResigned
Bond
Unbond
Reward
NewRound
NewJob
NewClaim
Verify
DistributeFees
ReceivedVerification
NewInflation
SetCurrentRewardTokens

Let me know if there are any additional events in particular that anyone thinks might be particularly helpful. Maybe @jozanza has some thoughts relevant for the SDK?

Closes #31 