### PR TITLE
Set jobs as inactive when a transcoder is slashed

### DIFF
--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -676,6 +676,8 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
         uint256 fees = job.escrow;
         job.escrow = job.escrow.sub(fees);
         broadcasters[job.broadcasterAddress].deposit = broadcasters[job.broadcasterAddress].deposit.add(fees);
+        // Set end block of job to current block - job becomes inactive
+        job.endBlock = roundsManager().blockNum();
     }
 
     /*


### PR DESCRIPTION
Fixes #175 

As described in the issue, the minor downside to the approach taken in this PR is that it removes the previous invariant: a broadcaster cannot withdraw its deposit if it has any active jobs. If a job is set as inactive by setting its end block to the current block when the job's transcoder is slashed, the contract does not maintain enough state (and ideally shouldn't have to) to also update the broadcaster's withdraw block to reflect the possibility that the broadcaster no longer has any active jobs. As a result, the restriction is no longer that a broadcaster cannot withdraw its deposit if it has any active jobs since a broadcaster might not be able to withdraw even if it does not have any active jobs. The rules for withdrawal are now:

-  A broadcaster commits to keeping a deposit on-chain until the largest end block it defines at the time of job creation
- The largest end block provided for a new job is the broadcaster's withdraw block
- A broadcaster cannot withdraw its deposit until its withdraw block
- A broadcaster's withdraw block can only become larger, it cannot become smaller

I think this is an OK tradeoff because in the current system, whether we set the job as inactive by setting its end block to the current block or introduce additional state to check if the transcoder was previously slashed for a job (in order to prevent the transcoder from claiming work for the job again), no other transcoder will be able to claim work for that job. Plus, either way we don't have a good way to update the broadcaster's withdraw block - so in both scenarios a broadcaster must wait until its withdraw block. Though in the future, we might want to add the feature where transcoders can fill in as the elected transcoder for a job if the originally elected transcoder was slashed, I don't think setting jobs as inactive for now will impact the implementation of that feature in the future.