### PR TITLE
Remove trailing newline from commit hash

### DIFF
--- a/utils/contractDeployer.js
+++ b/utils/contractDeployer.js
@@ -10,9 +10,9 @@ class ContractDeployer {
     }
 
     async getGitHeadCommitHash() {
-        const { stdout, stderr } = await exec("git rev-parse HEAD")
+        const {stdout, stderr} = await exec("git rev-parse HEAD")
         if (stderr) throw new Error(stderr)
-        return `0x${stdout}`
+        return `0x${stdout.trim()}`
     }
 
     async deployController() {


### PR DESCRIPTION
Apparently CircleCI doesn't do builds for pull requests based on forks so didn't catch this until after the change was merged in :(