### PR TITLE
GenesisManager unit test

### DIFF
--- a/contracts/test/GenericMock.sol
+++ b/contracts/test/GenericMock.sol
@@ -11,9 +11,10 @@ contract GenericMock {
         bytes32 bytes32Value;
         bool boolValue;
         MockValueType valueType;
+        bool set;
     }
 
-    enum MockValueType { Uint256, Bytes32, Bool, None }
+    enum MockValueType { Uint256, Bytes32, Bool }
 
     // Track function selectors and mapped mock values
     mapping (bytes4 => MockValue) mockValues;
@@ -35,6 +36,7 @@ contract GenericMock {
     function setMockUint256(bytes4 _func, uint256 _value) external returns (bool) {
         mockValues[_func].valueType = MockValueType.Uint256;
         mockValues[_func].uint256Value = _value;
+        mockValues[_func].set = true;
     }
 
     /*
@@ -45,6 +47,7 @@ contract GenericMock {
     function setMockBytes32(bytes4 _func, bytes32 _value) external {
         mockValues[_func].valueType = MockValueType.Bytes32;
         mockValues[_func].bytes32Value = _value;
+        mockValues[_func].set = true;
     }
 
     /*
@@ -55,6 +58,7 @@ contract GenericMock {
     function setMockBool(bytes4 _func, bool _value) external {
         mockValues[_func].valueType = MockValueType.Bool;
         mockValues[_func].boolValue = _value;
+        mockValues[_func].set = true;
     }
 
     /*
@@ -64,15 +68,17 @@ contract GenericMock {
         bytes4 func;
         assembly { func := calldataload(0) }
 
-        if (mockValues[func].valueType == MockValueType.Uint256) {
-            mLoadAndReturn(mockValues[func].uint256Value);
-        } else if (mockValues[func].valueType == MockValueType.Bytes32) {
-            mLoadAndReturn(mockValues[func].bytes32Value);
-        } else if (mockValues[func].valueType == MockValueType.Bool) {
-            mLoadAndReturn(mockValues[func].boolValue);
+        if (!mockValues[func].set) {
+            // If mock value not set, default to return a bool with value false
+            mLoadAndReturn(false);
         } else {
-            // No type set - no mock value
-            revert();
+            if (mockValues[func].valueType == MockValueType.Uint256) {
+                mLoadAndReturn(mockValues[func].uint256Value);
+            } else if (mockValues[func].valueType == MockValueType.Bytes32) {
+                mLoadAndReturn(mockValues[func].bytes32Value);
+            } else if (mockValues[func].valueType == MockValueType.Bool) {
+                mLoadAndReturn(mockValues[func].boolValue);
+            }
         }
     }
 

--- a/contracts/test/GenericMock.sol
+++ b/contracts/test/GenericMock.sol
@@ -1,0 +1,117 @@
+pragma solidity ^0.4.17;
+
+
+/*
+ * @title A mock contract that can set/return mock values and execute functions
+ * on target contracts
+ */
+contract GenericMock {
+    struct MockValue {
+        uint256 uint256Value;
+        bytes32 bytes32Value;
+        bool boolValue;
+        MockValueType valueType;
+    }
+
+    enum MockValueType { Uint256, Bytes32, Bool, None }
+
+    // Track function selectors and mapped mock values
+    mapping (bytes4 => MockValue) mockValues;
+
+    /*
+     * @dev Call a function on a target address using provided calldata for a function
+     * @param _target Target contract to call with data
+     * @param _data Transaction data to be used to call the target contract
+     */
+    function execute(address _target, bytes _data) external returns (bool) {
+        return _target.call(_data);
+    }
+
+    /*
+     * @dev Set a mock uint256 value for a function
+     * @param _func Function selector (bytes4(keccak256(FUNCTION_SIGNATURE)))
+     * @param _value Mock uint256 value
+     */
+    function setMockUint256(bytes4 _func, uint256 _value) external returns (bool) {
+        mockValues[_func].valueType = MockValueType.Uint256;
+        mockValues[_func].uint256Value = _value;
+    }
+
+    /*
+     * @dev Set a mock bytes32 value for a function
+     * @param _func Function selector (bytes4(keccak256(FUNCTION_SIGNATURE)))
+     * param _value Mock bytes32 value
+     */
+    function setMockBytes32(bytes4 _func, bytes32 _value) external {
+        mockValues[_func].valueType = MockValueType.Bytes32;
+        mockValues[_func].bytes32Value = _value;
+    }
+
+    /*
+     * @dev Set a mock bool value for a function
+     * @param _func Function selector (bytes4(keccak256(FUNCTION_SIGNATURE)))
+     * @param _value Mock bool value
+     */
+    function setMockBool(bytes4 _func, bool _value) external {
+        mockValues[_func].valueType = MockValueType.Bool;
+        mockValues[_func].boolValue = _value;
+    }
+
+    /*
+     * @dev Return mock value for a functione
+     */
+    function() public {
+        bytes4 func;
+        assembly { func := calldataload(0) }
+
+        if (mockValues[func].valueType == MockValueType.Uint256) {
+            mLoadAndReturn(mockValues[func].uint256Value);
+        } else if (mockValues[func].valueType == MockValueType.Bytes32) {
+            mLoadAndReturn(mockValues[func].bytes32Value);
+        } else if (mockValues[func].valueType == MockValueType.Bool) {
+            mLoadAndReturn(mockValues[func].boolValue);
+        } else {
+            // No type set - no mock value
+            revert();
+        }
+    }
+
+    /*
+     * @dev Load a uint256 value into memory and return it
+     * @param _value Uint256 value
+     */
+    function mLoadAndReturn(uint256 _value) private pure {
+        assembly {
+            let memOffset := mload(0x40)
+            mstore(0x40, add(memOffset, 32))
+            mstore(memOffset, _value)
+            return(memOffset, 32)
+        }
+    }
+
+    /*
+     * @dev Load a bytes32 value into memory and return it
+     * @param _value Bytes32 value
+     */
+    function mLoadAndReturn(bytes32 _value) private pure {
+        assembly {
+            let memOffset := mload(0x40)
+            mstore(0x40, add(memOffset, 32))
+            mstore(memOffset, _value)
+            return(memOffset, 32)
+        }
+    }
+
+    /*
+     * @dev Load a bool value into memory and return it
+     * @param _value Bool value
+     */
+    function mLoadAndReturn(bool _value) private pure {
+        assembly {
+            let memOffset := mload(0x40)
+            mstore(0x40, add(memOffset, 32))
+            mstore(memOffset, _value)
+            return(memOffset, 32)
+        }
+    }
+}

--- a/test/unit/GenesisManager.js
+++ b/test/unit/GenesisManager.js
@@ -1,0 +1,339 @@
+import Fixture from "../helpers/fixture"
+import expectThrow from "../helpers/expectThrow"
+import {functionSig} from "../../utils/helpers"
+
+const GenesisManager = artifacts.require("GenesisManager")
+const GenericMock = artifacts.require("GenericMock")
+
+const Stages = {
+    GenesisAllocation: 0,
+    GenesisStart: 1,
+    GenesisEnd: 2
+}
+
+contract("GenesisManager", accounts => {
+    describe("constructor", () => {
+        it("should set parameters and stage to the allocation stage", async () => {
+            const randomAddress = accounts[0]
+            const genesisManager = await GenesisManager.new(
+                randomAddress,
+                randomAddress,
+                randomAddress,
+                randomAddress
+            )
+
+            const token = await genesisManager.token.call()
+            assert.equal(token, randomAddress, "wrong token address")
+            const tokenDistribution = await genesisManager.token.call()
+            assert.equal(tokenDistribution, randomAddress, "wrong token distribution address")
+            const bankMultisig = await genesisManager.bankMultisig.call()
+            assert.equal(bankMultisig, randomAddress, "wrong bank multisig address")
+            const minter = await genesisManager.minter.call()
+            assert.equal(minter, randomAddress, "wrong minter address")
+            const stage = await genesisManager.stage.call()
+            assert.equal(stage, Stages.GenesisAllocation, "wrong stage")
+        })
+    })
+
+    let fixture
+    let genesisManager
+    let tokenDistribution
+
+    before(async () => {
+        fixture = new Fixture(web3)
+        tokenDistribution = await GenericMock.new()
+
+        const token = await GenericMock.new()
+        const bankMultisig = await GenericMock.new()
+        const minter = await GenericMock.new()
+
+        genesisManager = await GenesisManager.new(
+            token.address,
+            tokenDistribution.address,
+            bankMultisig.address,
+            minter.address
+        )
+    })
+
+    beforeEach(async () => {
+        await fixture.setUp()
+    })
+
+    afterEach(async () => {
+        await fixture.tearDown()
+    })
+
+    describe("setAllocations", () => {
+        it("should fail if sender is not the owner", async () => {
+            await expectThrow(genesisManager.setAllocations(100, 10, 30, 40, 10, 10, {from: accounts[1]}))
+        })
+
+        it("should fail if provided allocations do not sum to provided initial supply", async () => {
+            await expectThrow(genesisManager.setAllocations(100, 20, 20, 20, 20, 25))
+        })
+
+        it("should set supplies based on provided allocations", async () => {
+            await genesisManager.setAllocations(100, 10, 30, 40, 10, 10)
+
+            const initialSupply = await genesisManager.initialSupply.call()
+            assert.equal(initialSupply.toNumber(), 100, "wrong initial supply")
+            const crowdSupply = await genesisManager.crowdSupply.call()
+            assert.equal(crowdSupply.toNumber(), 10, "wrong crowd supply")
+            const companySupply = await genesisManager.companySupply.call()
+            assert.equal(companySupply.toNumber(), 30, "wrong company supply")
+            const teamSupply = await genesisManager.teamSupply.call()
+            assert.equal(teamSupply.toNumber(), 40, "wrong team supply")
+            const investorsSupply = await genesisManager.investorsSupply.call()
+            assert.equal(investorsSupply.toNumber(), 10, "wrong investors supply")
+            const communitySupply = await genesisManager.communitySupply.call()
+            assert.equal(communitySupply.toNumber(), 10, "wrong community supply")
+        })
+
+        it("should fail if it is not the allocation stage", async () => {
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            // Transition to start stage
+            await genesisManager.start()
+
+            await expectThrow(genesisManager.setAllocations(100, 10, 30, 40, 10, 10))
+        })
+    })
+
+    describe("start", () => {
+        it("should fail if sender is not the owner", async () => {
+            await expectThrow(genesisManager.start({from: accounts[1]}))
+        })
+
+        it("should fail if it is not the allocation stage", async () => {
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            // Transition to start stage
+            await genesisManager.start()
+
+            await expectThrow(genesisManager.start())
+        })
+
+        it("should fail if the token distribution is over", async () => {
+            // Set tokenDistribution to be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), true)
+
+            await expectThrow(genesisManager.start())
+        })
+
+        it("should set the stage to the genesis start stage", async () => {
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+
+            const stage = await genesisManager.stage.call()
+            assert.equal(stage, Stages.GenesisStart, "wrong stage")
+        })
+    })
+
+    describe("addTeamGrant", () => {
+        const timeToCliff = 1 * 60 * 60
+        const vestingDuration = 2 * 60 * 60
+
+        it("should fail if sender is not the owner", async () => {
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+
+            await expectThrow(genesisManager.addTeamGrant(accounts[0], 100, timeToCliff, vestingDuration, {from: accounts[1]}))
+        })
+
+        it("should fail if it is not the genesis start stage", async () => {
+            await expectThrow(genesisManager.addTeamGrant(accounts[0], 100, timeToCliff, vestingDuration))
+        })
+
+        it("should fail if amount of grants created > team supply", async () => {
+            await genesisManager.setAllocations(100, 10, 30, 40, 10, 10)
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+            // Set token distribution end time
+            const distributionEndTime = web3.eth.getBlock(web3.eth.blockNumber).timestamp + (1 * 60 * 60)
+            await tokenDistribution.setMockUint256(functionSig("getEndTime()"), distributionEndTime)
+
+            await expectThrow(genesisManager.addTeamGrant(accounts[0], 100, timeToCliff, vestingDuration))
+        })
+
+        it("should fail if the receiver already has a grant", async () => {
+            await genesisManager.setAllocations(100, 10, 30, 40, 10, 10)
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+            // Set token distribution end time
+            const distributionEndTime = web3.eth.getBlock(web3.eth.blockNumber).timestamp + (1 * 60 * 60)
+            await tokenDistribution.setMockUint256(functionSig("getEndTime()"), distributionEndTime)
+            // Receiver gets grant
+            await genesisManager.addTeamGrant(accounts[0], 5, timeToCliff, vestingDuration)
+
+            await expectThrow(genesisManager.addTeamGrant(accounts[0], 4, timeToCliff, vestingDuration))
+        })
+
+        it("should create a TokenVesting address mapped to the receiver", async () => {
+            await genesisManager.setAllocations(100, 10, 30, 40, 10, 10)
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+            // Set token distribution end time
+            const distributionEndTime = web3.eth.getBlock(web3.eth.blockNumber).timestamp + (1 * 60 * 60)
+            await tokenDistribution.setMockUint256(functionSig("getEndTime()"), distributionEndTime)
+
+            await genesisManager.addTeamGrant(accounts[0], 5, timeToCliff, vestingDuration)
+
+            const holder = await genesisManager.vestingHolders.call(accounts[0])
+            assert.notEqual(holder, "0x0000000000000000000000000000000000000000", "missing holder address")
+        })
+    })
+
+    describe("addInvestorGrant", () => {
+        const timeToCliff = 1 * 60 * 60
+        const vestingDuration = 2 * 60 * 60
+
+        it("should fail if sender is not the owner", async () => {
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+
+            await expectThrow(genesisManager.addInvestorGrant(accounts[0], 100, timeToCliff, vestingDuration, {from: accounts[1]}))
+        })
+
+        it("should fail if it is not the genesis start stage", async () => {
+            await expectThrow(genesisManager.addInvestorGrant(accounts[0], 100, timeToCliff, vestingDuration))
+        })
+
+        it("should fail if amount of grants created > team supply", async () => {
+            await genesisManager.setAllocations(100, 10, 30, 40, 10, 10)
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+            // Set token distribution end time
+            await tokenDistribution.setMockUint256(functionSig("getEndTime()"), web3.eth.getBlock(web3.eth.blockNumber).timestamp + (1 * 60 * 60))
+
+            await expectThrow(genesisManager.addInvestorGrant(accounts[0], 100, timeToCliff, vestingDuration))
+        })
+
+        it("should fail if the receiver already has a grant", async () => {
+            await genesisManager.setAllocations(100, 10, 30, 40, 10, 10)
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+            // Set token distribution end time
+            await tokenDistribution.setMockUint256(functionSig("getEndTime()"), web3.eth.getBlock(web3.eth.blockNumber).timestamp + (1 * 60 * 60))
+            // Receiver gets grant
+            await genesisManager.addInvestorGrant(accounts[0], 5, timeToCliff, vestingDuration)
+
+            await expectThrow(genesisManager.addInvestorGrant(accounts[0], 4, timeToCliff, vestingDuration))
+        })
+
+        it("should create a TokenVesting contract mapped to the receiver", async () => {
+            await genesisManager.setAllocations(100, 10, 30, 40, 10, 10)
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+            const distributionEndTime = web3.eth.getBlock(web3.eth.blockNumber).timestamp + (1 * 60 * 60)
+            // Set token distribution end time
+            await tokenDistribution.setMockUint256(functionSig("getEndTime()"), distributionEndTime)
+
+            await genesisManager.addInvestorGrant(accounts[0], 5, timeToCliff, vestingDuration)
+
+            const holder = await genesisManager.vestingHolders.call(accounts[0])
+            assert.notEqual(holder !== "0x0000000000000000000000000000000000000000", "missing holder address")
+        })
+    })
+
+    describe("addCommunityGrant", () => {
+        it("should fail if sender is not the owner", async () => {
+            await expectThrow(genesisManager.addCommunityGrant(accounts[0], 10, {from: accounts[1]}))
+        })
+
+        it("should fail if it is not the genesis start stage", async () => {
+            await expectThrow(genesisManager.addCommunityGrant(accounts[0], 10))
+        })
+
+        it("should fail if amount of grants created > community supply", async () => {
+            await genesisManager.setAllocations(100, 10, 30, 40, 10, 10)
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+
+            await expectThrow(genesisManager.addCommunityGrant(accounts[0], 100))
+        })
+
+        it("should update the amount of grants created", async () => {
+            await genesisManager.setAllocations(100, 10, 30, 40, 10, 10)
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+            // Set token distribution end time
+            const distributionEndTime = web3.eth.getBlock(web3.eth.blockNumber).timestamp + (1 * 60 * 60)
+            await tokenDistribution.setMockUint256(functionSig("getEndTime()"), distributionEndTime)
+
+            await genesisManager.addCommunityGrant(accounts[0], 10)
+
+            const amount = await genesisManager.communityGrantsAmount.call()
+            assert.equal(amount.toNumber(), 10, "wrong community grants amount")
+        })
+
+        it("should fail if the receiver already has a grant", async () => {
+            await genesisManager.setAllocations(100, 10, 30, 40, 10, 10)
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+            // Set token distribution end time
+            const distributionEndTime = web3.eth.getBlock(web3.eth.blockNumber).timestamp + (1 * 60 * 60)
+            await tokenDistribution.setMockUint256(functionSig("getEndTime()"), distributionEndTime)
+            await genesisManager.addCommunityGrant(accounts[0], 5)
+
+            await expectThrow(genesisManager.addCommunityGrant(accounts[0], 4))
+        })
+
+        it("should create a TokenTimelock address mapped to the receiver", async () => {
+            await genesisManager.setAllocations(100, 10, 30, 40, 10, 10)
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+            // Set token distribution end time
+            const distributionEndTime = web3.eth.getBlock(web3.eth.blockNumber).timestamp + (1 * 60 * 60)
+            await tokenDistribution.setMockUint256(functionSig("getEndTime()"), distributionEndTime)
+
+            await genesisManager.addCommunityGrant(accounts[0], 5)
+
+            const holder = await genesisManager.timeLockedHolders.call(accounts[0])
+            assert.notEqual(holder, "0x0000000000000000000000000000000000000000", "missing holder address")
+        })
+    })
+
+    describe("end", () => {
+        it("should fail if sender is not the owner", async () => {
+            await expectThrow(genesisManager.end({from: accounts[1]}))
+        })
+
+        it("should fail if it is not the genesis start stage", async () => {
+            await expectThrow(genesisManager.end())
+        })
+
+        it("should fail if token distribution is not over", async () => {
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+
+            await expectThrow(genesisManager.end())
+        })
+
+        it("should set the stage to genesis end", async () => {
+            // Set tokenDistribution to not be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), false)
+            await genesisManager.start()
+            // Set tokenDistribution to be over
+            await tokenDistribution.setMockBool(functionSig("isOver()"), true)
+
+            await genesisManager.end()
+
+            const stage = await genesisManager.stage.call()
+            assert.equal(stage, Stages.GenesisEnd, "wrong stage")
+        })
+    })
+})


### PR DESCRIPTION
- GenericMock contract that is meant to be used for mocking out any return values that a contract depends on from another contract. Ideally, we can switch to using this in all of our tests once I tweak it a little more rather than having a bunch of different mock contracts
- GenesisManager unit test

Integration test for genesis state to come separately