### PR TITLE
Enforce transcoders to be self-bonded

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -170,12 +170,17 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         // Fee share must be a valid percentage
         require(MathUtils.validPerc(_feeShare));
 
+        Delegator storage del = delegators[msg.sender];
+
+        // Must be bonded to self
+        require(del.delegateAddress == msg.sender);
+
         Transcoder storage t = transcoders[msg.sender];
         t.pendingBlockRewardCut = _blockRewardCut;
         t.pendingFeeShare = _feeShare;
         t.pendingPricePerSegment = _pricePerSegment;
 
-        uint256 delegatedAmount = delegators[msg.sender].delegatedAmount;
+        uint256 delegatedAmount = del.delegatedAmount;
 
         // Check if transcoder is not already registered
         if (transcoderStatus(msg.sender) == TranscoderStatus.NotRegistered) {
@@ -195,29 +200,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         }
 
         TranscoderUpdate(msg.sender, _blockRewardCut, _feeShare, _pricePerSegment);
-    }
-
-    /*
-     * @dev Remove the sender as a transcoder
-     */
-    function resignAsTranscoder()
-        external
-        whenSystemNotPaused
-        currentRoundInitialized
-    {
-        // Sender must be registered transcoder
-        require(transcoderStatus(msg.sender) == TranscoderStatus.Registered);
-
-        uint256 currentRound = roundsManager().currentRound();
-        if (activeTranscoderSet[currentRound].isActive[msg.sender]) {
-            // If transcoder is active for the round set it as inactive
-            activeTranscoderSet[currentRound].isActive[msg.sender] = false;
-        }
-
-        // Remove transcoder from pools
-        transcoderPool.remove(msg.sender);
-
-        TranscoderResigned(msg.sender);
     }
 
     /**
@@ -316,12 +298,18 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             transcoderPool.updateKey(del.delegateAddress, transcoderPool.getKey(del.delegateAddress).sub(del.bondedAmount), address(0), address(0));
         }
 
-        Unbond(del.delegateAddress, msg.sender);
-
         // Delegator no longer bonded to anyone
         del.delegateAddress = address(0);
         // Unbonding delegator does not have a start round
         del.startRound = 0;
+
+        // If caller is a registered transcoder, resign
+        // In the future, with partial unbonding there would be a check for 0 bonded stake as well
+        if (transcoderStatus(msg.sender) == TranscoderStatus.Registered) {
+            resignTranscoder(msg.sender);
+        }
+
+        Unbond(del.delegateAddress, msg.sender);
     }
 
     /**
@@ -802,6 +790,22 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      */
     function isActiveTranscoder(address _transcoder, uint256 _round) public view returns (bool) {
         return activeTranscoderSet[_round].isActive[_transcoder];
+    }
+
+    /*
+     * @dev Remove transcoder
+     */
+    function resignTranscoder(address _transcoder) internal {
+        uint256 currentRound = roundsManager().currentRound();
+        if (activeTranscoderSet[currentRound].isActive[_transcoder]) {
+            // If transcoder is active for the round set it as inactive
+            activeTranscoderSet[currentRound].isActive[_transcoder] = false;
+        }
+
+        // Remove transcoder from pools
+        transcoderPool.remove(_transcoder);
+
+        TranscoderResigned(_transcoder);
     }
 
     /*

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -172,8 +172,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
         Delegator storage del = delegators[msg.sender];
 
-        // Must be bonded to self
-        require(del.delegateAddress == msg.sender);
+        // Must have a non-zero amount bonded to self
+        require(del.delegateAddress == msg.sender && del.bondedAmount > 0);
 
         Transcoder storage t = transcoders[msg.sender];
         t.pendingBlockRewardCut = _blockRewardCut;

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -391,7 +391,6 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         // Sender must be elected transcoder
         require(job.transcoderAddress == msg.sender);
 
-        uint256 blockNum = roundsManager().blockNum();
         uint256 challengeBlock = claim.claimBlock + 1;
         // Segment must be eligible for verification
         // roundsManager().blockHash() ensures that the challenge block is within the last 256 blocks from the current block

--- a/contracts/test/GenericMock.sol
+++ b/contracts/test/GenericMock.sol
@@ -25,7 +25,7 @@ contract GenericMock {
      * @param _data Transaction data to be used to call the target contract
      */
     function execute(address _target, bytes _data) external returns (bool) {
-        // solium-disable security/no-low-level-calls
+        // solium-disable-next-line security/no-low-level-calls
         return _target.call(_data);
     }
 

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -57,15 +57,18 @@ contract("BondingManager", accounts => {
             await expectThrow(bondingManager.transcoder(blockRewardCut, feeShare, pricePerSegment), {from: tAddr})
         })
 
-        it("should fail with zero delegated amount", async () => {
-            await expectThrow(bondingManager.transcoder(blockRewardCut, feeShare, pricePerSegment), {from: tAddr})
-        })
-
         it("should fail if transcoder is not bonded to self", async () => {
             await fixture.token.setApproved(true)
             await bondingManager.bond(2000, tAddr, {from: accounts[2]})
 
             // Fails because transcoder has non zero delegated stake but is not bonded to self
+            await expectThrow(bondingManager.transcoder(blockRewardCut, feeShare, pricePerSegment), {from: tAddr})
+        })
+
+        it("should fail if transcoder does not have a non-zero amount bonded to self", async () => {
+            await bondingManager.bond(0, tAddr, {from: tAddr})
+
+            // Fails because transcoder is delegated to self but has zero bonded stake
             await expectThrow(bondingManager.transcoder(blockRewardCut, feeShare, pricePerSegment), {from: tAddr})
         })
 


### PR DESCRIPTION
Fixes #146 

A user that wants to register as a transcoder must delegate to themselves and have non-zero bonded stake before registering. This ensures that transcoders always have something at stake which is especially important right now since only transcoders are slashed for faults at the moment. 

As a result of this change, transcoders that unbond now also automatically resign as a registered transcoder. In the future, if we implement partial unbonding we could update the logic to automatically resign a registered transcoder once it unbonds all of its stake. This change also serves as a solution to the current issue where a transcoder's cut of rewards and fees can be lost if a transcoder is unbonded, but still registered.