### PR TITLE
Add a lock period during a round s.t. transcoders cannot change rates

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -162,6 +162,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         whenSystemNotPaused
         currentRoundInitialized
     {
+        // Only callable if current round is not locked
+        require(!roundsManager().currentRoundLocked());
         // Block reward cut must be a valid percentage
         require(_blockRewardCut <= PERC_DIVISOR);
         // Fee share must be a valid percentage

--- a/contracts/rounds/IRoundsManager.sol
+++ b/contracts/rounds/IRoundsManager.sol
@@ -14,4 +14,5 @@ contract IRoundsManager {
     function currentRound() public view returns (uint256);
     function currentRoundStartBlock() public view returns (uint256);
     function currentRoundInitialized() public view returns (bool);
+    function currentRoundLocked() public view returns (bool);
 }

--- a/contracts/rounds/RoundsManager.sol
+++ b/contracts/rounds/RoundsManager.sol
@@ -15,6 +15,8 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
     uint256 public roundLength;
 
     // Lock period of a round as a % of round length
+    // Transcoders cannot join the transcoder pool or change their rates during the lock period at the end of a round
+    // The lock period provides delegators time to review transcoder information without changes
     // # of blocks in the lock period = (roundLength * roundLockAmount) / PERC_DIVISOR
     uint256 public roundLockAmount;
 

--- a/contracts/test/RoundsManagerMock.sol
+++ b/contracts/test/RoundsManagerMock.sol
@@ -12,6 +12,7 @@ contract RoundsManagerMock is IRoundsManager {
     uint256 public currentRound;
     uint256 public currentRoundStartBlock;
     bool public currentRoundInitialized;
+    bool public currentRoundLocked;
 
     function setBondingManager(address _bondingManager) external {
         bondingManager = IBondingManager(_bondingManager);
@@ -23,6 +24,10 @@ contract RoundsManagerMock is IRoundsManager {
 
     function setCurrentRound(uint256 _round) external {
         currentRound = _round;
+    }
+
+    function setCurrentRoundLocked(bool _locked) external {
+        currentRoundLocked = _locked;
     }
 
     function setCurrentRoundInitialized(bool _initialized) external {
@@ -47,5 +52,9 @@ contract RoundsManagerMock is IRoundsManager {
 
     function currentRoundInitialized() public view returns (bool) {
         return currentRoundInitialized;
+    }
+
+    function currentRoundLocked() public view returns (bool) {
+        return currentRoundLocked;
     }
 }

--- a/migrations/3_deploy_contracts.js
+++ b/migrations/3_deploy_contracts.js
@@ -91,7 +91,7 @@ module.exports = function(deployer, network) {
             config.jobsManager.doubleClaimSegmentSlashAmount,
             config.jobsManager.finderFee
         )
-        await roundsManager.setParameters(config.roundsManager.roundLength)
+        await roundsManager.setParameters(config.roundsManager.roundLength, config.roundsManager.roundLockAmount)
 
         deployer.logger.log("Transferring ownership of the LivepeerToken to the Minter...")
 

--- a/migrations/migrations.config.js
+++ b/migrations/migrations.config.js
@@ -20,7 +20,8 @@ module.exports = {
         finderFee: 4 * PERC_MULTIPLIER
     },
     roundsManager: {
-        roundLength: 50
+        roundLength: 50,
+        roundLockAmount: 100000
     },
     faucet: {
         faucetAmount: new BigNumber(1000000000000000000000).mul(TOKEN_UNIT),

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -52,6 +52,11 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setCurrentRoundInitialized(true)
         })
 
+        it("should fail if the current round is locked", async () => {
+            await fixture.roundsManager.setCurrentRoundLocked(true)
+            await expectThrow(bondingManager.transcoder(blockRewardCut, feeShare, pricePerSegment), {from: tAddr})
+        })
+
         it("should fail with zero delegated amount", async () => {
             await expectThrow(bondingManager.transcoder(blockRewardCut, feeShare, pricePerSegment), {from: tAddr})
         })


### PR DESCRIPTION
Added a lock period during a round during which transcoders cannot join the transcoder pool or change their rates. The lock period is calculated as a percentage of the round length.

Closes #62 