### PR TITLE
Use ETH for job deposits and fee payments

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -575,10 +575,10 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /*
-     * @dev Returns bonded stake for a delegator. Includes reward pool shares since lastClaimTokenPoolsSharesRound
+     * @dev Returns pending bonded stake for a delegator. Includes reward pool shares since lastClaimTokenPoolsSharesRound
      * @param _delegator Address of delegator
      */
-    function delegatorStake(address _delegator) public view returns (uint256) {
+    function pendingStake(address _delegator) public view returns (uint256) {
         Delegator storage del = delegators[_delegator];
 
         // Add rewards from the rounds during which the delegator was bonded to a transcoder
@@ -603,10 +603,10 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /*
-     * @dev Returns fees for a delegator. Includes fee pool shares since lastClaimTokenPoolsSharesRound
+     * @dev Returns pending fees for a delegator. Includes fee pool shares since lastClaimTokenPoolsSharesRound
      * @param _delegator Address of delegator
      */
-    function delegatorFees(address _delegator) public view returns (uint256) {
+    function pendingFees(address _delegator) public view returns (uint256) {
         Delegator storage del = delegators[_delegator];
 
         // Add fees from the rounds during which the delegator was bonded to a transcoder

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -347,22 +347,22 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         // Delegator must either have unbonded tokens or be in the unbonded state
         require(delegators[msg.sender].unbondedAmount > 0 || delegatorStatus(msg.sender) == DelegatorStatus.Unbonded);
 
-        uint256 amount = 0;
-
         if (delegators[msg.sender].unbondedAmount > 0) {
-            // Withdraw unbonded amount
-            amount = amount.add(delegators[msg.sender].unbondedAmount);
+            // Withdraw unbonded amount (ETH)
+            uint256 unbondedAmount = delegators[msg.sender].unbondedAmount;
             delegators[msg.sender].unbondedAmount = 0;
+
+            minter().transferETH(msg.sender, unbondedAmount);
         }
 
         if (delegatorStatus(msg.sender) == DelegatorStatus.Unbonded) {
-            // Withdraw bonded amount which is now unbonded
-            amount = amount.add(delegators[msg.sender].bondedAmount);
+            // Withdraw bonded amount (LPT)
+            uint256 bondedAmount = delegators[msg.sender].bondedAmount;
             delegators[msg.sender].bondedAmount = 0;
             delegators[msg.sender].withdrawRound = 0;
-        }
 
-        minter().transferTokens(msg.sender, amount);
+            minter().transferTokens(msg.sender, bondedAmount);
+        }
 
         Withdraw(msg.sender);
     }

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -13,7 +13,8 @@ contract IBondingManager {
     event Reward(address indexed transcoder, uint256 amount);
     event Bond(address indexed delegate, address indexed delegator);
     event Unbond(address indexed delegate, address indexed delegator);
-    event Withdraw(address indexed delegator);
+    event WithdrawStake(address indexed delegator);
+    event WithdrawFees(address indexed delegator);
 
     // External functions
     function setActiveTranscoders() external;

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -233,15 +233,14 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
     }
 
     /*
-     * @dev Deposit funds for jobs
-     * @param _amount Amount to deposit
+     * @dev Deposit ETH for jobs
      */
-    function deposit(uint256 _amount) external whenSystemNotPaused {
-        broadcasters[msg.sender].deposit = broadcasters[msg.sender].deposit.add(_amount);
-        // Transfer tokens for deposit to Minter. Sender needs to approve amount first
-        livepeerToken().transferFrom(msg.sender, minter(), _amount);
+    function deposit() external payable whenSystemNotPaused {
+        broadcasters[msg.sender].deposit = broadcasters[msg.sender].deposit.add(msg.value);
+        // Transfer ETH for deposit to Minter
+        minter().receiveETH.value(msg.value)();
 
-        Deposit(msg.sender, _amount);
+        Deposit(msg.sender, msg.value);
     }
 
     /*
@@ -253,7 +252,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
 
         uint256 amount = broadcasters[msg.sender].deposit;
         delete broadcasters[msg.sender];
-        minter().transferTokens(msg.sender, amount);
+        minter().transferETH(msg.sender, amount);
 
         Withdraw(msg.sender);
     }

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -238,7 +238,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
     function deposit() external payable whenSystemNotPaused {
         broadcasters[msg.sender].deposit = broadcasters[msg.sender].deposit.add(msg.value);
         // Transfer ETH for deposit to Minter
-        minter().receiveETH.value(msg.value)();
+        minter().depositETH.value(msg.value)();
 
         Deposit(msg.sender, msg.value);
     }
@@ -252,7 +252,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
 
         uint256 amount = broadcasters[msg.sender].deposit;
         delete broadcasters[msg.sender];
-        minter().transferETH(msg.sender, amount);
+        minter().withdrawETH(msg.sender, amount);
 
         Withdraw(msg.sender);
     }

--- a/contracts/test/BondingManagerMock.sol
+++ b/contracts/test/BondingManagerMock.sol
@@ -40,8 +40,12 @@ contract BondingManagerMock is IBondingManager {
         withdrawAmount = _amount;
     }
 
-    function withdraw() external {
-        minter.transferTokens(msg.sender, withdrawAmount);
+    function withdraw(bool _unbonded, address _recipient) external {
+        if (_unbonded) {
+            minter.transferETH(_recipient, withdrawAmount);
+        } else {
+            minter.transferTokens(_recipient, withdrawAmount);
+        }
     }
 
     function reward() external {

--- a/contracts/test/BondingManagerMock.sol
+++ b/contracts/test/BondingManagerMock.sol
@@ -42,7 +42,7 @@ contract BondingManagerMock is IBondingManager {
 
     function withdraw(bool _unbonded, address _recipient) external {
         if (_unbonded) {
-            minter.transferETH(_recipient, withdrawAmount);
+            minter.withdrawETH(_recipient, withdrawAmount);
         } else {
             minter.transferTokens(_recipient, withdrawAmount);
         }

--- a/contracts/test/JobsManagerMock.sol
+++ b/contracts/test/JobsManagerMock.sol
@@ -91,12 +91,12 @@ contract JobsManagerMock is IJobsManager {
     }
 
     function deposit() external payable {
-        minter.receiveETH.value(msg.value)();
+        minter.depositETH.value(msg.value)();
     }
 
     function withdraw(bool _unbonded, address _recipient) external {
         if (_unbonded) {
-            minter.transferETH(_recipient, withdrawAmount);
+            minter.withdrawETH(_recipient, withdrawAmount);
         } else {
             minter.transferTokens(_recipient, withdrawAmount);
         }

--- a/contracts/test/JobsManagerMock.sol
+++ b/contracts/test/JobsManagerMock.sol
@@ -90,8 +90,16 @@ contract JobsManagerMock is IJobsManager {
         return bondingManager.slashTranscoder(transcoder, finder, slashAmount, finderFee);
     }
 
-    function withdraw() external {
-        minter.transferTokens(msg.sender, withdrawAmount);
+    function deposit() external payable {
+        minter.receiveETH.value(msg.value)();
+    }
+
+    function withdraw(bool _unbonded, address _recipient) external {
+        if (_unbonded) {
+            minter.transferETH(_recipient, withdrawAmount);
+        } else {
+            minter.transferTokens(_recipient, withdrawAmount);
+        }
     }
 
     function callVerify() external payable {

--- a/contracts/test/MinterMock.sol
+++ b/contracts/test/MinterMock.sol
@@ -18,9 +18,9 @@ contract MinterMock is IMinter {
 
     function burnTokens(uint256 _amount) external {}
 
-    function transferETH(address _to, uint256 _amount) external {}
+    function withdrawETH(address _to, uint256 _amount) external {}
 
-    function receiveETH() external payable returns (bool) {
+    function depositETH() external payable returns (bool) {
         return true;
     }
 

--- a/contracts/test/MinterMock.sol
+++ b/contracts/test/MinterMock.sol
@@ -18,6 +18,12 @@ contract MinterMock is IMinter {
 
     function burnTokens(uint256 _amount) external {}
 
+    function transferETH(address _to, uint256 _amount) external {}
+
+    function receiveETH() external payable returns (bool) {
+        return true;
+    }
+
     function addToRedistributionPool(uint256 _amount) external {}
 
     function setCurrentRewardTokens() external {}

--- a/contracts/token/IMinter.sol
+++ b/contracts/token/IMinter.sol
@@ -8,5 +8,7 @@ contract IMinter {
     function createReward(uint256 _fracNum, uint256 _fracDenom) external returns (uint256);
     function transferTokens(address _to, uint256 _amount) external;
     function burnTokens(uint256 _amount) external;
+    function transferETH(address _to, uint256 _amount) external;
+    function receiveETH() external payable returns (bool);
     function setCurrentRewardTokens() external;
 }

--- a/contracts/token/IMinter.sol
+++ b/contracts/token/IMinter.sol
@@ -8,7 +8,7 @@ contract IMinter {
     function createReward(uint256 _fracNum, uint256 _fracDenom) external returns (uint256);
     function transferTokens(address _to, uint256 _amount) external;
     function burnTokens(uint256 _amount) external;
-    function transferETH(address _to, uint256 _amount) external;
-    function receiveETH() external payable returns (bool);
+    function depositETH() external payable returns (bool);
+    function withdrawETH(address _to, uint256 _amount) external;
     function setCurrentRewardTokens() external;
 }

--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -108,18 +108,18 @@ contract Minter is Manager, IMinter {
     }
 
     /*
-     * @dev Transfer ETH to a recipient
+     * @dev Withdraw ETH to a recipient
      * @param _to Recipient address
      * @param _amount Amount of ETH
      */
-    function transferETH(address _to, uint256 _amount) external onlyBondingManagerOrJobsManager whenSystemNotPaused {
+    function withdrawETH(address _to, uint256 _amount) external onlyBondingManagerOrJobsManager whenSystemNotPaused {
         _to.transfer(_amount);
     }
 
     /*
-     * @dev Receive ETH from JobsManager
+     * @dev Deposit ETH from the JobsManager
      */
-    function receiveETH() external payable onlyJobsManager whenSystemNotPaused returns (bool) {
+    function depositETH() external payable onlyJobsManager whenSystemNotPaused returns (bool) {
         return true;
     }
 

--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -108,6 +108,22 @@ contract Minter is Manager, IMinter {
     }
 
     /*
+     * @dev Transfer ETH to a recipient
+     * @param _to Recipient address
+     * @param _amount Amount of ETH
+     */
+    function transferETH(address _to, uint256 _amount) external onlyBondingManagerOrJobsManager whenSystemNotPaused {
+        _to.transfer(_amount);
+    }
+
+    /*
+     * @dev Receive ETH from JobsManager
+     */
+    function receiveETH() external payable onlyJobsManager whenSystemNotPaused returns (bool) {
+        return true;
+    }
+
+    /*
      * @dev Set the reward token amounts for the round. Only callable by the RoundsManager
      */
     function setCurrentRewardTokens() external onlyRoundsManager whenSystemNotPaused {

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -465,7 +465,7 @@ contract("BondingManager", accounts => {
         })
     })
 
-    describe("delegatorStake", async () => {
+    describe("pendingStake", async () => {
         const tAddr = accounts[1]
         const dAddr = accounts[2]
 
@@ -514,12 +514,12 @@ contract("BondingManager", accounts => {
             const delegatorsRewardShare = Math.floor((mintedTokens * (PERC_DIVISOR - blockRewardCut)) / PERC_DIVISOR)
             const delegatorRewardShare = Math.floor((2000 * delegatorsRewardShare) / transcoderTotalStake)
             const expDelegatorStake = add(2000, delegatorRewardShare).toString()
-            const delegatorStake = await bondingManager.delegatorStake(dAddr)
-            assert.equal(delegatorStake.toString(), expDelegatorStake, "delegator stake incorrect")
+            const pendingStake = await bondingManager.pendingStake(dAddr)
+            assert.equal(pendingStake.toString(), expDelegatorStake, "delegator stake incorrect")
         })
     })
 
-    describe("delegatorFees", () => {
+    describe("pendingFees", () => {
         const tAddr = accounts[1]
         const dAddr = accounts[2]
 
@@ -562,11 +562,11 @@ contract("BondingManager", accounts => {
             await fixture.jobsManager.distributeFees()
         })
 
-        it("should compute delegator's colellected fees with latest fee shares", async () => {
+        it("should compute delegator's collected fees with latest fee shares", async () => {
             const delegatorsFeeShare = Math.floor((fees * feeShare) / PERC_DIVISOR)
             const delegatorFeeShare = Math.floor((2000 * delegatorsFeeShare) / transcoderTotalStake)
             const expFees = delegatorFeeShare
-            const dFees = await bondingManager.delegatorFees(dAddr)
+            const dFees = await bondingManager.pendingFees(dAddr)
             assert.equal(dFees, expFees, "delegator fees incorrect")
         })
     })

--- a/test/unit/JobsManager.js
+++ b/test/unit/JobsManager.js
@@ -74,7 +74,7 @@ contract("JobsManager", accounts => {
         })
 
         it("should update broadcaster deposit", async () => {
-            await jobsManager.deposit(1000, {from: broadcaster})
+            await jobsManager.deposit({from: broadcaster, value: 1000})
             const bDeposit = (await jobsManager.broadcasters.call(broadcaster))[0]
             assert.equal(bDeposit, 1000, "broadcaster deposit incorrect")
         })
@@ -173,7 +173,7 @@ contract("JobsManager", accounts => {
             await fixture.token.setApproved(true)
 
             // Broadcaster deposits fees
-            await jobsManager.deposit(deposit, {from: broadcaster})
+            await jobsManager.deposit({from: broadcaster, value: deposit})
 
             await fixture.roundsManager.setBlockNum(100)
 
@@ -335,7 +335,7 @@ contract("JobsManager", accounts => {
             await fixture.bondingManager.setActiveTranscoder(electedTranscoder, maxPricePerSegment, 100, 200)
             await fixture.token.setApproved(true)
 
-            await jobsManager.deposit(1000, {from: broadcaster})
+            await jobsManager.deposit({from: broadcaster, value: 1000})
 
             await fixture.roundsManager.setBlockNum(100)
 
@@ -432,7 +432,7 @@ contract("JobsManager", accounts => {
             await fixture.bondingManager.setActiveTranscoder(electedTranscoder, maxPricePerSegment, 100, 200)
             await fixture.token.setApproved(true)
 
-            await jobsManager.deposit(1000, {from: broadcaster})
+            await jobsManager.deposit({from: broadcaster, value: 1000})
 
             await fixture.roundsManager.setBlockNum(100)
 
@@ -577,7 +577,7 @@ contract("JobsManager", accounts => {
             await fixture.bondingManager.setActiveTranscoder(electedTranscoder, maxPricePerSegment, 100, 200)
             await fixture.token.setApproved(true)
 
-            await jobsManager.deposit(1000, {from: broadcaster})
+            await jobsManager.deposit({from: broadcaster, value: 1000})
 
             await fixture.roundsManager.setBlockNum(100)
 
@@ -677,7 +677,7 @@ contract("JobsManager", accounts => {
             await fixture.bondingManager.setActiveTranscoder(electedTranscoder, maxPricePerSegment, 100, 200)
             await fixture.token.setApproved(true)
 
-            await jobsManager.deposit(1000, {from: broadcaster})
+            await jobsManager.deposit({from: broadcaster, value: 1000})
 
             await fixture.roundsManager.setBlockNum(100)
 
@@ -775,7 +775,7 @@ contract("JobsManager", accounts => {
             await fixture.bondingManager.setActiveTranscoder(electedTranscoder, maxPricePerSegment, 100, 200)
             await fixture.token.setApproved(true)
 
-            await jobsManager.deposit(1000, {from: broadcaster})
+            await jobsManager.deposit({from: broadcaster, value: 1000})
 
             await fixture.roundsManager.setBlockNum(100)
 
@@ -835,7 +835,7 @@ contract("JobsManager", accounts => {
             await fixture.bondingManager.setActiveTranscoder(accounts[1], 100, 100, 200)
             await fixture.token.setApproved(true)
 
-            await jobsManager.deposit(1000, {from: accounts[0]})
+            await jobsManager.deposit({from: accounts[0], value: 1000})
 
             await fixture.roundsManager.setBlockNum(100)
         })

--- a/test/unit/Minter.js
+++ b/test/unit/Minter.js
@@ -137,12 +137,54 @@ contract("Minter", accounts => {
 
         it("should transfer tokens to receiving address when sender is bonding manager", async () => {
             await fixture.bondingManager.setWithdrawAmount(100)
-            await fixture.bondingManager.withdraw({from: accounts[1]})
+            await fixture.bondingManager.withdraw(false, accounts[1], {from: accounts[1]})
         })
 
         it("should transfer tokens to receiving address when sender is jobs manager", async () => {
             await fixture.jobsManager.setWithdrawAmount(100)
-            await fixture.jobsManager.withdraw({from: accounts[1]})
+            await fixture.jobsManager.withdraw(false, accounts[1], {from: accounts[1]})
+        })
+    })
+
+    describe("transferETH", () => {
+        it("should throw if sender is not bonding manager or jobs manager", async () => {
+            await expectThrow(minter.transferETH(accounts[1], 100))
+        })
+
+        it("should transfer ETH to receiving address when sender is bonding manager", async () => {
+            await fixture.jobsManager.deposit({from: accounts[0], value: 100})
+            await fixture.bondingManager.setWithdrawAmount(100)
+
+            const startBalance = web3.eth.getBalance(accounts[1])
+            await fixture.bondingManager.withdraw(true, accounts[1], {from: accounts[2]})
+            const endBalance = web3.eth.getBalance(accounts[1])
+
+            assert.equal(endBalance.sub(startBalance), 100, "balance did not update correctly")
+        })
+
+        it("should transfer ETH to receiving address when sender is jobs manager", async () => {
+            await fixture.jobsManager.deposit({from: accounts[0], value: 100})
+            await fixture.jobsManager.setWithdrawAmount(100)
+
+            const startBalance = web3.eth.getBalance(accounts[1])
+            await fixture.jobsManager.withdraw(true, accounts[1], {from: accounts[2]})
+            const endBalance = web3.eth.getBalance(accounts[1])
+
+            assert.equal(endBalance.sub(startBalance).toNumber(), 100, "balance did not update correctly")
+        })
+    })
+
+    describe("receiveETH", () => {
+        it("should throw if sender is not jobs manager", async () => {
+            await expectThrow(minter.receiveETH({from: accounts[1]}))
+        })
+
+        it("should receive ETH from the jobs manager", async () => {
+            const startBalance = web3.eth.getBalance(minter.address)
+            await fixture.jobsManager.deposit({from: accounts[0], value: 100})
+            const endBalance = web3.eth.getBalance(minter.address)
+
+            assert.equal(endBalance.sub(startBalance), 100, "minter balance did not update corretly")
         })
     })
 

--- a/test/unit/Minter.js
+++ b/test/unit/Minter.js
@@ -146,9 +146,9 @@ contract("Minter", accounts => {
         })
     })
 
-    describe("transferETH", () => {
+    describe("withdrawETH", () => {
         it("should throw if sender is not bonding manager or jobs manager", async () => {
-            await expectThrow(minter.transferETH(accounts[1], 100))
+            await expectThrow(minter.withdrawETH(accounts[1], 100))
         })
 
         it("should transfer ETH to receiving address when sender is bonding manager", async () => {
@@ -174,9 +174,9 @@ contract("Minter", accounts => {
         })
     })
 
-    describe("receiveETH", () => {
+    describe("depositETH", () => {
         it("should throw if sender is not jobs manager", async () => {
-            await expectThrow(minter.receiveETH({from: accounts[1]}))
+            await expectThrow(minter.depositETH({from: accounts[1]}))
         })
 
         it("should receive ETH from the jobs manager", async () => {


### PR DESCRIPTION
This PR changes job deposits and fee payouts to be denominated in ETH rather than LPT.

Broadcasters now use the payable `deposit` function in JobsManager to make a ETH deposit to pay for transcode jobs. Similar to with LPT, all ETH is forwarded to the Minter, which is the interim owner of all funds in the protocol until they are paid out.