### PR TITLE
Remove redistribution pool. Track claimable stake for token pools

### DIFF
--- a/contracts/Manager.sol
+++ b/contracts/Manager.sol
@@ -8,9 +8,6 @@ contract Manager is IManager {
     // Controller that contract is registered with
     IController public controller;
 
-    // Divisor used for representing percentages
-    uint256 public constant PERC_DIVISOR = 1000000;
-
     // Check if sender is controller
     modifier onlyController() {
         require(msg.sender == address(controller));

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -499,9 +499,18 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
         // Award finder fee
         if (penalty > 0 && _finder != address(0)) {
-            // Award finder fee
-            uint256 finderAmount = penalty.mul(_finderFee).div(PERC_DIVISOR);
-            minter().transferTokens(_finder, finderAmount);
+            uint256 burnAmount = penalty;
+
+            if (_finder != address(0)) {
+                // Award finder fee
+                uint256 finderAmount = penalty.mul(_finderFee).div(PERC_DIVISOR);
+                minter().transferTokens(_finder, finderAmount);
+
+                burnAmount = burnAmount.sub(finderAmount);
+            }
+
+            // Minter burns the remaining slashed funds
+            minter().burnTokens(burnAmount);
         }
 
         TranscoderSlashed(_transcoder, penalty);

--- a/contracts/bonding/libraries/TokenPools.sol
+++ b/contracts/bonding/libraries/TokenPools.sol
@@ -57,7 +57,11 @@ library TokenPools {
 
         if (tokenPools.claimableStake > 0) {
             transcoderFees = tokenPools.feePool.mul(PERC_DIVISOR.sub(tokenPools.transcoderFeeShare)).div(PERC_DIVISOR);
-            delegatorFees = tokenPools.feePool.sub(transcoderFees).mul(_stake).div(tokenPools.claimableStake);
+
+            // Compute delegator's claimable stake percentage
+            uint256 percPoints = _stake.mul(PERC_DIVISOR).div(tokenPools.claimableStake);
+            // Compute delegator's fees according to claimable stake percentage
+            delegatorFees = tokenPools.feePool.sub(transcoderFees).mul(percPoints).div(PERC_DIVISOR);
         }
 
         if (_isTranscoder) {
@@ -73,7 +77,11 @@ library TokenPools {
 
         if (tokenPools.claimableStake > 0) {
             transcoderRewards = tokenPools.rewardPool.mul(tokenPools.transcoderBlockRewardCut).div(PERC_DIVISOR);
-            delegatorRewards = tokenPools.rewardPool.sub(transcoderRewards).mul(_stake).div(tokenPools.claimableStake);
+
+            // Compute delegator's claimable stake percentage
+            uint256 percPoints = _stake.mul(PERC_DIVISOR).div(tokenPools.claimableStake);
+            // Compute delegator's rewards according to claimable stake percentage
+            delegatorRewards = tokenPools.rewardPool.sub(transcoderRewards).mul(percPoints).div(PERC_DIVISOR);
         }
 
         if (_isTranscoder) {

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -9,6 +9,7 @@ import "../bonding/IBondingManager.sol";
 import "../rounds/IRoundsManager.sol";
 import "../verification/IVerifiable.sol";
 import "../verification/IVerifier.sol";
+import "../libraries/MathUtils.sol";
 
 import "zeppelin-solidity/contracts/math/SafeMath.sol";
 
@@ -187,7 +188,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
      */
     function setFailedVerificationSlashAmount(uint256 _failedVerificationSlashAmount) external onlyControllerOwner {
         // Must be a valid percentage
-        require(_failedVerificationSlashAmount <= PERC_DIVISOR);
+        require(MathUtils.validPerc(_failedVerificationSlashAmount));
 
         failedVerificationSlashAmount = _failedVerificationSlashAmount;
 
@@ -200,7 +201,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
      */
     function setMissedVerificationSlashAmount(uint256 _missedVerificationSlashAmount) external onlyControllerOwner {
         // Must be a valid percentage
-        require(_missedVerificationSlashAmount <= PERC_DIVISOR);
+        require(MathUtils.validPerc(_missedVerificationSlashAmount));
 
         missedVerificationSlashAmount = _missedVerificationSlashAmount;
 
@@ -213,7 +214,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
      */
     function setDoubleClaimSegmentSlashAmount(uint256 _doubleClaimSegmentSlashAmount) external onlyControllerOwner {
         // Must be a valid percentage
-        require(_doubleClaimSegmentSlashAmount <= PERC_DIVISOR);
+        require(MathUtils.validPerc(_doubleClaimSegmentSlashAmount));
 
         doubleClaimSegmentSlashAmount = _doubleClaimSegmentSlashAmount;
 
@@ -226,7 +227,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
      */
     function setFinderFee(uint256 _finderFee) external onlyControllerOwner {
         // Must be a valid percentage
-        require(_finderFee <= PERC_DIVISOR);
+        require(MathUtils.validPerc(_finderFee));
 
         finderFee = _finderFee;
     }

--- a/contracts/libraries/MathUtils.sol
+++ b/contracts/libraries/MathUtils.sol
@@ -1,0 +1,47 @@
+pragma solidity ^0.4.17;
+
+import "zeppelin-solidity/contracts/math/SafeMath.sol";
+
+
+library MathUtils {
+    using SafeMath for uint256;
+
+    // Divisor used for representing percentages
+    uint256 public constant PERC_DIVISOR = 1000000;
+
+    /*
+     * @dev Returns whether an amount is a valid percentage out of PERC_DIVISOR
+     * @param _amount Amount that is supposed to be a percentage
+     */
+    function validPerc(uint256 _amount) internal view returns (bool) {
+        return _amount <= PERC_DIVISOR;
+    }
+
+    /*
+     * @dev Compute percentage of a value with the percentage represented by a fraction
+     * @param _amount Amount to take the percentage of
+     * @param _fracNum Numerator of fraction representing the percentage
+     * @param _fracDenom Denominator of fraction representing the percentage
+     */
+    function percOf(uint256 _amount, uint256 _fracNum, uint256 _fracDenom) internal view returns (uint256) {
+        return _amount.mul(percPoints(_fracNum, _fracDenom)).div(PERC_DIVISOR);
+    }
+
+    /*
+     * @dev Compute percentage of a value with the percentage represented by a fraction over PERC_DIVISOR
+     * @param _amount Amount to take the percentage of
+     * @param _fracNum Numerator of fraction representing the percentage with PERC_DIVISOR as the denominator
+     */
+    function percOf(uint256 _amount, uint256 _fracNum) internal view returns (uint256) {
+        return _amount.mul(_fracNum).div(PERC_DIVISOR);
+    }
+
+    /*
+     * @dev Compute percentage representation of a fraction
+     * @param _fracNum Numerator of fraction represeting the percentage
+     * @param _fracDenom Denominator of fraction represeting the percentage
+     */
+    function percPoints(uint256 _fracNum, uint256 _fracDenom) internal view returns (uint256) {
+        return _fracNum.mul(PERC_DIVISOR).div(_fracDenom);
+    }
+}

--- a/contracts/rounds/RoundsManager.sol
+++ b/contracts/rounds/RoundsManager.sol
@@ -4,6 +4,7 @@ import "../ManagerProxyTarget.sol";
 import "./IRoundsManager.sol";
 import "../bonding/IBondingManager.sol";
 import "../token/IMinter.sol";
+import "../libraries/MathUtils.sol";
 
 import "zeppelin-solidity/contracts/math/SafeMath.sol";
 
@@ -31,7 +32,7 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
      */
     function setParameters(uint256 _roundLength, uint256 _roundLockAmount) external onlyControllerOwner {
         // Must be a valid percentage
-        require(_roundLockAmount <= PERC_DIVISOR);
+        require(MathUtils.validPerc(_roundLockAmount));
 
         roundLength = _roundLength;
         roundLockAmount = _roundLockAmount;
@@ -103,7 +104,8 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
      * @dev Check if we are in the lock period of the current round
      */
     function currentRoundLocked() public view returns (bool) {
-        return blockNum().sub(currentRoundStartBlock()) >= roundLength.sub(roundLength.mul(roundLockAmount).div(PERC_DIVISOR));
+        uint256 lockedBlocks = MathUtils.percOf(roundLength, roundLockAmount);
+        return blockNum().sub(currentRoundStartBlock()) >= roundLength.sub(lockedBlocks);
     }
 
     /*

--- a/contracts/test/BondingManagerMock.sol
+++ b/contracts/test/BondingManagerMock.sol
@@ -52,10 +52,6 @@ contract BondingManagerMock is IBondingManager {
 
     function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external {}
 
-    function callAddToRedistributionPool(uint256 _amount) external {
-        minter.addToRedistributionPool(_amount);
-    }
-
     function slashTranscoder(address _transcoder, address _finder, uint256 _slashAmount, uint256 _finderFee) external {}
 
     function electActiveTranscoder(uint256 _maxPricePerSegment, uint256 _block, uint256 _round) external view returns (address) {

--- a/contracts/test/BondingManagerMock.sol
+++ b/contracts/test/BondingManagerMock.sol
@@ -48,6 +48,10 @@ contract BondingManagerMock is IBondingManager {
         minter.createReward(activeStake, totalActiveStake);
     }
 
+    function callBurnTokens(uint256 _amount) external {
+        minter.burnTokens(_amount);
+    }
+
     function setActiveTranscoders() external {}
 
     function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external {}

--- a/contracts/test/LivepeerTokenMock.sol
+++ b/contracts/test/LivepeerTokenMock.sol
@@ -9,6 +9,7 @@ contract LivepeerTokenMock is ILivepeerToken {
     bool public approved;
     address public mintedTo;
     uint256 public minted;
+    uint256 public burned;
 
     function setApproved(bool _value) external {
         approved = _value;
@@ -17,6 +18,10 @@ contract LivepeerTokenMock is ILivepeerToken {
     function mint(address _to, uint256 _amount) public returns (bool) {
         mintedTo = _to;
         minted = _amount;
+    }
+
+    function burn(uint256 _amount) public {
+        burned = _amount;
     }
 
     function allowance(address _owner, address _spender) public view returns (uint256) {

--- a/contracts/test/MinterMock.sol
+++ b/contracts/test/MinterMock.sol
@@ -16,6 +16,8 @@ contract MinterMock is IMinter {
 
     function transferTokens(address _to, uint256 _amount) external {}
 
+    function burnTokens(uint256 _amount) external {}
+
     function addToRedistributionPool(uint256 _amount) external {}
 
     function setCurrentRewardTokens() external {}

--- a/contracts/token/ILivepeerToken.sol
+++ b/contracts/token/ILivepeerToken.sol
@@ -6,4 +6,5 @@ import "zeppelin-solidity/contracts/ownership/Ownable.sol";
 
 contract ILivepeerToken is ERC20, Ownable {
     function mint(address _to, uint256 _amount) public returns (bool);
+    function burn(uint256 _amount) public;
 }

--- a/contracts/token/ILivepeerToken.sol
+++ b/contracts/token/ILivepeerToken.sol
@@ -1,8 +1,9 @@
 pragma solidity ^0.4.17;
 
 import "zeppelin-solidity/contracts/token/ERC20.sol";
+import "zeppelin-solidity/contracts/ownership/Ownable.sol";
 
 
-contract ILivepeerToken is ERC20 {
+contract ILivepeerToken is ERC20, Ownable {
     function mint(address _to, uint256 _amount) public returns (bool);
 }

--- a/contracts/token/IMinter.sol
+++ b/contracts/token/IMinter.sol
@@ -7,5 +7,6 @@ contract IMinter {
 
     function createReward(uint256 _fracNum, uint256 _fracDenom) external returns (uint256);
     function transferTokens(address _to, uint256 _amount) external;
+    function burnTokens(uint256 _amount) external;
     function setCurrentRewardTokens() external;
 }

--- a/contracts/token/IMinter.sol
+++ b/contracts/token/IMinter.sol
@@ -3,10 +3,9 @@ pragma solidity ^0.4.17;
 
 contract IMinter {
     event NewInflation(uint256 inflation);
-    event SetCurrentRewardTokens(uint256 mintableTokens, uint256 redistributableTokens);
+    event SetCurrentRewardTokens(uint256 mintableTokens);
 
     function createReward(uint256 _fracNum, uint256 _fracDenom) external returns (uint256);
     function transferTokens(address _to, uint256 _amount) external;
-    function addToRedistributionPool(uint256 _amount) external;
     function setCurrentRewardTokens() external;
 }

--- a/contracts/token/LivepeerToken.sol
+++ b/contracts/token/LivepeerToken.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.4.17;
 
-import "zeppelin-solidity/contracts/token/MintableToken.sol";
+import "./VariableSupplyToken.sol";
 
 
 // Livepeer Token
-contract LivepeerToken is MintableToken {
+contract LivepeerToken is VariableSupplyToken {
     string public name = "Livepeer Token";
     uint8 public decimals = 18;
     string public symbol = "LPT";

--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -101,6 +101,14 @@ contract Minter is Manager, IMinter {
     }
 
     /*
+     * @dev Burn tokens
+     * @param _amount Amount of tokens to burn
+     */
+    function burnTokens(uint256 _amount) external onlyBondingManager whenSystemNotPaused {
+        livepeerToken().burn(_amount);
+    }
+
+    /*
      * @dev Set the reward token amounts for the round. Only callable by the RoundsManager
      */
     function setCurrentRewardTokens() external onlyRoundsManager whenSystemNotPaused {

--- a/contracts/token/VariableSupplyToken.sol
+++ b/contracts/token/VariableSupplyToken.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.4.17;
+
+import "zeppelin-solidity/contracts/token/MintableToken.sol";
+
+
+contract VariableSupplyToken is MintableToken {
+    event Burn(address indexed burner, uint256 value);
+
+    /*
+     * @dev Burns a specific amount of the sender's tokens
+     * @param _value The amount of tokens to be burned
+     */
+    function burn(uint256 _amount) public {
+        // Must not burn more than the sender owns
+        require(_amount <= balances[msg.sender]);
+
+        address burner = msg.sender;
+        balances[burner] = balances[burner].sub(_amount);
+        totalSupply = totalSupply.sub(_amount);
+
+        Burn(burner, _amount);
+    }
+}

--- a/migrations/2_deploy_libraries.js
+++ b/migrations/2_deploy_libraries.js
@@ -4,7 +4,9 @@ const MerkleProof = artifacts.require("MerkleProof")
 const ECRecovery = artifacts.require("ECRecovery")
 const JobLib = artifacts.require("JobLib")
 const SafeMath = artifacts.require("SafeMath")
+const MathUtils = artifacts.require("MathUtils")
 
+const Minter = artifacts.require("Minter")
 const JobsManager = artifacts.require("JobsManager")
 const BondingManager = artifacts.require("BondingManager")
 const RoundsManager = artifacts.require("RoundsManager")
@@ -17,7 +19,17 @@ module.exports = function(deployer) {
         JobsManager,
         RoundsManager,
         OraclizeVerifier,
-        SortedDoublyLL
+        SortedDoublyLL,
+        MathUtils
+    ])
+
+    deployer.deploy(MathUtils)
+    deployer.link(MathUtils, [
+        BondingManager,
+        JobsManager,
+        RoundsManager,
+        Minter,
+        TokenPools
     ])
 
     deployer.deploy(SortedDoublyLL)

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -402,37 +402,29 @@ contract("BondingManager", accounts => {
             // Transcoder calls reward
             await bondingManager.reward({from: tAddr})
 
-            // 15
-            const delegatorsFeeShare1 = Math.floor((fees * feeShare) / PERC_DIVISOR)
-            // 7
-            const delegatorFeeShare1 = Math.floor((2000 * delegatorsFeeShare1) / transcoderTotalStake)
+            const percPoints1 = Math.floor((2000 * PERC_DIVISOR) / transcoderTotalStake)
+            const transcoderFeeShare1 = Math.floor((fees * (PERC_DIVISOR - feeShare)) / PERC_DIVISOR)
+            const delegatorsFeeShare1 = fees - transcoderFeeShare1
+            const delegatorFeeShare1 = Math.floor((percPoints1 * delegatorsFeeShare1) / PERC_DIVISOR)
+            const transcoderRewardShare1 = Math.floor((mintedTokens * blockRewardCut) / PERC_DIVISOR)
+            const delegatorsRewardShare1 = mintedTokens - transcoderRewardShare1
+            const delegatorRewardShare1 = Math.floor((percPoints1 * delegatorsRewardShare1) / PERC_DIVISOR)
 
-            // 450
-            const delegatorsRewardShare1 = Math.floor((mintedTokens * (PERC_DIVISOR - blockRewardCut)) / PERC_DIVISOR)
-            // 225
-            const delegatorRewardShare1 = Math.floor((2000 * delegatorsRewardShare1) / transcoderTotalStake)
+            const percPoints2 = Math.floor((add(2000, delegatorRewardShare1) * PERC_DIVISOR) / transcoderTotalStake2)
+            const transcoderFeeShare2 = Math.floor((fees2 * (PERC_DIVISOR - feeShare)) / PERC_DIVISOR)
+            const delegatorsFeeShare2 = fees2 - transcoderFeeShare2
+            const delegatorFeeShare2 = Math.floor((percPoints2 * delegatorsFeeShare2) / PERC_DIVISOR)
+            const transcoderRewardShare2 = Math.floor((mintedTokens2 * blockRewardCut) / PERC_DIVISOR)
+            const delegatorsRewardShare2 = mintedTokens2 - transcoderRewardShare2
+            const delegatorRewardShare2 = Math.floor((percPoints2 * delegatorsRewardShare2) / PERC_DIVISOR)
 
-            // 20
-            const delegatorsFeeShare2 = Math.floor((fees2 * feeShare) / PERC_DIVISOR)
-            // 9
-            const delegatorFeeShare2 = Math.floor((add(2000, delegatorRewardShare1) * delegatorsFeeShare2) / transcoderTotalStake2)
-
-            // 540
-            const delegatorsRewardShare2 = Math.floor((mintedTokens2 * (PERC_DIVISOR - blockRewardCut)) / PERC_DIVISOR)
-            // 267
-            const delegatorRewardShare2 = Math.floor((add(2000, delegatorRewardShare1).toNumber() * delegatorsRewardShare2) / transcoderTotalStake2)
-
-            // 2492
-            const expDelegatorStake = add(2000, delegatorRewardShare1, delegatorRewardShare2).toString()
-            // 18
-            const expUnbondedAmount = add(delegatorFeeShare1, delegatorFeeShare2).toString()
+            const expDelegatorStake = add(2000, delegatorRewardShare1, delegatorRewardShare2)
+            const expUnbondedAmount = add(delegatorFeeShare1, delegatorFeeShare2)
             await bondingManager.claimTokenPoolsShares(8, {from: dAddr})
 
             const dInfo = await bondingManager.getDelegator(dAddr)
-            const delegatorStake = dInfo[0]
-            assert.equal(delegatorStake.toString(), expDelegatorStake, "delegator stake incorrect")
-            const unbondedAmount = dInfo[1]
-            assert.equal(unbondedAmount.toString(), expUnbondedAmount, "delegator unbonded amount incorrect")
+            assert.equal(dInfo[0].toString(), expDelegatorStake, "delegator stake incorrect")
+            assert.equal(dInfo[1].toString(), expUnbondedAmount, "delegator unbonded amount incorrect")
         })
 
         it("should update delegator's stake and unbonded amount through the end round with a larger portion of rewards and fees after another delegator unbonds before the rewards and fees are released", async () => {
@@ -473,11 +465,13 @@ contract("BondingManager", accounts => {
             // Get Delegator 1 unbonded amount
             const unbondedAmount = (await bondingManager.getDelegator(dAddr))[1]
 
-            const delegatorsFeeShare = Math.floor((fees2 * feeShare) / PERC_DIVISOR)
-            const delegatorFeeShare = Math.floor((delegatorStake * delegatorsFeeShare) / claimableStake)
-
-            const delegatorsRewardShare = Math.floor((mintedTokens2 * (PERC_DIVISOR - blockRewardCut)) / PERC_DIVISOR)
-            const delegatorRewardShare = Math.floor((delegatorStake * delegatorsRewardShare) / claimableStake)
+            const percPoints = Math.floor((delegatorStake * PERC_DIVISOR) / claimableStake)
+            const transcoderFeeShare = Math.floor((fees2 * (PERC_DIVISOR - feeShare)) / PERC_DIVISOR)
+            const delegatorsFeeShare = fees2 - transcoderFeeShare
+            const delegatorFeeShare = Math.floor((percPoints * delegatorsFeeShare) / PERC_DIVISOR)
+            const transcoderRewardShare = Math.floor((mintedTokens2 * blockRewardCut) / PERC_DIVISOR)
+            const delegatorsRewardShare = mintedTokens2 - transcoderRewardShare
+            const delegatorRewardShare = Math.floor((percPoints * delegatorsRewardShare) / PERC_DIVISOR)
 
             const expDelegatorStake = add(delegatorStake, delegatorRewardShare).toString()
             const expUnbondedAmount = add(unbondedAmount, delegatorFeeShare).toString()

--- a/test/unit/Minter.js
+++ b/test/unit/Minter.js
@@ -146,6 +146,19 @@ contract("Minter", accounts => {
         })
     })
 
+    describe("burnTokens", () => {
+        it("should throw if sender is not bonding manager", async () => {
+            await expectThrow(minter.burnTokens(100, {from: accounts[1]}))
+        })
+
+        it("should burn an amount of tokens", async () => {
+            await fixture.bondingManager.callBurnTokens(100)
+
+            const burned = await fixture.token.burned.call()
+            assert.equal(burned, 100, "wrong burned amount")
+        })
+    })
+
     describe("setCurrentRewardTokens", () => {
         it("should throw if sender is not rounds manager", async () => {
             await expectThrow(minter.setCurrentRewardTokens())

--- a/test/unit/Minter.js
+++ b/test/unit/Minter.js
@@ -41,7 +41,7 @@ contract("Minter", accounts => {
             await expectThrow(minter.createReward(10, 100))
         })
 
-        it("should compute rewards when redistributionPool = 0", async () => {
+        it("should compute rewards", async () => {
             await fixture.token.setTotalSupply(1000)
             await fixture.bondingManager.setTotalBonded(200)
             // Set up current reward tokens via RoundsManager
@@ -59,33 +59,6 @@ contract("Minter", accounts => {
             assert.equal(mintedTo, minter.address, "wrong minted to address")
             const minted = await fixture.token.minted.call()
             assert.equal(minted, mintedTokens.mul(10).div(100).floor().toNumber(), "wrong minted amount")
-        })
-
-        it("should compute rewards and update the redistributionPool when redistributionPool > 0", async () => {
-            await fixture.token.setTotalSupply(1000000)
-            await fixture.bondingManager.setTotalBonded(200000)
-            // Set up current reward tokens via RoundsManager
-            await fixture.bondingManager.callAddToRedistributionPool(100000)
-            await fixture.roundsManager.callSetCurrentRewardTokens()
-
-            // Set up reward call via BondingManager
-            await fixture.bondingManager.setActiveTranscoder(accounts[1], 0, 10, 100)
-            await fixture.bondingManager.reward()
-
-            const supply = await fixture.token.totalSupply.call()
-            const inflation = await minter.inflation.call()
-            const mintedTokens = supply.mul(inflation).div(PERC_DIVISOR).floor()
-
-            const mintedTo = await fixture.token.mintedTo.call()
-            assert.equal(mintedTo, minter.address, "wrong minted to address")
-            const minted = await fixture.token.minted.call()
-            assert.equal(minted, mintedTokens.mul(10).div(100).floor().toNumber(), "wrong minted amount")
-
-            const redistributedTokens = ((100000 / 100) * 10) / 100
-            const expRedistributionPool = 100000 - redistributedTokens
-
-            const redistributionPool = await minter.redistributionPool.call()
-            assert.equal(redistributionPool, expRedistributionPool, "redistribution pool incorrect")
         })
 
         it("should compute rewards correctly for large fraction = 1", async () => {

--- a/test/unit/TestMathUtils.sol
+++ b/test/unit/TestMathUtils.sol
@@ -1,0 +1,29 @@
+pragma solidity ^0.4.17;
+
+import "../../contracts/libraries/MathUtils.sol";
+import "truffle/Assert.sol";
+
+
+contract TestMathUtils {
+    function test_validPerc() public {
+        Assert.equal(MathUtils.validPerc(50), true, "50 should be a valid percentage");
+        Assert.equal(MathUtils.validPerc(0), true, "0 should be a valid percentage");
+        Assert.equal(MathUtils.validPerc(1000000), true, "the max should be a valid percentage");
+        Assert.equal(MathUtils.validPerc(1000001), false, "1 more than the max should not be valid percentage");
+    }
+
+    function test_percOf1() public {
+        Assert.equal(MathUtils.percOf(100, 3, 4), 75, "3/4 of 100 should be 75");
+        Assert.equal(MathUtils.percOf(100, 7, 9), 77, "7/9 of 100 should be 77");
+    }
+
+    function test_percOf2() public {
+        Assert.equal(MathUtils.percOf(100, 3), 0, ".0003% of 100 is 0");
+        Assert.equal(MathUtils.percOf(100, 100000), 10, "10% of 100 is 10");
+    }
+
+    function test_percPoints() public {
+        Assert.equal(MathUtils.percPoints(3, 4), 750000, "3/4 should convert to valid percentage");
+        Assert.equal(MathUtils.percPoints(100, 300), 333333, "100/300 should convert to valid percentage");
+    }
+}

--- a/test/unit/VariableSupplyToken.js
+++ b/test/unit/VariableSupplyToken.js
@@ -1,0 +1,28 @@
+import expectThrow from "../helpers/expectThrow"
+
+const VariableSupplyToken = artifacts.require("VariableSupplyToken")
+
+contract("VariableSupplyToken", accounts => {
+    let token
+
+    before(async () => {
+        token = await VariableSupplyToken.new()
+    })
+
+    describe("burn", () => {
+        it("should reduce the supply and balance of the sender", async () => {
+            await token.mint(accounts[0], 500, {from: accounts[0]})
+
+            await token.burn(200, {from: accounts[0]})
+
+            const balance = await token.balanceOf(accounts[0])
+            assert.equal(balance, 300, "wrong balance")
+            const totalSupply = await token.totalSupply.call()
+            assert.equal(totalSupply, 300, "wrong total supply")
+        })
+
+        it("should throw if burn amount is greater than sender balance", async () => {
+            await expectThrow(token.burn(400, {from: accounts[0]}))
+        })
+    })
+})


### PR DESCRIPTION
This PR removes the concept of a redistribution pool - previously, the Minter maintained a redistribution pool that contained slashed funds and unclaimable rewards/fees. Removing the redistribution pool simplifies some of the accounting logic in the protocol and also makes it easier to implement ETH based payments (we wouldn't have to keep track of a redistribution pool for LPT and a redistribution pool for ETH).

We originally sent unclaimable rewards/fees to the redistribution pool because if a delegator with `lastClaimTokenPoolsSharesRound = M` s.t. `M < currentRound` changes its delegation away from a transcoder in `currentRound` before the transcoder calls `reward` during `currentRound` or calls `distributeFees` for a job created in round `N` s.t. `M < N < currentRound`, its reward share for `currentRound` and its fee share for round `N` will be unclaimable. The redistribution pool was distributed amongst the active transcoder set over the next few rounds.

Now, in this scenario, if a delegator changes its delegation, we decrease the `ClaimableStake` for that round so each remaining delegator that is still delegated to the transcoder can claim a larger % of the rewards/fees for that round.

An example with fees:

*Note: using integer division

Delegators of a transcoder:
`A = 20`
`B = 30`
`C = 40`
`D = 90`

`ClaimableStake = 180`

`A` unbonds so ClaimableStake = 160
100 fees are placed in the fee pool for this round

`B` claims shares for this round
`B` gets `(100 * 30) / 160 = 18` instead of `(100 * 30) / 180` = 16
There are now `100 - 18 = 82` fees and `ClaimableStake = 160 - 30 = 130`

`C` claims shares for this round
`C` gets `(82 * 40) / 130 = 25` instead of `(100 * 40) / 180) = 22`
There are now `82 - 25 = 57` fees and `ClaimableStake = 130 - 40 = 90`

`D` claims shares for this round
`D` gets `(57 * 90) / 90 = 57` instead of `(100 * 90) / 180) = 50`
There are now `57 - 57 = 0` fees and `ClaimableStake = 90 - 90 = 0`

Slashed funds are now effectively burned instead of being placed in the redistribution pool (though they are technically just stuck in the ownership of the Minter contract without anyway of getting them out - perhaps they should by explicitly sent to the null address...)

Also added the `transferTokenOwnership` function to the Minter to allow the Controller's owner to transfer ownership of LivepeerToken from the current Minter to a new Minter if needed