### PR TITLE
Slashing fixes with accompanying tests

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -797,6 +797,14 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /*
+     * @dev Return whether a transcoder is registered
+     * @param _transcoder Transcoder address
+     */
+    function isRegisteredTranscoder(address _transcoder) public view returns (bool) {
+        return transcoderStatus(_transcoder) == TranscoderStatus.Registered;
+    }
+
+    /*
      * @dev Remove transcoder
      */
     function resignTranscoder(address _transcoder) internal {

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -477,24 +477,25 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         uint256 currentRound = roundsManager().currentRound();
 
         if (activeTranscoderSet[currentRound].isActive[_transcoder]) {
-            // Set transcoder as inactive
-            activeTranscoderSet[currentRound].isActive[_transcoder] = false;
             // Decrease total active stake for the round
             activeTranscoderSet[currentRound].totalStake = activeTranscoderSet[currentRound].totalStake.sub(activeTranscoderTotalStake(_transcoder, currentRound));
+            // Set transcoder as inactive
+            activeTranscoderSet[currentRound].isActive[_transcoder] = false;
         }
 
         // Remove transcoder from pools
         transcoderPool.remove(_transcoder);
 
-        // Award finder fee
-        if (penalty > 0 && _finder != address(0)) {
+        // Account for penalty
+        if (penalty > 0) {
             uint256 burnAmount = penalty;
 
+            // Award finder fee if there is a finder address
             if (_finder != address(0)) {
-                // Award finder fee
                 uint256 finderAmount = MathUtils.percOf(penalty, _finderFee);
                 minter().transferTokens(_finder, finderAmount);
 
+                // Subtract finder fee from the amount to be burned
                 burnAmount = burnAmount.sub(finderAmount);
             }
 

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -457,9 +457,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         whenSystemNotPaused
         onlyJobsManager
     {
-        // Transcoder must be valid
-        require(transcoderStatus(_transcoder) == TranscoderStatus.Registered);
-
         uint256 penalty = MathUtils.percOf(delegators[_transcoder].bondedAmount, _slashAmount);
         if (penalty > del.bondedAmount) {
             penalty = del.bondedAmount;

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -25,5 +25,6 @@ contract IBondingManager {
     // Public functions
     function transcoderTotalStake(address _transcoder) public view returns (uint256);
     function activeTranscoderTotalStake(address _transcoder, uint256 _round) public view returns (uint256);
+    function isRegisteredTranscoder(address _transcoder) public view returns (bool);
     function getTotalBonded() public view returns (uint256);
 }

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -319,6 +319,8 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         require(jobStatus(_jobId) != JobStatus.Inactive);
         // Segment range must be valid
         require(_segmentRange[1] >= _segmentRange[0]);
+        // Caller must be registered transcoder
+        require(bondingManager().isRegisteredTranscoder(msg.sender));
 
         uint256 blockNum = roundsManager().blockNum();
 

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -488,9 +488,9 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
             // Protocol slashes transcoder for failing verification (no finder)
             bondingManager().slashTranscoder(transcoder, address(0), failedVerificationSlashAmount, 0);
 
-            PassedVerification(transcoder, _jobId, _claimId, _segmentNumber);
-        } else {
             FailedVerification(transcoder, _jobId, _claimId, _segmentNumber);
+        } else {
+            PassedVerification(transcoder, _jobId, _claimId, _segmentNumber);
         }
     }
 

--- a/contracts/rounds/AdjustableRoundsManager.sol
+++ b/contracts/rounds/AdjustableRoundsManager.sol
@@ -26,7 +26,7 @@ contract AdjustableRoundsManager is RoundsManager {
     }
 
     function blockHash(uint256 _block) public view returns (bytes32) {
-        require(_block <= blockNum() - 256);
+        require(_block >= blockNum() - 256);
 
         return hash;
     }

--- a/contracts/test/BondingManagerMock.sol
+++ b/contracts/test/BondingManagerMock.sol
@@ -73,4 +73,8 @@ contract BondingManagerMock is IBondingManager {
     function activeTranscoderTotalStake(address _transcoder, uint256 _round) public view returns (uint256) {
         return activeStake;
     }
+
+    function isRegisteredTranscoder(address _transcoder) public view returns (bool) {
+        return true;
+    }
 }

--- a/migrations/3_deploy_contracts.js
+++ b/migrations/3_deploy_contracts.js
@@ -7,7 +7,6 @@ const BondingManager = artifacts.require("BondingManager")
 const JobsManager = artifacts.require("JobsManager")
 const RoundsManager = artifacts.require("RoundsManager")
 const AdjustableRoundsManager = artifacts.require("AdjustableRoundsManager")
-const IdentityVerifier = artifacts.require("IdentityVerifier")
 const LivepeerVerifier = artifacts.require("LivepeerVerifier")
 const LivepeerToken = artifacts.require("LivepeerToken")
 const LivepeerTokenFaucet = artifacts.require("LivepeerTokenFaucet")
@@ -20,13 +19,7 @@ module.exports = function(deployer, network) {
         const controller = await lpDeployer.deployController()
         const token = await lpDeployer.deployAndRegister(LivepeerToken, "LivepeerToken")
         await lpDeployer.deployAndRegister(Minter, "Minter", controller.address, config.minter.inflation, config.minter.inflationChange, config.minter.targetBondingRate)
-
-        if (network === "development" || network === "testrpc" || network === "parityDev" || network === "gethDev") {
-            await lpDeployer.deployAndRegister(IdentityVerifier, "Verifier", controller.address)
-        } else {
-            await lpDeployer.deployAndRegister(LivepeerVerifier, "Verifier", controller.address, config.verifier.solvers, config.verifier.verificationCodeHash)
-        }
-
+        await lpDeployer.deployAndRegister(LivepeerVerifier, "Verifier", controller.address, config.verifier.solvers, config.verifier.verificationCodeHash)
         await lpDeployer.deployAndRegister(LivepeerTokenFaucet, "LivepeerTokenFaucet", token.address, config.faucet.requestAmount, config.faucet.requestWait)
 
         const bondingManager = await lpDeployer.deployProxyAndRegister(BondingManager, "BondingManager", controller.address)

--- a/test/integration/DoubleClaimSegmentSlashing.js
+++ b/test/integration/DoubleClaimSegmentSlashing.js
@@ -3,28 +3,25 @@ import batchTranscodeReceiptHashes from "../../utils/batchTranscodeReceipts"
 import MerkleTree from "../../utils/merkleTree"
 import {createTranscodingOptions} from "../../utils/videoProfile"
 import Segment from "../../utils/segment"
-import ethUtil from "ethereumjs-util"
 
 const Controller = artifacts.require("Controller")
 const BondingManager = artifacts.require("BondingManager")
 const JobsManager = artifacts.require("JobsManager")
 const AdjustableRoundsManager = artifacts.require("AdjustableRoundsManager")
-const LivepeerVerifier = artifacts.require("LivepeerVerifier")
 const LivepeerToken = artifacts.require("LivepeerToken")
 const LivepeerTokenFaucet = artifacts.require("LivepeerTokenFaucet")
 
-contract("FailedVerificationSlashing", accounts => {
+contract("DoubleClaimSegmentSlashing", accounts => {
     let controller
     let bondingManager
     let roundsManager
     let jobsManager
     let token
-    let verifier
 
     let transcoder
     let delegator1
     let delegator2
-    let solver
+    let watcher
     let broadcaster
 
     let roundLength
@@ -33,7 +30,7 @@ contract("FailedVerificationSlashing", accounts => {
         transcoder = accounts[0]
         delegator1 = accounts[1]
         delegator2 = accounts[2]
-        solver = accounts[3]
+        watcher = accounts[3]
         broadcaster = accounts[3]
 
         controller = await Controller.deployed()
@@ -49,14 +46,8 @@ contract("FailedVerificationSlashing", accounts => {
 
         // Set verification rate to 1 out of 1 segments, so every segment is challenged
         await jobsManager.setVerificationRate(1)
-        // Set failed verification slash amount to 20%
-        await jobsManager.setFailedVerificationSlashAmount(200000)
-
-        const verifierAddr = await controller.getContract(contractId("Verifier"))
-        verifier = await LivepeerVerifier.at(verifierAddr)
-
-        // Whitelist a solver address
-        await verifier.addSolver(solver)
+        // Set double claim segment slash amount to 20%
+        await jobsManager.setDoubleClaimSegmentSlashAmount(200000)
 
         const tokenAddr = await controller.getContract(contractId("LivepeerToken"))
         token = await LivepeerToken.at(tokenAddr)
@@ -87,13 +78,13 @@ contract("FailedVerificationSlashing", accounts => {
         await roundsManager.initializeRound()
     })
 
-    it("solver should slash a transcoder for failing verification", async () => {
+    it("watcher should slash a transcoder for double claiming segments", async () => {
         await jobsManager.deposit({from: broadcaster, value: 1000})
 
         const endBlock = (await roundsManager.blockNum()).add(100)
         await jobsManager.job("foo", createTranscodingOptions(["foo", "bar"]), 1, endBlock, {from: broadcaster})
 
-        const rand = web3.eth.getBlock(web3.eth.blockNumber).hash
+        let rand = web3.eth.getBlock(web3.eth.blockNumber).hash
         await roundsManager.mineBlocks(1)
         await roundsManager.setBlockHash(rand)
 
@@ -124,28 +115,37 @@ contract("FailedVerificationSlashing", accounts => {
 
         const tokenStartSupply = await token.totalSupply.call()
 
+        // Transcoder claims segments 0 through 3
         await jobsManager.claimWork(0, [0, 3], merkleTree.getHexRoot(), {from: transcoder})
-        // Mine the claim block and the claim block + 1
+        // Transcoder claims segments 0 through 3 again
+        await jobsManager.claimWork(0, [0, 3], merkleTree.getHexRoot(), {from: transcoder})
+        // Wait for claims to be mined
         await roundsManager.mineBlocks(2)
-        await jobsManager.verify(0, 0, 0, "bar", [dataHashes[0], tDataHashes[0]], ethUtil.bufferToHex(segments[0].signedHash()), merkleTree.getHexProof(tReceiptHashes[0]), {from: transcoder})
-        await verifier.__callback(0, web3.sha3("wrong hash"), {from: solver})
+
+        // Watcher slashes transcoder for double claiming segments
+        // Transcoder claimed segments 0 through 3 twice
+        await jobsManager.doubleClaimSegmentSlash(0, 0, 1, 0, {from: watcher})
 
         // Check that the transcoder is penalized
         const currentRound = await roundsManager.currentRound()
-        const failedVerificationSlashAmount = await jobsManager.failedVerificationSlashAmount.call()
-        const penalty = Math.floor((1000 * failedVerificationSlashAmount.toNumber()) / 1000000)
+        const doubleClaimSegmentSlashAmount = await jobsManager.doubleClaimSegmentSlashAmount.call()
+        const penalty = Math.floor((1000 * doubleClaimSegmentSlashAmount.toNumber()) / 1000000)
         const expTransStakeRemaining = 1000 - penalty
         const expDelegatedStakeRemaining = (1000 + 1000 + 1000) - penalty
         const expTotalBondedRemaining = expDelegatedStakeRemaining
         const tokenEndSupply = await token.totalSupply.call()
+        const finderFeeAmount = await jobsManager.finderFee.call()
+        const finderFee = Math.floor((penalty * finderFeeAmount) / 1000000)
         const burned = tokenStartSupply.sub(tokenEndSupply).toNumber()
         const trans = await bondingManager.getDelegator(transcoder)
 
         assert.isNotOk(await bondingManager.isActiveTranscoder(transcoder, currentRound), "transcoder should be inactive")
         assert.equal(await bondingManager.transcoderStatus(transcoder), 0, "transcoder should not be registered")
         assert.equal(trans[0], expTransStakeRemaining, "wrong transcoder stake remaining")
-        assert.equal(trans[3], expDelegatedStakeRemaining, "wrong delegated stake remaining")
-        assert.equal(burned, penalty, "wrong amount burned")
+        assert.equal(burned, penalty - finderFee, "wrong amount burned")
+
+        // Check that the finder was rewarded
+        assert.equal(await token.balanceOf(watcher), finderFee, "wrong finder fee")
 
         // Check that the broadcaster was refunded
         assert.equal((await jobsManager.getJob(0))[8], 0, "job escrow should be 0")

--- a/test/integration/SlashingEdgeCases.js
+++ b/test/integration/SlashingEdgeCases.js
@@ -1,0 +1,269 @@
+import {contractId} from "../../utils/helpers"
+import batchTranscodeReceiptHashes from "../../utils/batchTranscodeReceipts"
+import MerkleTree from "../../utils/merkleTree"
+import {createTranscodingOptions} from "../../utils/videoProfile"
+import Segment from "../../utils/segment"
+
+const Controller = artifacts.require("Controller")
+const BondingManager = artifacts.require("BondingManager")
+const JobsManager = artifacts.require("JobsManager")
+const AdjustableRoundsManager = artifacts.require("AdjustableRoundsManager")
+const LivepeerToken = artifacts.require("LivepeerToken")
+const LivepeerTokenFaucet = artifacts.require("LivepeerTokenFaucet")
+
+contract("SlashingEdgeCases", accounts => {
+    let controller
+    let bondingManager
+    let roundsManager
+    let jobsManager
+    let token
+
+    let transcoder1
+    let transcoder2
+    let watcher
+    let broadcaster
+
+    let roundLength
+
+    before(async () => {
+        transcoder1 = accounts[0]
+        transcoder2 = accounts[1]
+        watcher = accounts[3]
+        broadcaster = accounts[3]
+
+        controller = await Controller.deployed()
+
+        const bondingManagerAddr = await controller.getContract(contractId("BondingManager"))
+        bondingManager = await BondingManager.at(bondingManagerAddr)
+
+        const roundsManagerAddr = await controller.getContract(contractId("RoundsManager"))
+        roundsManager = await AdjustableRoundsManager.at(roundsManagerAddr)
+
+        const jobsManagerAddr = await controller.getContract(contractId("JobsManager"))
+        jobsManager = await JobsManager.at(jobsManagerAddr)
+
+        // Set verification rate to 1 out of 1 segments, so every segment is challenged
+        await jobsManager.setVerificationRate(1)
+        // Set double claim segment slash amount to 20%
+        await jobsManager.setDoubleClaimSegmentSlashAmount(200000)
+        // Set missed verification slash amount to 20%
+        await jobsManager.setMissedVerificationSlashAmount(200000)
+
+        const tokenAddr = await controller.getContract(contractId("LivepeerToken"))
+        token = await LivepeerToken.at(tokenAddr)
+
+        const faucetAddr = await controller.getContract(contractId("LivepeerTokenFaucet"))
+        const faucet = await LivepeerTokenFaucet.at(faucetAddr)
+
+        await faucet.request({from: transcoder1})
+        await faucet.request({from: transcoder2})
+
+        roundLength = await roundsManager.roundLength.call()
+        await roundsManager.mineBlocks(roundLength.toNumber() * 1000)
+        await roundsManager.initializeRound()
+
+        await token.approve(bondingManager.address, 1000, {from: transcoder1})
+        await bondingManager.bond(1000, transcoder1, {from: transcoder1})
+        await bondingManager.transcoder(10, 5, 1, {from: transcoder1})
+
+        // Fast forward to new round with locked in active transcoder set
+        await roundsManager.mineBlocks(roundLength.toNumber())
+        await roundsManager.initializeRound()
+    })
+
+    it("transcoder that unbonds should still be slashable for a fault", async () => {
+        await jobsManager.deposit({from: broadcaster, value: 1000})
+
+        const endBlock = (await roundsManager.blockNum()).add(100)
+        await jobsManager.job("foo", createTranscodingOptions(["foo", "bar"]), 1, endBlock, {from: broadcaster})
+
+        const rand = web3.eth.getBlock(web3.eth.blockNumber).hash
+        await roundsManager.mineBlocks(1)
+        await roundsManager.setBlockHash(rand)
+
+        // Segment data hashes
+        const dataHashes = [
+            "0x80084bf2fba02475726feb2cab2d8215eab14bc6bdd8bfb2c8151257032ecd8b",
+            "0xb039179a8a4ce2c252aa6f2f25798251c19b75fc1508d9d511a191e0487d64a7",
+            "0x263ab762270d3b73d3e2cddf9acc893bb6bd41110347e5d5e4bd1d3c128ea90a",
+            "0x4ce8765e720c576f6f5a34ca380b3de5f0912e6e3cc5355542c363891e54594b"
+        ]
+
+        // Segments
+        const segments = dataHashes.map((dataHash, idx) => new Segment("foo", idx, dataHash, broadcaster))
+
+        // Transcoded data hashes
+        const tDataHashes = [
+            "0x42538602949f370aa331d2c07a1ee7ff26caac9cc676288f94b82eb2188b8465",
+            "0xa0b37b8bfae8e71330bd8e278e4a45ca916d00475dd8b85e9352533454c9fec8",
+            "0x9f2898da52dedaca29f05bcac0c8e43e4b9f7cb5707c14cc3f35a567232cec7c",
+            "0x5a082c81a7e4d5833ee20bd67d2f4d736f679da33e4bebd3838217cb27bec1d3"
+        ]
+
+        // Transcode receipts
+        const tReceiptHashes = batchTranscodeReceiptHashes(segments, tDataHashes)
+
+        // Build merkle tree
+        const merkleTree = new MerkleTree(tReceiptHashes)
+
+        const tokenStartSupply = await token.totalSupply.call()
+
+        // Transcoder claims segments 0 through 3
+        await jobsManager.claimWork(0, [0, 3], merkleTree.getHexRoot(), {from: transcoder1})
+        // Transcoder claims segments 0 through 3 again
+        await jobsManager.claimWork(0, [0, 3], merkleTree.getHexRoot(), {from: transcoder1})
+        // Wait for claims to be mined
+        await roundsManager.mineBlocks(2)
+
+        // Transcoder unbonds and tries to avoid being slashed
+        await bondingManager.unbond({from: transcoder1})
+
+        // Watcher slashes transcoder for double claiming segments
+        // Transcoder claimed segments 0 through 3 twice
+        await jobsManager.doubleClaimSegmentSlash(0, 0, 1, 0, {from: watcher})
+
+        // Check that the transcoder is penalized
+        const currentRound = await roundsManager.currentRound()
+        const doubleClaimSegmentSlashAmount = await jobsManager.doubleClaimSegmentSlashAmount.call()
+        const penalty = Math.floor((1000 * doubleClaimSegmentSlashAmount.toNumber()) / 1000000)
+        const expTransStakeRemaining = 1000 - penalty
+        const expDelegatedStakeRemaining = 0
+        const expTotalBondedRemaining = 0
+        const tokenEndSupply = await token.totalSupply.call()
+        const finderFeeAmount = await jobsManager.finderFee.call()
+        const finderFee = Math.floor((penalty * finderFeeAmount) / 1000000)
+        const burned = tokenStartSupply.sub(tokenEndSupply).toNumber()
+        const trans = await bondingManager.getDelegator(transcoder1)
+
+        assert.isNotOk(await bondingManager.isActiveTranscoder(transcoder1, currentRound), "transcoder should be inactive")
+        assert.equal(await bondingManager.transcoderStatus(transcoder1), 0, "transcoder should not be registered")
+        assert.equal(trans[0], expTransStakeRemaining, "wrong transcoder stake remaining")
+        assert.equal(trans[3], expDelegatedStakeRemaining, "wrong delegated stake remaining")
+        assert.equal(burned, penalty - finderFee, "wrong amount burned")
+
+        // Check that the finder was rewarded
+        assert.equal(await token.balanceOf(watcher), finderFee, "wrong finder fee")
+
+        // Check that the broadcaster was refunded
+        assert.equal((await jobsManager.getJob(0))[8], 0, "job escrow should be 0")
+        assert.equal((await jobsManager.broadcasters.call(broadcaster))[0], 1000)
+
+        // Check that the total stake for the round is updated
+        // activeTranscoderSet.call(round) only returns the active stake and not the array of transcoder addresses
+        // because Solidity does not return nested arrays in structs
+        assert.equal(await bondingManager.activeTranscoderSet.call(currentRound), 0, "wrong active stake remaining")
+
+        // Check that the total tokens bonded is updated
+        assert.equal(await bondingManager.getTotalBonded(), expTotalBondedRemaining, "wrong total bonded amount")
+    })
+
+    it("transcoder that is slashed should still be slashable if it claims work and faults again", async () => {
+        await token.approve(bondingManager.address, 1000, {from: transcoder2})
+        await bondingManager.bond(1000, transcoder2, {from: transcoder2})
+        await bondingManager.transcoder(10, 15, 1, {from: transcoder2})
+
+        // Fast forward to new round with locked in active transcoder set
+        await roundsManager.mineBlocks(roundLength.toNumber())
+        await roundsManager.initializeRound()
+
+        const endBlock = (await roundsManager.blockNum()).add(100)
+        await jobsManager.job("foo", createTranscodingOptions(["foo", "bar"]), 1, endBlock, {from: broadcaster})
+
+        let rand = web3.eth.getBlock(web3.eth.blockNumber).hash
+        await roundsManager.mineBlocks(1)
+        await roundsManager.setBlockHash(rand)
+
+        // Segment data hashes
+        const dataHashes = [
+            "0x80084bf2fba02475726feb2cab2d8215eab14bc6bdd8bfb2c8151257032ecd8b",
+            "0xb039179a8a4ce2c252aa6f2f25798251c19b75fc1508d9d511a191e0487d64a7",
+            "0x263ab762270d3b73d3e2cddf9acc893bb6bd41110347e5d5e4bd1d3c128ea90a",
+            "0x4ce8765e720c576f6f5a34ca380b3de5f0912e6e3cc5355542c363891e54594b"
+        ]
+
+        // Segments
+        const segments = dataHashes.map((dataHash, idx) => new Segment("foo", idx, dataHash, broadcaster))
+
+        // Transcoded data hashes
+        const tDataHashes = [
+            "0x42538602949f370aa331d2c07a1ee7ff26caac9cc676288f94b82eb2188b8465",
+            "0xa0b37b8bfae8e71330bd8e278e4a45ca916d00475dd8b85e9352533454c9fec8",
+            "0x9f2898da52dedaca29f05bcac0c8e43e4b9f7cb5707c14cc3f35a567232cec7c",
+            "0x5a082c81a7e4d5833ee20bd67d2f4d736f679da33e4bebd3838217cb27bec1d3"
+        ]
+
+        // Transcode receipts
+        const tReceiptHashes = batchTranscodeReceiptHashes(segments, tDataHashes)
+
+        // Build merkle tree
+        const merkleTree = new MerkleTree(tReceiptHashes)
+
+        const tokenStartSupply = await token.totalSupply.call()
+        const watcherStartBalance = await token.balanceOf(watcher)
+
+        // Transcoder claims segments 0 through 3
+        await jobsManager.claimWork(1, [0, 3], merkleTree.getHexRoot(), {from: transcoder2})
+        // Transcoder claims segments 0 through 3 again
+        await jobsManager.claimWork(1, [0, 3], merkleTree.getHexRoot(), {from: transcoder2})
+        // Wait for claims to be mined
+        await roundsManager.mineBlocks(2)
+
+        // Watcher slashes transcoder for double claiming segments
+        // Transcoder claimed segments 0 through 3 twice
+        await jobsManager.doubleClaimSegmentSlash(1, 0, 1, 0, {from: watcher})
+
+        // Transcoder claims again after it was slashed
+        await jobsManager.claimWork(1, [0, 3], merkleTree.getHexRoot(), {from: transcoder2})
+        // Wait through the verification period
+        const verificationPeriod = await jobsManager.verificationPeriod.call()
+        await roundsManager.mineBlocks(verificationPeriod.toNumber() + 1)
+        // Make sure the round is initialized
+        await roundsManager.initializeRound()
+
+        rand = web3.eth.getBlock(web3.eth.blockNumber).hash
+        await roundsManager.setBlockHash(rand)
+        // Watcher slashes transcoder for missing verification
+        // transcoder should have submitted every segment for verification because the verification rate was 1 out of 1 segments
+        await jobsManager.missedVerificationSlash(1, 2, 0, {from: watcher})
+
+        // Check that the transcoder is penalized twice (once for double claiming and once for missing verification)
+        const currentRound = await roundsManager.currentRound()
+        const doubleClaimSegmentSlashAmount = await jobsManager.doubleClaimSegmentSlashAmount.call()
+        const missedVerificationSlashAmount = await jobsManager.missedVerificationSlashAmount.call()
+        const penalty1 = Math.floor((1000 * doubleClaimSegmentSlashAmount.toNumber()) / 1000000)
+        const transStakeRemaining1 = 1000 - penalty1
+        const penalty2 = Math.floor((transStakeRemaining1 * missedVerificationSlashAmount.toNumber()) / 1000000)
+        const expTransStakeRemaining = transStakeRemaining1 - penalty2
+        const expDelegatedStakeRemaining = expTransStakeRemaining
+        const expTotalBondedRemaining = expTransStakeRemaining
+        const tokenEndSupply = await token.totalSupply.call()
+        const watcherEndBalance = await token.balanceOf(watcher)
+        const finderFeeAmount = await jobsManager.finderFee.call()
+        const finderFee1 = Math.floor((penalty1 * finderFeeAmount) / 1000000)
+        const finderFee2 = Math.floor((penalty2 * finderFeeAmount) / 1000000)
+        const burned = tokenStartSupply.sub(tokenEndSupply).toNumber()
+        const trans = await bondingManager.getDelegator(transcoder2)
+
+        assert.isNotOk(await bondingManager.isActiveTranscoder(transcoder2, currentRound), "transcoder should be inactive")
+        assert.equal(await bondingManager.transcoderStatus(transcoder2), 0, "transcoder should not be registered")
+        assert.equal(trans[0], expTransStakeRemaining, "wrong transcoder stake remaining")
+        assert.equal(trans[3], expDelegatedStakeRemaining, "wrong delegated stake remaining")
+        assert.equal(burned, (penalty1 + penalty2) - (finderFee1 + finderFee2), "wrong amount burned")
+
+        // Check that the finder was rewarded
+        assert.equal(watcherEndBalance.sub(watcherStartBalance), finderFee1 + finderFee2, "wrong finder fee")
+
+        // Check that the broadcaster was refunded for both jobs
+        assert.equal((await jobsManager.getJob(0))[8], 0, "job escrow should be 0")
+        assert.equal((await jobsManager.getJob(1))[8], 0, "job escrow should be 0")
+        assert.equal((await jobsManager.broadcasters.call(broadcaster))[0], 1000)
+
+        // Check that the total stake for the round is updated
+        // activeTranscoderSet.call(round) only returns the active stake and not the array of transcoder addresses
+        // because Solidity does not return nested arrays in structs
+        assert.equal(await bondingManager.activeTranscoderSet.call(currentRound), 0, "wrong active stake remaining")
+
+        // Check that the total tokens bonded is updated
+        assert.equal(await bondingManager.getTotalBonded(), expTotalBondedRemaining, "wrong total bonded amount")
+    })
+})


### PR DESCRIPTION
Closes #162 

Addresses the two problems mentioned in the issue. Added integration tests for each slashing condition in: `FailedVerificationSlashing.js`, `MissedVerificationSlashing.js` and `DoubleClaimSegmentSlashing.js`. Also added `SlashingEdgeCases.js` that tests that the bugs/exploits described in the issue are fixed - there is one test for slashing a transcoder after it has unbonded and resigned and one test for slashing a transcoder after it has already been slashed because it committed another fault (the scenario used in the test is the transcoder first double claims segments, is slashed and then misses verification for a subsequent transcode claim). Additional clarifying comments made in-line.