### PR TITLE
Fix job assignment

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -522,7 +522,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * Returns address of elected active transcoder and its price per segment
      * @param _maxPricePerSegment Max price (in LPT base units) per segment of a stream
      */
-    function electActiveTranscoder(uint256 _maxPricePerSegment, uint256 _block, uint256 _round) external view returns (address) {
+    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _challengeHash, uint256 _round) external view returns (address) {
         uint256 activeSetSize = activeTranscoderSet[_round].transcoders.length;
         // Create array to store available transcoders charging an acceptable price per segment
         address[] memory availableTranscoders = new address[](activeSetSize);
@@ -548,7 +548,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             address electedTranscoder = availableTranscoders[numAvailableTranscoders - 1];
 
             // Pseudorandomly pick an available transcoder weighted by its stake relative to the total stake of all available transcoders
-            uint256 r = uint256(roundsManager().blockHash(_block)) % totalAvailableTranscoderStake;
+            uint256 r = uint256(_challengeHash) % totalAvailableTranscoderStake;
             uint256 s = 0;
 
             for (uint256 j = 0; j < numAvailableTranscoders; j++) {

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -521,8 +521,10 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * @dev Pseudorandomly elect a currently active transcoder that charges a price per segment less than or equal to the max price per segment for a job
      * Returns address of elected active transcoder and its price per segment
      * @param _maxPricePerSegment Max price (in LPT base units) per segment of a stream
+     * @param _blockHash Job creation block hash used as a pseudorandom seed for assigning an active transcoder
+     * @param _round Job creation round
      */
-    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _rand, uint256 _round) external view returns (address) {
+    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _blockHash, uint256 _round) external view returns (address) {
         uint256 activeSetSize = activeTranscoderSet[_round].transcoders.length;
         // Create array to store available transcoders charging an acceptable price per segment
         address[] memory availableTranscoders = new address[](activeSetSize);
@@ -548,7 +550,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             address electedTranscoder = availableTranscoders[numAvailableTranscoders - 1];
 
             // Pseudorandomly pick an available transcoder weighted by its stake relative to the total stake of all available transcoders
-            uint256 r = uint256(_rand) % totalAvailableTranscoderStake;
+            uint256 r = uint256(_blockHash) % totalAvailableTranscoderStake;
             uint256 s = 0;
 
             for (uint256 j = 0; j < numAvailableTranscoders; j++) {

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -548,7 +548,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             address electedTranscoder = availableTranscoders[numAvailableTranscoders - 1];
 
             // Pseudorandomly pick an available transcoder weighted by its stake relative to the total stake of all available transcoders
-            uint256 r = uint256(block.blockhash(_block)) % totalAvailableTranscoderStake;
+            uint256 r = uint256(roundsManager().blockHash(_block)) % totalAvailableTranscoderStake;
             uint256 s = 0;
 
             for (uint256 j = 0; j < numAvailableTranscoders; j++) {

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -522,7 +522,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * Returns address of elected active transcoder and its price per segment
      * @param _maxPricePerSegment Max price (in LPT base units) per segment of a stream
      */
-    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _challengeHash, uint256 _round) external view returns (address) {
+    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _rand, uint256 _round) external view returns (address) {
         uint256 activeSetSize = activeTranscoderSet[_round].transcoders.length;
         // Create array to store available transcoders charging an acceptable price per segment
         address[] memory availableTranscoders = new address[](activeSetSize);
@@ -548,7 +548,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             address electedTranscoder = availableTranscoders[numAvailableTranscoders - 1];
 
             // Pseudorandomly pick an available transcoder weighted by its stake relative to the total stake of all available transcoders
-            uint256 r = uint256(_challengeHash) % totalAvailableTranscoderStake;
+            uint256 r = uint256(_rand) % totalAvailableTranscoderStake;
             uint256 s = 0;
 
             for (uint256 j = 0; j < numAvailableTranscoders; j++) {

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -20,7 +20,7 @@ contract IBondingManager {
     function setActiveTranscoders() external;
     function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external;
     function slashTranscoder(address _transcoder, address _finder, uint256 _slashAmount, uint256 _finderFee) external;
-    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _challengeHash, uint256 _round) external view returns (address);
+    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _rand, uint256 _round) external view returns (address);
 
     // Public functions
     function transcoderTotalStake(address _transcoder) public view returns (uint256);

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -20,7 +20,7 @@ contract IBondingManager {
     function setActiveTranscoders() external;
     function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external;
     function slashTranscoder(address _transcoder, address _finder, uint256 _slashAmount, uint256 _finderFee) external;
-    function electActiveTranscoder(uint256 _maxPricePerSegment, uint256 _block, uint256 _round) external view returns (address);
+    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _challengeHash, uint256 _round) external view returns (address);
 
     // Public functions
     function transcoderTotalStake(address _transcoder) public view returns (uint256);

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -20,7 +20,7 @@ contract IBondingManager {
     function setActiveTranscoders() external;
     function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external;
     function slashTranscoder(address _transcoder, address _finder, uint256 _slashAmount, uint256 _finderFee) external;
-    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _rand, uint256 _round) external view returns (address);
+    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _blockHash, uint256 _round) external view returns (address);
 
     // Public functions
     function transcoderTotalStake(address _transcoder) public view returns (uint256);

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -392,10 +392,10 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         require(job.transcoderAddress == msg.sender);
 
         uint256 blockNum = roundsManager().blockNum();
-        // Claim block + 1 must be within the last 256 blocks from the current block
-        require(blockNum < 256 || claim.claimBlock + 1 >= blockNum - 256);
+        uint256 challengeBlock = claim.claimBlock + 1;
         // Segment must be eligible for verification
-        require(JobLib.shouldVerifySegment(_segmentNumber, claim.segmentRange, claim.claimBlock + 1, roundsManager().blockHash(claim.claimBlock + 1), verificationRate));
+        // roundsManager().blockHash() ensures that the challenge block is within the last 256 blocks from the current block
+        require(JobLib.shouldVerifySegment(_segmentNumber, claim.segmentRange, challengeBlock, roundsManager().blockHash(challengeBlock), verificationRate));
         // Segment must be signed by broadcaster
         require(
             JobLib.validateBroadcasterSig(
@@ -524,16 +524,16 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         Claim storage claim = job.claims[_claimId];
 
         uint256 blockNum = roundsManager().blockNum();
+        uint256 challengeBlock = claim.claimBlock + 1;
         // Must be after verification period
         require(blockNum > claim.endVerificationBlock);
         // Must be before end of slashing period
         require(blockNum <= claim.endSlashingBlock);
         // Claim must be pending
         require(claim.status == ClaimStatus.Pending);
-        // Claim block + 1 must be within the last 256 blocks from the current block
-        require(blockNum < 256 || claim.claimBlock >= blockNum - 256);
         // Segment must be eligible for verification
-        require(JobLib.shouldVerifySegment(_segmentNumber, claim.segmentRange, claim.claimBlock + 1, roundsManager().blockHash(claim.claimBlock + 1), verificationRate));
+        // roundsManager().blockHash() ensures that the challenge block is within the last 256 blocks from the current block
+        require(JobLib.shouldVerifySegment(_segmentNumber, claim.segmentRange, challengeBlock, roundsManager().blockHash(challengeBlock), verificationRate));
         // Transcoder must have missed verification for the segment
         require(!claim.segmentVerifications[_segmentNumber]);
 

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -327,9 +327,11 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
             // the assigned transcoder
             require(job.transcoderAddress == msg.sender);
         } else {
-            // If transcoder is not already assigned, check if sender
-            // should be assigned and that job creation block has been mined and it has been <= 256 blocks since the job creation block
-            require(blockNum > job.creationBlock && blockNum <= job.creationBlock + 256 && bondingManager().electActiveTranscoder(job.maxPricePerSegment, job.creationBlock, job.creationRound) == msg.sender);
+            // If transcoder is not already assigned, check if sender should be assigned
+            // roundsManager.blockHash() will ensure that the job creation block has been mined and it has not
+            // been more than 256 blocks since the creation block
+            require(bondingManager().electActiveTranscoder(job.maxPricePerSegment, roundsManager().blockHash(job.creationBlock), job.creationRound) == msg.sender);
+
             job.transcoderAddress = msg.sender;
         }
 

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -393,7 +393,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         // Claim block + 1 must be within the last 256 blocks from the current block
         require(blockNum < 256 || claim.claimBlock + 1 >= blockNum - 256);
         // Segment must be eligible for verification
-        require(JobLib.shouldVerifySegment(_segmentNumber, claim.segmentRange, claim.claimBlock, verificationRate));
+        require(JobLib.shouldVerifySegment(_segmentNumber, claim.segmentRange, claim.claimBlock + 1, roundsManager().blockHash(claim.claimBlock + 1), verificationRate));
         // Segment must be signed by broadcaster
         require(
             JobLib.validateBroadcasterSig(
@@ -531,7 +531,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         // Claim block + 1 must be within the last 256 blocks from the current block
         require(blockNum < 256 || claim.claimBlock >= blockNum - 256);
         // Segment must be eligible for verification
-        require(JobLib.shouldVerifySegment(_segmentNumber, claim.segmentRange, claim.claimBlock, verificationRate));
+        require(JobLib.shouldVerifySegment(_segmentNumber, claim.segmentRange, claim.claimBlock + 1, roundsManager().blockHash(claim.claimBlock + 1), verificationRate));
         // Transcoder must have missed verification for the segment
         require(!claim.segmentVerifications[_segmentNumber]);
 

--- a/contracts/jobs/libraries/JobLib.sol
+++ b/contracts/jobs/libraries/JobLib.sol
@@ -31,17 +31,19 @@ library JobLib {
      * Computes whether a segment is eligible for verification based on the last call to claimWork()
      * @param _segmentNumber Sequence number of segment in stream
      * @param _segmentRange Range of segments claimed
-     * @param _claimBlock Block when claimWork() was called
+     * @param _challengeBlock Block afer the block when claimWork() was called
+     * @param _challengeBlockHash Block hash of challenge block
      * @param _verificationRate Rate at which a particular segment should be verified
      */
     function shouldVerifySegment(
         uint256 _segmentNumber,
         uint256[2] _segmentRange,
-        uint256 _claimBlock,
+        uint256 _challengeBlock,
+        bytes32 _challengeBlockHash,
         uint64 _verificationRate
     )
         public
-        view
+        pure
         returns (bool)
     {
         // Segment must be in segment range
@@ -51,7 +53,7 @@ library JobLib {
 
         // Use block hash and block number of the block after a claim to determine if a segment
         // should be verified
-        if (uint256(keccak256(_claimBlock + 1, block.blockhash(_claimBlock + 1), _segmentNumber)) % _verificationRate == 0) {
+        if (uint256(keccak256(_challengeBlock, _challengeBlockHash, _segmentNumber)) % _verificationRate == 0) {
             return true;
         } else {
             return false;

--- a/contracts/rounds/AdjustableRoundsManager.sol
+++ b/contracts/rounds/AdjustableRoundsManager.sol
@@ -26,6 +26,8 @@ contract AdjustableRoundsManager is RoundsManager {
     }
 
     function blockHash(uint256 _block) public view returns (bytes32) {
+        require(_block <= blockNum() - 256);
+
         return hash;
     }
 }

--- a/contracts/rounds/AdjustableRoundsManager.sol
+++ b/contracts/rounds/AdjustableRoundsManager.sol
@@ -5,11 +5,16 @@ import "./RoundsManager.sol";
 
 contract AdjustableRoundsManager is RoundsManager {
     uint256 num;
+    bytes32 hash;
 
     function AdjustableRoundsManager(address _controller) public RoundsManager(_controller) {}
 
     function setBlockNum(uint256 _num) external {
         num = _num;
+    }
+
+    function setBlockHash(bytes32 _hash) external {
+        hash = _hash;
     }
 
     function mineBlocks(uint256 _blocks) external {
@@ -18,5 +23,9 @@ contract AdjustableRoundsManager is RoundsManager {
 
     function blockNum() public view returns (uint256) {
         return num;
+    }
+
+    function blockHash(uint256 _block) public view returns (bytes32) {
+        return hash;
     }
 }

--- a/contracts/rounds/IRoundsManager.sol
+++ b/contracts/rounds/IRoundsManager.sol
@@ -12,6 +12,7 @@ contract IRoundsManager {
 
     // Public functions
     function blockNum() public view returns (uint256);
+    function blockHash(uint256 _block) public view returns (bytes32);
     function currentRound() public view returns (uint256);
     function currentRoundStartBlock() public view returns (uint256);
     function currentRoundInitialized() public view returns (bool);

--- a/contracts/rounds/RoundsManager.sol
+++ b/contracts/rounds/RoundsManager.sol
@@ -83,6 +83,12 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
      * @dev Return blockhash for a block
      */
     function blockHash(uint256 _block) public view returns (bytes32) {
+        uint256 currentBlock = blockNum();
+        // Can only retrieve past block hashes
+        require(_block < currentBlock);
+        // Can only retrieve hashes for last 256 blocks
+        require(currentBlock < 256 || _block >= currentBlock - 256);
+
         return block.blockhash(_block);
     }
 

--- a/contracts/rounds/RoundsManager.sol
+++ b/contracts/rounds/RoundsManager.sol
@@ -80,6 +80,13 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
     }
 
     /*
+     * @dev Return blockhash for a block
+     */
+    function blockHash(uint256 _block) public view returns (bytes32) {
+        return block.blockhash(_block);
+    }
+
+    /*
      * @dev Return current round
      */
     function currentRound() public view returns (uint256) {

--- a/contracts/test/BondingManagerMock.sol
+++ b/contracts/test/BondingManagerMock.sol
@@ -62,7 +62,7 @@ contract BondingManagerMock is IBondingManager {
 
     function slashTranscoder(address _transcoder, address _finder, uint256 _slashAmount, uint256 _finderFee) external {}
 
-    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _challengeHash, uint256 _round) external view returns (address) {
+    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _rand, uint256 _round) external view returns (address) {
         return transcoder;
     }
 

--- a/contracts/test/BondingManagerMock.sol
+++ b/contracts/test/BondingManagerMock.sol
@@ -62,7 +62,7 @@ contract BondingManagerMock is IBondingManager {
 
     function slashTranscoder(address _transcoder, address _finder, uint256 _slashAmount, uint256 _finderFee) external {}
 
-    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _rand, uint256 _round) external view returns (address) {
+    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _blockHash, uint256 _round) external view returns (address) {
         return transcoder;
     }
 

--- a/contracts/test/BondingManagerMock.sol
+++ b/contracts/test/BondingManagerMock.sol
@@ -62,7 +62,7 @@ contract BondingManagerMock is IBondingManager {
 
     function slashTranscoder(address _transcoder, address _finder, uint256 _slashAmount, uint256 _finderFee) external {}
 
-    function electActiveTranscoder(uint256 _maxPricePerSegment, uint256 _block, uint256 _round) external view returns (address) {
+    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _challengeHash, uint256 _round) external view returns (address) {
         return transcoder;
     }
 

--- a/contracts/test/GenericMock.sol
+++ b/contracts/test/GenericMock.sol
@@ -25,6 +25,7 @@ contract GenericMock {
      * @param _data Transaction data to be used to call the target contract
      */
     function execute(address _target, bytes _data) external returns (bool) {
+        // solium-disable security/no-low-level-calls
         return _target.call(_data);
     }
 

--- a/contracts/test/RoundsManagerMock.sol
+++ b/contracts/test/RoundsManagerMock.sol
@@ -10,6 +10,7 @@ contract RoundsManagerMock is IRoundsManager {
     IMinter minter;
 
     uint256 public blockNum;
+    bytes32 public blockHash;
     uint256 public currentRound;
     uint256 public currentRoundStartBlock;
     bool public currentRoundInitialized;
@@ -53,6 +54,10 @@ contract RoundsManagerMock is IRoundsManager {
 
     function blockNum() public view returns (uint256) {
         return blockNum;
+    }
+
+    function blockHash(uint256 _block) public view returns (bytes32) {
+        return blockHash;
     }
 
     function currentRound() public view returns (uint256) {

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "ganache": "./node_modules/.bin/ganache-cli -l 0x663BE0",
     "compile": "rm -rf build/contracts && truffle compile --all",
     "test:unit": "bash scripts/run_ganache.sh && truffle test test/unit/*",
-    "test:integration": "truffle test test/integration/Delegation.js && truffle test test/integration/JobAssignment.js",
+    "test:integration": "truffle test truffle test test/integration/*",
     "docker:build": "docker build --cache-from livepeer/protocol:latest --tag livepeer/protocol:latest -f Dockerfile .",
     "docker:push": "docker push livepeer/protocol:latest",
     "docker:run:lint": "docker run --rm --entrypoint=npm livepeer/protocol:latest run lint",
     "docker:run:test:unit": "docker run --rm --entrypoint=npm livepeer/protocol:latest run test:unit",
-    "docker:run:test:integration": "bash scripts/run_integration_tests.sh"
+    "docker:run:test:integration": "docker run --rm --entrypoint=npm livepeer/protocol:latest run test:integration"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ganache": "./node_modules/.bin/ganache-cli -l 0x663BE0",
     "compile": "rm -rf build/contracts && truffle compile --all",
     "test:unit": "bash scripts/run_ganache.sh && truffle test test/unit/*",
-    "test:integration": "truffle test truffle test test/integration/*",
+    "test:integration": "truffle test test/integration/*",
     "docker:build": "docker build --cache-from livepeer/protocol:latest --tag livepeer/protocol:latest -f Dockerfile .",
     "docker:push": "docker push livepeer/protocol:latest",
     "docker:run:lint": "docker run --rm --entrypoint=npm livepeer/protocol:latest run lint",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ganache": "./node_modules/.bin/ganache-cli -l 0x663BE0",
     "compile": "rm -rf build/contracts && truffle compile --all",
     "test:unit": "bash scripts/run_ganache.sh && truffle test test/unit/*",
-    "test:integration": "truffle test test/integration/*",
+    "test:integration": "truffle test test/integration/Delegation.js && truffle test test/integration/JobAssignment.js",
     "docker:build": "docker build --cache-from livepeer/protocol:latest --tag livepeer/protocol:latest -f Dockerfile .",
     "docker:push": "docker push livepeer/protocol:latest",
     "docker:run:lint": "docker run --rm --entrypoint=npm livepeer/protocol:latest run lint",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ganache": "./node_modules/.bin/ganache-cli -l 0x663BE0",
     "compile": "rm -rf build/contracts && truffle compile --all",
     "test:unit": "bash scripts/run_ganache.sh && truffle test test/unit/*",
-    "test:integration": "truffle test test/integration/*",
+    "test:integration": "bash scripts/run_ganache.sh && truffle test test/integration/*",
     "docker:build": "docker build --cache-from livepeer/protocol:latest --tag livepeer/protocol:latest -f Dockerfile .",
     "docker:push": "docker push livepeer/protocol:latest",
     "docker:run:lint": "docker run --rm --entrypoint=npm livepeer/protocol:latest run lint",

--- a/test/integration/JobAssignment.js
+++ b/test/integration/JobAssignment.js
@@ -1,0 +1,218 @@
+import {contractId} from "../../utils/helpers"
+
+const Controller = artifacts.require("Controller")
+const BondingManager = artifacts.require("BondingManager")
+const JobsManager = artifacts.require("JobsManager")
+const AdjustableRoundsManager = artifacts.require("AdjustableRoundsManager")
+const LivepeerToken = artifacts.require("LivepeerToken")
+const LivepeerTokenFaucet = artifacts.require("LivepeerTokenFaucet")
+
+contract("JobAssignment", accounts => {
+    let controller
+    let bondingManager
+    let jobsManager
+    let roundsManager
+    let token
+
+    let transcoder1
+    let transcoder2
+    let transcoder3
+    let broadcaster
+
+    let roundLength
+
+    before(async () => {
+        transcoder1 = accounts[0]
+        transcoder2 = accounts[1]
+        transcoder3 = accounts[2]
+        broadcaster = accounts[3]
+
+        controller = await Controller.deployed()
+
+        const bondingManagerAddr = await controller.getContract(contractId("BondingManager"))
+        bondingManager = await BondingManager.at(bondingManagerAddr)
+
+        const jobsManagerAddr = await controller.getContract(contractId("JobsManager"))
+        jobsManager = await JobsManager.at(jobsManagerAddr)
+
+        const roundsManagerAddr = await controller.getContract(contractId("RoundsManager"))
+        roundsManager = await AdjustableRoundsManager.at(roundsManagerAddr)
+
+        const tokenAddr = await controller.getContract(contractId("LivepeerToken"))
+        token = await LivepeerToken.at(tokenAddr)
+
+        const faucetAddr = await controller.getContract(contractId("LivepeerTokenFaucet"))
+        const faucet = await LivepeerTokenFaucet.at(faucetAddr)
+
+        await faucet.request({from: transcoder1})
+        await faucet.request({from: transcoder2})
+        await faucet.request({from: transcoder3})
+
+        roundLength = await roundsManager.roundLength.call()
+
+        await roundsManager.setBlockNum(roundLength.toNumber())
+        await roundsManager.initializeRound()
+
+        // Register and bond transcoder 1 with 50% of the total active stake
+        await token.approve(bondingManager.address, 50000, {from: transcoder1})
+        await bondingManager.bond(50000, transcoder1, {from: transcoder1})
+        await bondingManager.transcoder(10, 5, 5, {from: transcoder1})
+
+        // Register and bond transcoder 2 with 30% of the total active stake
+        await token.approve(bondingManager.address, 30000, {from: transcoder2})
+        await bondingManager.bond(30000, transcoder2, {from: transcoder2})
+        await bondingManager.transcoder(10, 5, 1, {from: transcoder2})
+
+        // Register and bond transcoder 3 with 20% of the total active stake
+        await token.approve(bondingManager.address, 20000, {from: transcoder3})
+        await bondingManager.bond(20000, transcoder3, {from: transcoder3})
+        await bondingManager.transcoder(10, 5, 1, {from: transcoder3})
+
+        // Initialize new round and initialize new active transcoder set
+        await roundsManager.mineBlocks(roundLength.toNumber())
+        await roundsManager.initializeRound()
+    })
+
+    it("assign transcoders to jobs proportionally weighted by stake", async () => {
+        let transcoder1JobCount = 0
+        let transcoder2JobCount = 0
+        let transcoder3JobCount = 0
+        let nullAddressJobCount = 0
+
+        const streamId = "foo"
+        const transcodingOptions = "0x123"
+        const maxPricePerSegment = 10
+        const endBlock = (await roundsManager.blockNum()).add(1000)
+
+        // Broadcaster makes a deposit for jobs
+        await jobsManager.deposit({from: broadcaster, value: 100000})
+
+        let job
+        let jobCreationBlock
+        let jobCreationRound
+        let challengeHash
+        let electedTranscoder
+
+        let numJobs = 0
+
+        while (numJobs < 100) {
+            // Set challenge hash
+            challengeHash = web3.eth.getBlock(web3.eth.blockNumber).hash
+            await roundsManager.setBlockHash(challengeHash)
+
+            await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, endBlock)
+            job = await jobsManager.getJob(numJobs)
+            jobCreationBlock = job[6]
+            jobCreationRound = job[5]
+
+            electedTranscoder = await bondingManager.electActiveTranscoder(maxPricePerSegment, jobCreationBlock, jobCreationRound)
+
+            switch (electedTranscoder) {
+              case transcoder1:
+                  transcoder1JobCount++
+                  break
+              case transcoder2:
+                  transcoder2JobCount++
+                  break
+              case transcoder3:
+                  transcoder3JobCount++
+                  break
+              default:
+                  nullAddressJobCount++
+                  break
+            }
+
+            await roundsManager.mineBlocks(1)
+
+            if (!(await roundsManager.currentRoundInitialized())) {
+                await roundsManager.initializeRound()
+            }
+
+            numJobs++
+        }
+
+        const transcoder1JobShare = transcoder1JobCount / numJobs
+        const transcoder2JobShare = transcoder2JobCount / numJobs
+        const transcoder3JobShare = transcoder3JobCount / numJobs
+        const acceptableDelta = .1
+
+        assert.equal(nullAddressJobCount, 0, "should not be any unassigned jobs")
+        assert.isAbove(transcoder1JobShare, transcoder2JobShare, "transcoder 1 job share should be > transcoder 2 job share")
+        assert.isAbove(transcoder2JobShare, transcoder3JobShare, "transcoder 2 job share should be > transcdoer 3 job share")
+        assert.isAtMost(Math.abs(transcoder1JobShare - .5), acceptableDelta, "transcoder 1 job share not within acceptable delta")
+        assert.isAtMost(Math.abs(transcoder2JobShare - .3), acceptableDelta, "transcoder 2 job share not within acceptable delta")
+        assert.isAtMost(Math.abs(transcoder3JobShare - .2), acceptableDelta, "transcoder 3 job share not within acceptable delta")
+    })
+
+    it("excludes transcoders if the broadcast price is too low", async () => {
+        // Transcoder 1 increases its price
+        await bondingManager.transcoder(10, 5, 100, {from: transcoder1})
+        // Initialize new round and update pricing for active transcoder set
+        await roundsManager.mineBlocks(roundLength.toNumber())
+        await roundsManager.initializeRound()
+
+        let transcoder1JobCount = 0
+        let transcoder2JobCount = 0
+        let transcoder3JobCount = 0
+        let nullAddressJobCount = 0
+
+        const streamId = "foo"
+        const transcodingOptions = "0x123"
+        const maxPricePerSegment = 1
+        const endBlock = (await roundsManager.blockNum()).add(1000)
+
+        let job
+        let jobCreationBlock
+        let jobCreationRound
+        let challengeHash
+        let electedTranscoder
+
+        let numJobs = 0
+
+        while (numJobs < 50) {
+            // Set challenge hash
+            challengeHash = web3.eth.getBlock(web3.eth.blockNumber).hash
+            await roundsManager.setBlockHash(challengeHash)
+
+            await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, endBlock)
+            job = await jobsManager.getJob(numJobs)
+            jobCreationBlock = job[6]
+            jobCreationRound = job[5]
+
+            electedTranscoder = await bondingManager.electActiveTranscoder(maxPricePerSegment, jobCreationBlock, jobCreationRound)
+
+            switch (electedTranscoder) {
+              case transcoder1:
+                  transcoder1JobCount++
+                  break
+              case transcoder2:
+                  transcoder2JobCount++
+                  break
+              case transcoder3:
+                  transcoder3JobCount++
+                  break
+              default:
+                  nullAddressJobCount++
+                  break
+            }
+
+            await roundsManager.mineBlocks(1)
+
+            if (!(await roundsManager.currentRoundInitialized())) {
+                await roundsManager.initializeRound()
+            }
+
+            numJobs++
+        }
+
+        const transcoder2JobShare = transcoder2JobCount / numJobs
+        const transcoder3JobShare = transcoder3JobCount / numJobs
+        const acceptableDelta = .1
+
+        assert.equal(nullAddressJobCount, 0, "should not be any unassigned jobs")
+        assert.equal(transcoder1JobCount, 0, "transcoder 1 should not be assigned jobs if its price is too high")
+        assert.isAbove(transcoder2JobShare, transcoder3JobShare, "transcoder 2 job share should be > transcoder 3 job share")
+        assert.isAtMost(Math.abs(transcoder2JobShare - .6), acceptableDelta, "transcoder 2 job share not within acceptable delta")
+        assert.isAtMost(Math.abs(transcoder3JobShare - .4), acceptableDelta, "transcoder 3 job share not within acceptable delta")
+    })
+})

--- a/test/integration/JobAssignment.js
+++ b/test/integration/JobAssignment.js
@@ -90,22 +90,22 @@ contract("JobAssignment", accounts => {
         let jobID
         let job
         let jobCreationRound
-        let challengeHash
+        let rand
         let electedTranscoder
 
         let jobsCreated = 0
 
         while (jobsCreated < 100) {
-            // Set challenge hash
-            challengeHash = web3.eth.getBlock(web3.eth.blockNumber).hash
-            await roundsManager.setBlockHash(challengeHash)
+            // Set rand hash
+            rand = web3.eth.getBlock(web3.eth.blockNumber).hash
+            await roundsManager.setBlockHash(rand)
 
             await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, endBlock)
             jobID = (await jobsManager.numJobs.call()).sub(1)
             job = await jobsManager.getJob(jobID)
             jobCreationRound = job[5]
 
-            electedTranscoder = await bondingManager.electActiveTranscoder(maxPricePerSegment, challengeHash, jobCreationRound)
+            electedTranscoder = await bondingManager.electActiveTranscoder(maxPricePerSegment, rand, jobCreationRound)
 
             switch (electedTranscoder) {
               case transcoder1:
@@ -164,22 +164,22 @@ contract("JobAssignment", accounts => {
         let jobID
         let job
         let jobCreationRound
-        let challengeHash
+        let rand
         let electedTranscoder
 
         let jobsCreated = 0
 
         while (jobsCreated < 5) {
-            // Set challenge hash
-            challengeHash = web3.eth.getBlock(web3.eth.blockNumber).hash
-            await roundsManager.setBlockHash(challengeHash)
+            // Set rand hash
+            rand = web3.eth.getBlock(web3.eth.blockNumber).hash
+            await roundsManager.setBlockHash(rand)
 
             await jobsManager.job(streamId, transcodingOptions, maxPricePerSegment, endBlock)
             jobID = (await jobsManager.numJobs.call()).sub(1)
             job = await jobsManager.getJob(jobID)
             jobCreationRound = job[5]
 
-            electedTranscoder = await bondingManager.electActiveTranscoder(maxPricePerSegment, challengeHash, jobCreationRound)
+            electedTranscoder = await bondingManager.electActiveTranscoder(maxPricePerSegment, rand, jobCreationRound)
 
             switch (electedTranscoder) {
               case transcoder1:

--- a/test/unit/JobsManager.js
+++ b/test/unit/JobsManager.js
@@ -207,13 +207,6 @@ contract("JobsManager", accounts => {
             await expectThrow(jobsManager.claimWork(jobId, segmentRange, claimRoot, {from: accounts[2]}))
         })
 
-        it("should fail if the transcoder is not assigned and it has been more than 256 blocks since the job creation block", async () => {
-            const creationBlock = (await jobsManager.getJob(jobId))[6]
-            await fixture.roundsManager.mineBlocks(256 - (100 - creationBlock.toNumber()))
-
-            await expectThrow(jobsManager.claimWork(jobId, segmentRange, claimRoot, {from: electedTranscoder}))
-        })
-
         it("should fail if the sender should not be assigned the job", async () => {
             // Account 2 (not elected transcoder) claims work
             await expectThrow(jobsManager.claimWork(jobId, segmentRange, claimRoot, {from: accounts[2]}))


### PR DESCRIPTION
Fixes #147 

Implements solution #3 described in the issue. The Go client will require a small change to pass in the job creation block hash instead of the job creation block number as well. Includes an integration test for job assignment (the test might be flaky sometimes because it runs a bunch of trials and computes the percentage of assigned jobs for each transcoder and compares the computed percentage against the expected percentage with some acceptable delta)