### PR TITLE
Compute percentage points first when computing reward

### DIFF
--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -78,8 +78,10 @@ contract Minter is Manager, IMinter {
      * @param _fracDenom Denominator of fraction (total active stake)
      */
     function createReward(uint256 _fracNum, uint256 _fracDenom) external onlyBondingManager whenSystemNotPaused returns (uint256) {
+        uint256 percPoints = _fracNum.mul(PERC_DIVISOR).div(_fracDenom);
+
         // Compute fraction of redistributable tokens to include in reward
-        uint256 redistributeAmount = currentRedistributableTokens.mul(_fracNum).div(_fracDenom);
+        uint256 redistributeAmount = currentRedistributableTokens.mul(percPoints).div(PERC_DIVISOR);
         // Update amount of redistributed tokens for round
         currentRedistributedTokens = currentRedistributedTokens.add(redistributeAmount);
         redistributionPool = redistributionPool.sub(redistributeAmount);
@@ -87,7 +89,7 @@ contract Minter is Manager, IMinter {
         require(currentRedistributedTokens <= currentRedistributableTokens);
 
         // Compute and mint fraction of mintable tokens to include in reward
-        uint256 mintAmount = currentMintableTokens.mul(_fracNum).div(_fracDenom);
+        uint256 mintAmount = currentMintableTokens.mul(percPoints).div(PERC_DIVISOR);
         // Update amount of minted tokens for round
         currentMintedTokens = currentMintedTokens.add(mintAmount);
         // Minted tokens must not exceed mintable tokens


### PR DESCRIPTION
Currently, in `minter.createReward`, we calculate the mintable reward portion as `(mintableAmount * fracNum) / fracDenom)`. In the extreme case, both `mintableAmount` and `fracNum` can be very large (an example being when there is a single transcoder that is capturing all of the inflationary rewards for a few rounds leading to both a large `mintableAmount` and `fracNum`). In this case, it is possible for `mintableAmount * fracNum` to overflow.

As a proposed fix, `minter.createReward` can instead compute the percentage points represented by `fracNum` and `fracDenom` as `(fracNum * PERC_DIVISOR) / fracDenom)`. Since `PERC_DIVISOR` is known to be a constant 10^6, the risk of overflow when computing `fracNum * PERC_DIVISOR)` is less than the risk of overflow when computing `mintableAmount * fracNum` since both values here are unbounded. 

We then compute the mintable reward portion as `(mintableAmount * percPoints) / PERC_DIVISOR)`. `percPoints` is also bounded in magnitude by the magnitude of `PERC_DIVISOR`.

This doesn't completely eliminate the risk of overflow because if `fracNum` ever gets very very large (it is the delegated stake of a transcoder) it can still overflow when multiplied by `PERC_DIVISOR`. This fix just mitigates the risk somewhat.