### PR TITLE
Remove nodegit from contract deployer

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "ethereumjs-util": "^5.1.2",
     "ganache-cli": "^6.0.3",
     "mkdirp": "^0.5.1",
-    "nodegit": "^0.20.3",
     "solium": "^1.1.2",
     "truffle": "^4.0.4",
     "truffle-hdwallet-provider-privkey": "github:yondonfu/truffle-hdwallet-provider-privkey",

--- a/utils/contractDeployer.js
+++ b/utils/contractDeployer.js
@@ -1,5 +1,5 @@
-const path = require("path")
-const {Repository} = require("nodegit")
+const util = require("util")
+const exec = util.promisify(require("child_process").exec)
 const {contractId} = require("./helpers")
 
 class ContractDeployer {
@@ -10,10 +10,9 @@ class ContractDeployer {
     }
 
     async getGitHeadCommitHash() {
-        const repoRootPath = path.resolve(__dirname, "..")
-        const repo = await Repository.open(repoRootPath)
-        const headCommit = await repo.getHeadCommit()
-        return `0x${headCommit.sha()}`
+        const { stdout, stderr } = await exec("git rev-parse HEAD")
+        if (stderr) throw new Error(stderr)
+        return `0x${stdout}`
     }
 
     async deployController() {


### PR DESCRIPTION
Using `git rev-parse HEAD` to get head commit hash instead, as suggested by @j0sh in #152 