### PR TITLE
Upgradeable Minter with additional tests

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -337,7 +337,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         delegators[msg.sender].withdrawRound = 0;
 
         // Tell Minter to transfer stake (LPT) to the delegator
-        minter().transferTokens(msg.sender, amount);
+        minter().trustedTransferTokens(msg.sender, amount);
 
         WithdrawStake(msg.sender);
     }
@@ -358,7 +358,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         delegators[msg.sender].fees = 0;
 
         // Tell Minter to transfer fees (ETH) to the delegator
-        minter().withdrawETH(msg.sender, amount);
+        minter().trustedWithdrawETH(msg.sender, amount);
 
         WithdrawFees(msg.sender);
     }
@@ -504,14 +504,14 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             // Award finder fee if there is a finder address
             if (_finder != address(0)) {
                 uint256 finderAmount = MathUtils.percOf(penalty, _finderFee);
-                minter().transferTokens(_finder, finderAmount);
+                minter().trustedTransferTokens(_finder, finderAmount);
 
                 // Subtract finder fee from the amount to be burned
                 burnAmount = burnAmount.sub(finderAmount);
             }
 
             // Minter burns the remaining slashed funds
-            minter().burnTokens(burnAmount);
+            minter().trustedBurnTokens(burnAmount);
         }
 
         TranscoderSlashed(_transcoder, penalty);

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -217,7 +217,7 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
 
         uint256 amount = broadcasters[msg.sender].deposit;
         delete broadcasters[msg.sender];
-        minter().withdrawETH(msg.sender, amount);
+        minter().trustedWithdrawETH(msg.sender, amount);
 
         Withdraw(msg.sender);
     }

--- a/contracts/test/BondingManagerMock.sol
+++ b/contracts/test/BondingManagerMock.sol
@@ -42,9 +42,9 @@ contract BondingManagerMock is IBondingManager {
 
     function withdraw(bool _unbonded, address _recipient) external {
         if (_unbonded) {
-            minter.withdrawETH(_recipient, withdrawAmount);
+            minter.trustedWithdrawETH(_recipient, withdrawAmount);
         } else {
-            minter.transferTokens(_recipient, withdrawAmount);
+            minter.trustedTransferTokens(_recipient, withdrawAmount);
         }
     }
 
@@ -53,7 +53,7 @@ contract BondingManagerMock is IBondingManager {
     }
 
     function callBurnTokens(uint256 _amount) external {
-        minter.burnTokens(_amount);
+        minter.trustedBurnTokens(_amount);
     }
 
     function setActiveTranscoders() external {}

--- a/contracts/test/GenericMock.sol
+++ b/contracts/test/GenericMock.sol
@@ -25,9 +25,9 @@ contract GenericMock {
      * @param _target Target contract to call with data
      * @param _data Transaction data to be used to call the target contract
      */
-    function execute(address _target, bytes _data) external returns (bool) {
+    function execute(address _target, bytes _data) external payable {
         // solium-disable-next-line security/no-low-level-calls
-        return _target.call(_data);
+        require(_target.call.value(msg.value)(_data));
     }
 
     /*

--- a/contracts/test/GenericMock.sol
+++ b/contracts/test/GenericMock.sol
@@ -26,7 +26,7 @@ contract GenericMock {
      * @param _data Transaction data to be used to call the target contract
      */
     function execute(address _target, bytes _data) external payable {
-        // solium-disable-next-line security/no-low-level-calls
+        // solium-disable-next-line
         require(_target.call.value(msg.value)(_data));
     }
 

--- a/contracts/test/JobsManagerMock.sol
+++ b/contracts/test/JobsManagerMock.sol
@@ -105,9 +105,9 @@ contract JobsManagerMock is IJobsManager {
 
     function withdraw(bool _unbonded, address _recipient) external {
         if (_unbonded) {
-            minter.withdrawETH(_recipient, withdrawAmount);
+            minter.trustedWithdrawETH(_recipient, withdrawAmount);
         } else {
-            minter.transferTokens(_recipient, withdrawAmount);
+            minter.trustedTransferTokens(_recipient, withdrawAmount);
         }
     }
 

--- a/contracts/test/MinterMock.sol
+++ b/contracts/test/MinterMock.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.4.17;
 
 import "../token/IMinter.sol";
+import "../IController.sol";
 
 
 contract MinterMock is IMinter {
@@ -14,15 +15,19 @@ contract MinterMock is IMinter {
         return reward;
     }
 
-    function transferTokens(address _to, uint256 _amount) external {}
+    function trustedTransferTokens(address _to, uint256 _amount) external {}
 
-    function burnTokens(uint256 _amount) external {}
+    function trustedBurnTokens(uint256 _amount) external {}
 
-    function withdrawETH(address _to, uint256 _amount) external {}
+    function trustedWithdrawETH(address _to, uint256 _amount) external {}
 
     function depositETH() external payable returns (bool) {
         return true;
     }
 
     function setCurrentRewardTokens() external {}
+
+    function getController() public view returns (IController) {
+        return IController(address(0));
+    }
 }

--- a/contracts/token/IMinter.sol
+++ b/contracts/token/IMinter.sol
@@ -1,14 +1,23 @@
 pragma solidity ^0.4.17;
 
+import "../IController.sol";
 
+
+/**
+ * @title Minter interface
+ */
 contract IMinter {
-    event NewInflation(uint256 inflation);
-    event SetCurrentRewardTokens(uint256 mintableTokens);
+    // Events
+    event SetCurrentRewardTokens(uint256 currentMintableTokens, uint256 currentInflation);
 
+    // External functions
     function createReward(uint256 _fracNum, uint256 _fracDenom) external returns (uint256);
-    function transferTokens(address _to, uint256 _amount) external;
-    function burnTokens(uint256 _amount) external;
+    function trustedTransferTokens(address _to, uint256 _amount) external;
+    function trustedBurnTokens(uint256 _amount) external;
+    function trustedWithdrawETH(address _to, uint256 _amount) external;
     function depositETH() external payable returns (bool);
-    function withdrawETH(address _to, uint256 _amount) external;
     function setCurrentRewardTokens() external;
+
+    // Public functions
+    function getController() public view returns (IController);
 }

--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -53,6 +53,12 @@ contract Minter is Manager, IMinter {
         _;
     }
 
+    // Checks if caller is either the currently registered Minter or JobsManager
+    modifier onlyMinterOrJobsManager() {
+        require(msg.sender == controller.getContract(keccak256("Minter")) || msg.sender == controller.getContract(keccak256("JobsManager")));
+        _;
+    }
+
     /**
      * @dev Minter constructor
      * @param _inflation Base inflation rate as a percentage of current total token supply
@@ -119,6 +125,8 @@ contract Minter is Manager, IMinter {
         livepeerToken().transferOwnership(_newMinter);
         // Transfer current Minter's token balance to new Minter
         livepeerToken().transfer(_newMinter, livepeerToken().balanceOf(this));
+        // Transfer current Minter's ETH balance to new Minter
+        _newMinter.depositETH.value(this.balance)();
     }
 
     /**
@@ -167,9 +175,9 @@ contract Minter is Manager, IMinter {
     }
 
     /**
-     * @dev Deposit ETH to this contract. Only callable by JobsManager
+     * @dev Deposit ETH to this contract. Only callable by the currently registered Minter or JobsManager
      */
-    function depositETH() external payable onlyJobsManager whenSystemNotPaused returns (bool) {
+    function depositETH() external payable onlyMinterOrJobsManager whenSystemNotPaused returns (bool) {
         return true;
     }
 

--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -106,10 +106,10 @@ contract Minter is Manager, IMinter {
 
     /**
      * @dev Migrate to a new Minter by transferring ownership of the token as well
-     * as the current Minter's token balance to the new Minter
+     * as the current Minter's token balance to the new Minter. Only callable by Controller when system is paused
      * @param _newMinter Address of new Minter
      */
-    function migrateToNewMinter(IMinter _newMinter) external onlyControllerOwner {
+    function migrateToNewMinter(IMinter _newMinter) external onlyControllerOwner whenSystemPaused {
         // New Minter cannot be the current Minter
         require(_newMinter != this);
         // Check for null address

--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -10,6 +10,10 @@ import "../libraries/MathUtils.sol";
 import "zeppelin-solidity/contracts/math/SafeMath.sol";
 
 
+/**
+ * @title Minter
+ * @dev Manages inflation rate and the minting of new tokens for each round of the Livepeer protocol
+ */
 contract Minter is Manager, IMinter {
     using SafeMath for uint256;
 
@@ -25,26 +29,36 @@ contract Minter is Manager, IMinter {
     // Current number of minted tokens. Reset every round
     uint256 public currentMintedTokens;
 
+    // Checks if caller is BondingManager
     modifier onlyBondingManager() {
         require(msg.sender == controller.getContract(keccak256("BondingManager")));
         _;
     }
 
+    // Checks if caller is JobsManager
     modifier onlyJobsManager() {
         require(msg.sender == controller.getContract(keccak256("JobsManager")));
         _;
     }
 
+    // Checks if caller is RoundsManager
     modifier onlyRoundsManager() {
         require(msg.sender == controller.getContract(keccak256("RoundsManager")));
         _;
     }
 
+    // Checks if caller is either BondingManager or JobsManager
     modifier onlyBondingManagerOrJobsManager() {
         require(msg.sender == controller.getContract(keccak256("BondingManager")) || msg.sender == controller.getContract(keccak256("JobsManager")));
         _;
     }
 
+    /**
+     * @dev Minter constructor
+     * @param _inflation Base inflation rate as a percentage of current total token supply
+     * @param _inflationChange Change in inflation rate each round (increase or decrease) if target bonding rate is not achieved
+     * @param _targetBondingRate Target bonding rate as a percentage of total bonded tokens / total token supply
+     */
     function Minter(address _controller, uint256 _inflation, uint256 _inflationChange, uint256 _targetBondingRate) public Manager(_controller) {
         // Inflation must be valid percentage
         require(MathUtils.validPerc(_inflation));
@@ -58,6 +72,10 @@ contract Minter is Manager, IMinter {
         targetBondingRate = _targetBondingRate;
     }
 
+    /**
+     * @dev Set targetBondingRate. Only callable by Controller owner
+     * @param _targetBondingRate Target bonding rate as a percentage of total bonded tokens / total token supply
+     */
     function setTargetBondingRate(uint256 _targetBondingRate) external onlyControllerOwner {
         // Must be valid percentage
         require(MathUtils.validPerc(_targetBondingRate));
@@ -67,6 +85,10 @@ contract Minter is Manager, IMinter {
         ParameterUpdate("targetBondingRate");
     }
 
+    /**
+     * @dev Set inflationChange. Only callable by Controller owner
+     * @param _inflationChange Inflation change as a percentage of total token supply
+     */
     function setInflationChange(uint256 _inflationChange) external onlyControllerOwner {
         // Must be valid percentage
         require(MathUtils.validPerc(_inflationChange));
@@ -76,12 +98,31 @@ contract Minter is Manager, IMinter {
         ParameterUpdate("inflationChange");
     }
 
-    function transferTokenOwnership(address _newOwner) external onlyControllerOwner {
-        livepeerToken().transferOwnership(_newOwner);
+    /**
+     * @dev Migrate to a new Minter by transferring ownership of the token as well
+     * as the current Minter's token balance to the new Minter
+     * @param _newMinter Address of new Minter
+     */
+    function migrateToNewMinter(IMinter _newMinter) external onlyControllerOwner {
+        // New Minter cannot be the current Minter
+        require(_newMinter != this);
+        // Check for null address
+        require(address(_newMinter) != address(0));
+
+        IController newMinterController = _newMinter.getController();
+        // New Minter must have same Controller as current Minter
+        require(newMinterController == controller);
+        // New Minter's Controller must have the current Minter registered
+        require(newMinterController.getContract(keccak256("Minter")) == address(this));
+
+        // Transfer ownership of token to new Minter
+        livepeerToken().transferOwnership(_newMinter);
+        // Transfer current Minter's token balance to new Minter
+        livepeerToken().transfer(_newMinter, livepeerToken().balanceOf(this));
     }
 
-    /*
-     * @dev Create reward based on a fractional portion of the mintable tokens and redistributable funds for a round
+    /**
+     * @dev Create reward based on a fractional portion of the mintable tokens for the current round
      * @param _fracNum Numerator of fraction (active transcoder's stake)
      * @param _fracDenom Denominator of fraction (total active stake)
      */
@@ -99,53 +140,61 @@ contract Minter is Manager, IMinter {
         return mintAmount;
     }
 
-    /*
-     * @dev Transfer tokens to a receipient
+    /**
+     * @dev Transfer tokens to a receipient. Only callable by BondingManager - always trusts BondingManager
      * @param _to Recipient address
      * @param _amount Amount of tokens
      */
-    function transferTokens(address _to, uint256 _amount) external onlyBondingManager whenSystemNotPaused {
+    function trustedTransferTokens(address _to, uint256 _amount) external onlyBondingManager whenSystemNotPaused {
         livepeerToken().transfer(_to, _amount);
     }
 
-    /*
-     * @dev Burn tokens
+    /**
+     * @dev Burn tokens. Only callable by BondingManager - always trusts BondingManager
      * @param _amount Amount of tokens to burn
      */
-    function burnTokens(uint256 _amount) external onlyBondingManager whenSystemNotPaused {
+    function trustedBurnTokens(uint256 _amount) external onlyBondingManager whenSystemNotPaused {
         livepeerToken().burn(_amount);
     }
 
-    /*
-     * @dev Withdraw ETH to a recipient
+    /**
+     * @dev Withdraw ETH to a recipient. Only callable by BondingManager or JobsManager - always trusts these two contracts
      * @param _to Recipient address
      * @param _amount Amount of ETH
      */
-    function withdrawETH(address _to, uint256 _amount) external onlyBondingManagerOrJobsManager whenSystemNotPaused {
+    function trustedWithdrawETH(address _to, uint256 _amount) external onlyBondingManagerOrJobsManager whenSystemNotPaused {
         _to.transfer(_amount);
     }
 
-    /*
-     * @dev Deposit ETH from the JobsManager
+    /**
+     * @dev Deposit ETH to this contract. Only callable by JobsManager
      */
     function depositETH() external payable onlyJobsManager whenSystemNotPaused returns (bool) {
         return true;
     }
 
-    /*
-     * @dev Set the reward token amounts for the round. Only callable by the RoundsManager
+    /**
+     * @dev Set inflation and mintable tokens for the round. Only callable by the RoundsManager
      */
     function setCurrentRewardTokens() external onlyRoundsManager whenSystemNotPaused {
         setInflation();
 
-        currentMintableTokens = mintedTokensPerRound();
+        // Set mintable tokens based upon current inflation and current total token supply
+        currentMintableTokens = MathUtils.percOf(livepeerToken().totalSupply(), inflation);
         currentMintedTokens = 0;
 
-        SetCurrentRewardTokens(currentMintableTokens);
+        SetCurrentRewardTokens(currentMintableTokens, inflation);
     }
 
-    /*
-     * @dev Set inflation based upon the current bonding rate
+    /**
+     * @dev Returns Controller interface
+     */
+    function getController() public view returns (IController) {
+        return controller;
+    }
+
+    /**
+     * @dev Set inflation based upon the current bonding rate and target bonding rate
      */
     function setInflation() internal {
         uint256 currentBondingRate = 0;
@@ -167,34 +216,24 @@ contract Minter is Manager, IMinter {
                 inflation -= inflationChange;
             }
         }
-
-        NewInflation(inflation);
     }
 
-    /*
-     * @dev Return minted tokens per round based current inflation and token supply
-     */
-    function mintedTokensPerRound() internal view returns (uint256) {
-        uint256 currentSupply = livepeerToken().totalSupply();
-        return MathUtils.percOf(currentSupply, inflation);
-    }
-
-    /*
-     * @dev Returns LivepeerToken
+    /**
+     * @dev Returns LivepeerToken interface
      */
     function livepeerToken() internal view returns (ILivepeerToken) {
         return ILivepeerToken(controller.getContract(keccak256("LivepeerToken")));
     }
 
-    /*
-     * @dev Returns RoundsManager
+    /**
+     * @dev Returns RoundsManager interface
      */
     function roundsManager() internal view returns (IRoundsManager) {
         return IRoundsManager(controller.getContract(keccak256("RoundsManager")));
     }
 
-    /*
-     * @dev Returns BondingManager
+    /**
+     * @dev Returns BondingManager interface
      */
     function bondingManager() internal view returns (IBondingManager) {
         return IBondingManager(controller.getContract(keccak256("BondingManager")));

--- a/test/unit/Minter.js
+++ b/test/unit/Minter.js
@@ -1,31 +1,28 @@
-import Fixture from "../helpers/fixture"
+import Fixture from "./helpers/fixture"
 import BigNumber from "bignumber.js"
 import expectThrow from "../helpers/expectThrow"
+import {constants} from "../../utils/constants"
+import {contractId, functionSig, functionEncodedABI} from "../../utils/helpers"
 
+const GenericMock = artifacts.require("GenericMock")
 const Minter = artifacts.require("Minter")
-
-const PERC_DIVISOR = 1000000
-const PERC_MULTIPLIER = PERC_DIVISOR / 100
-
-const INFLATION = 26 * PERC_MULTIPLIER
-const INFLATION_CHANGE = .02 * PERC_MULTIPLIER
-const TARGET_BONDING_RATE = 50 * PERC_MULTIPLIER
 
 contract("Minter", accounts => {
     let fixture
     let minter
 
+    const PERC_DIVISOR = 1000000
+    const PERC_MULTIPLIER = PERC_DIVISOR / 100
+
+    const INFLATION = 26 * PERC_MULTIPLIER
+    const INFLATION_CHANGE = .02 * PERC_MULTIPLIER
+    const TARGET_BONDING_RATE = 50 * PERC_MULTIPLIER
+
     before(async () => {
         fixture = new Fixture(web3)
-        await fixture.deployController()
-        await fixture.deployMocks()
+        await fixture.deploy()
 
         minter = await fixture.deployAndRegister(Minter, "Minter", fixture.controller.address, INFLATION, INFLATION_CHANGE, TARGET_BONDING_RATE)
-        fixture.minter = minter
-
-        await fixture.bondingManager.setMinter(minter.address)
-        await fixture.jobsManager.setMinter(minter.address)
-        await fixture.roundsManager.setMinter(minter.address)
     })
 
     beforeEach(async () => {
@@ -36,234 +33,305 @@ contract("Minter", accounts => {
         await fixture.tearDown()
     })
 
-    describe("setInflationChange", () => {
-        it("should fail if not called by the Controller's owner", async () => {
-            await expectThrow(minter.setInflationChange(5, {from: accounts[4]}))
+    describe("setTargetBondingRate", () => {
+        it("should fail if caller is not Controller owner", async () => {
+            await expectThrow(minter.setTargetBondingRate(10, {from: accounts[4]}))
         })
 
-        it("should set the inflation change", async () => {
-            await minter.setInflationChange(.1 * PERC_MULTIPLIER)
+        it("should fail if provided targetBondingRate is not a valid percentage", async () => {
+            await expectThrow(minter.setTargetBondingRate(PERC_DIVISOR + 1))
+        })
 
-            const inflationChange = await minter.inflationChange.call()
-            assert.equal(inflationChange, .1 * PERC_MULTIPLIER, "wrong inflation change")
+        it("should set targetBondingRate", async () => {
+            await minter.setTargetBondingRate(10)
+
+            assert.equal(await minter.targetBondingRate.call(), 10, "wrong targetBondingRate")
         })
     })
 
-    describe("createRewards", () => {
-        it("should throw if sender is not bonding manager", async () => {
+    describe("setInflationChange", () => {
+        it("should fail if caller is not Controller owner", async () => {
+            await expectThrow(minter.setInflationChange(5, {from: accounts[4]}))
+        })
+
+        it("should fail if provided inflationChange is not a valid percentage", async () => {
+            await expectThrow(minter.setInflationChange(PERC_DIVISOR + 1))
+        })
+
+        it("should set inflationChange", async () => {
+            await minter.setInflationChange(5)
+
+            assert.equal(await minter.inflationChange.call(), 5, "wrong inflationChange")
+        })
+    })
+
+    describe("migrateToNewMinter", () => {
+        it("should fail if caller is not Controller owner", async () => {
+            await expectThrow(minter.migrateToNewMinter(accounts[1], {from: accounts[4]}))
+        })
+
+        it("should fail if provided new minter is the current minter", async () => {
+            await expectThrow(minter.migrateToNewMinter(minter.address))
+        })
+
+        it("should fail if provided new minter is null address", async () => {
+            await expectThrow(minter.migrateToNewMinter(constants.NULL_ADDRESS))
+        })
+
+        it("should fail if provided new minter does not have a getController() function", async () => {
+            await expectThrow(minter.migrateToNewMinter(accounts[1]))
+        })
+
+        it("should fail if provided new minter has a different controller", async () => {
+            const newMinter = await GenericMock.new()
+            await newMinter.setMockAddress(functionSig("getController()"), accounts[1])
+
+            await expectThrow(minter.migrateToNewMinter(newMinter.address))
+        })
+
+        it("should fail if provided new minter's controller does not have current minter registered", async () => {
+            const newMinter = await GenericMock.new()
+            const controllerAddr = await minter.controller.call()
+            await newMinter.setMockAddress(functionSig("getController()"), controllerAddr)
+            await fixture.controller.setContractInfo(contractId("Minter"), accounts[1], "0x123")
+
+            await expectThrow(minter.migrateToNewMinter(newMinter.address))
+        })
+
+        it("should transfer ownership of the token and current token balance to new minter", async () => {
+            const newMinter = await GenericMock.new()
+            const controllerAddr = await minter.controller.call()
+            await newMinter.setMockAddress(functionSig("getController()"), controllerAddr)
+
+            // Just ensure that this does not fail
+            await minter.migrateToNewMinter(newMinter.address)
+        })
+    })
+
+    describe("createReward", () => {
+        beforeEach(async () => {
+            // Set current supply
+            await fixture.token.setMockUint256(functionSig("totalSupply()"), 1000)
+            // Set current reward tokens
+            await fixture.roundsManager.execute(minter.address, functionSig("setCurrentRewardTokens()"))
+        })
+
+        it("should fail if caller is not BondingManager", async () => {
             await expectThrow(minter.createReward(10, 100))
         })
 
-        it("should compute rewards", async () => {
-            await fixture.token.setTotalSupply(1000)
-            await fixture.bondingManager.setTotalBonded(200)
-            // Set up current reward tokens via RoundsManager
-            await fixture.roundsManager.callSetCurrentRewardTokens()
-
+        it("should update currentMintedTokens with computed reward", async () => {
             // Set up reward call via BondingManager
-            await fixture.bondingManager.setActiveTranscoder(accounts[1], 0, 10, 100)
-            await fixture.bondingManager.reward()
+            await fixture.bondingManager.execute(minter.address, functionEncodedABI("createReward(uint256,uint256)", ["uint256", "uint256"], [10, 100]))
+            const currentMintableTokens = await minter.currentMintableTokens.call()
+            const expCurrentMintedTokens = Math.floor((currentMintableTokens.toNumber() * Math.floor((10 * PERC_DIVISOR) / 100) / PERC_DIVISOR))
 
-            const supply = await fixture.token.totalSupply.call()
-            const inflation = await minter.inflation.call()
-            const mintedTokens = supply.mul(inflation).div(PERC_DIVISOR).floor()
-
-            const mintedTo = await fixture.token.mintedTo.call()
-            assert.equal(mintedTo, minter.address, "wrong minted to address")
-            const minted = await fixture.token.minted.call()
-            assert.equal(minted, mintedTokens.mul(10).div(100).floor().toNumber(), "wrong minted amount")
+            const currentMintedTokens = await minter.currentMintedTokens.call()
+            assert.equal(currentMintedTokens, expCurrentMintedTokens, "wrong currentMintedTokens")
         })
 
-        it("should compute rewards correctly for large fraction = 1", async () => {
+        it("should compute reward correctly for fraction = 1", async () => {
+            // Set up reward call via BondingManager
+            await fixture.bondingManager.execute(minter.address, functionEncodedABI("createReward(uint256,uint256)", ["uint256", "uint256"], [100, 100]))
+            const currentMintableTokens = await minter.currentMintableTokens.call()
+            const expCurrentMintedTokens = Math.floor((currentMintableTokens.toNumber() * Math.floor((100 * PERC_DIVISOR) / 100) / PERC_DIVISOR))
+
+            const currentMintedTokens = await minter.currentMintedTokens.call()
+            assert.equal(currentMintedTokens.toNumber(), expCurrentMintedTokens, "wrong currentMintedTokens")
+        })
+
+        it("should compute reward correctly for large fraction = 1", async () => {
             // If we compute the output of createReward as: (mintedTokens * fracNum) / fracDenom where all the values are bigAmount
             // we would overflow when we try to to do mintedTokens * fracNum
             // Instead we compute the output of createReward as: (mintedTokens * ((fracNum * PERC_DIVISOR) / fracDenom)) / PERC_DIVISOR
             // fracNum * PERC_DIVISOR has less of a chance of overflowing since PERC_DIVISOR is bounded in magnitude
+
             const bigAmount = new BigNumber("10000000000000000000000000000000000000000000000")
-            await fixture.token.setTotalSupply(bigAmount)
-            await fixture.bondingManager.setTotalBonded(bigAmount)
-            // Set up current reward tokens via RoundsManager
-            await fixture.roundsManager.callSetCurrentRewardTokens()
-
-            const supply = await fixture.token.totalSupply.call()
-            const inflation = await minter.inflation.call()
-            const mintedTokens = supply.mul(inflation).div(PERC_DIVISOR).floor()
-            const expMinted = mintedTokens.mul(bigAmount.mul(PERC_DIVISOR).div(bigAmount).floor()).div(PERC_DIVISOR).floor()
-
             // Set up reward call via BondingManager
-            await fixture.bondingManager.setActiveTranscoder(accounts[1], 0, bigAmount, bigAmount)
-            await fixture.bondingManager.reward()
+            await fixture.bondingManager.execute(minter.address, functionEncodedABI("createReward(uint256,uint256)", ["uint256", "uint256"], [bigAmount.toString(), bigAmount.toString()]))
+            const currentMintableTokens = await minter.currentMintableTokens.call()
+            const expCurrentMintedTokens = currentMintableTokens.mul(bigAmount.mul(PERC_DIVISOR).div(bigAmount).floor()).div(PERC_DIVISOR).floor().toNumber()
 
-            let mintedTo = await fixture.token.mintedTo.call()
-            assert.equal(mintedTo, minter.address, "wrong minted to address")
-            let minted = await fixture.token.minted.call()
-            assert.equal(minted.toString(), expMinted.toString(), "wrong minted amount")
+            const currentMintedTokens = await minter.currentMintedTokens.call()
+            assert.equal(currentMintedTokens, expCurrentMintedTokens, "wrong currentMintedTokens")
         })
 
         it("should compute rewards correctly for multiple valid calls", async () => {
-            await fixture.token.setTotalSupply(1000000)
-            await fixture.bondingManager.setTotalBonded(200000)
-            // Set up current reward tokens via RoundsManager
-            await fixture.roundsManager.callSetCurrentRewardTokens()
-
-            const supply = await fixture.token.totalSupply.call()
-            const inflation = await minter.inflation.call()
-            const mintedTokens = supply.mul(inflation).div(PERC_DIVISOR).floor()
-
             // Set up reward call via BondingManager
-            await fixture.bondingManager.setActiveTranscoder(accounts[1], 0, 10, 100)
-            await fixture.bondingManager.reward()
+            await fixture.bondingManager.execute(minter.address, functionEncodedABI("createReward(uint256,uint256)", ["uint256", "uint256"], [10, 100]))
+            // Set up second reward call via BondingManager
+            await fixture.bondingManager.execute(minter.address, functionEncodedABI("createReward(uint256,uint256)", ["uint256", "uint256"], [20, 100]))
 
-            let mintedTo = await fixture.token.mintedTo.call()
-            assert.equal(mintedTo, minter.address, "wrong minted to address")
-            let minted = await fixture.token.minted.call()
-            assert.equal(minted, mintedTokens.mul(10).div(100).floor().toNumber(), "wrong minted amount")
+            const currentMintableTokens = await minter.currentMintableTokens.call()
+            const expMintedTokens0 = Math.floor((currentMintableTokens.toNumber() * Math.floor((10 * PERC_DIVISOR) / 100) / PERC_DIVISOR))
+            const expMintedTokens1 = Math.floor((currentMintableTokens.toNumber() * Math.floor((20 * PERC_DIVISOR) / 100) / PERC_DIVISOR))
 
-            // Set up reward call via BondingManager
-            await fixture.bondingManager.setActiveTranscoder(accounts[1], 0, 20, 100)
-            await fixture.bondingManager.reward()
-
-            mintedTo = await fixture.token.mintedTo.call()
-            assert.equal(mintedTo, minter.address, "wrong minted to address")
-            minted = await fixture.token.minted.call()
-            assert.equal(minted, mintedTokens.mul(20).div(100).floor().toNumber(), "wrong minted amount")
+            const currentMintedTokens = await minter.currentMintedTokens.call()
+            assert.equal(currentMintedTokens, expMintedTokens0 + expMintedTokens1, "wrong currentMintedTokens")
         })
 
-        it("should throw if all mintable tokens have been minted", async () => {
-            await fixture.token.setTotalSupply(1000000)
-            await fixture.bondingManager.setTotalBonded(200000)
-            // Set up current reward tokens via RoundsManager
-            await fixture.roundsManager.callSetCurrentRewardTokens()
-
+        it("should fail if all mintable tokens for current round have been minted", async () => {
             // Set up reward call via BondingManager
-            await fixture.bondingManager.setActiveTranscoder(accounts[1], 0, 100, 100)
-            await fixture.bondingManager.reward()
+            await fixture.bondingManager.execute(minter.address, functionEncodedABI("createReward(uint256,uint256)", ["uint256", "uint256"], [100, 100]))
 
-            await expectThrow(fixture.bondingManager.reward())
+            await expectThrow(fixture.bondingManager.execute(minter.address, functionEncodedABI("createReward(uint256,uint256)", ["uint256", "uint256"], [10, 100])))
        })
     })
 
-    describe("transferTokens", () => {
-        it("should throw if sender is not bonding manager", async () => {
-            await expectThrow(minter.transferTokens(accounts[1], 100))
+    describe("trustedTransferTokens", () => {
+        it("should fail if caller is not BondingManager", async () => {
+            await expectThrow(minter.trustedTransferTokens(accounts[1], 100))
         })
 
-        it("should transfer tokens to receiving address when sender is bonding manager", async () => {
-            await fixture.bondingManager.setWithdrawAmount(100)
-            await fixture.bondingManager.withdraw(false, accounts[1], {from: accounts[1]})
+        it("should transfer tokens to receiving address", async () => {
+            // Just make sure that this does not fail
+            await fixture.bondingManager.execute(minter.address, functionEncodedABI("trustedTransferTokens(address,uint256)", ["address", "uint256"], [accounts[1], 100]))
         })
     })
 
-    describe("withdrawETH", () => {
-        it("should throw if sender is not bonding manager or jobs manager", async () => {
-            await expectThrow(minter.withdrawETH(accounts[1], 100))
+    describe("trustedBurnTokens", () => {
+        it("should fail if caller is not BondingManager", async () => {
+            await expectThrow(minter.trustedBurnTokens(100))
         })
 
-        it("should transfer ETH to receiving address when sender is bonding manager", async () => {
-            await fixture.jobsManager.deposit({from: accounts[0], value: 100})
-            await fixture.bondingManager.setWithdrawAmount(100)
+        it("should burn tokens", async () => {
+            // Just make sure that this does not fail
+            await fixture.bondingManager.execute(minter.address, functionEncodedABI("trustedBurnTokens(uint256)", ["uint256"], [100]))
+        })
+    })
 
-            const startBalance = web3.eth.getBalance(accounts[1])
-            await fixture.bondingManager.withdraw(true, accounts[1], {from: accounts[2]})
-            const endBalance = web3.eth.getBalance(accounts[1])
-
-            assert.equal(endBalance.sub(startBalance), 100, "balance did not update correctly")
+    describe("trustedWithdrawETH", () => {
+        it("should fail if caller is not BondingManager or JobsManager", async () => {
+            await expectThrow(minter.trustedWithdrawETH(accounts[1], 100))
         })
 
-        it("should transfer ETH to receiving address when sender is jobs manager", async () => {
-            await fixture.jobsManager.deposit({from: accounts[0], value: 100})
-            await fixture.jobsManager.setWithdrawAmount(100)
+        it("should fail if insufficient balance when caller is BondingManager", async () => {
+            await expectThrow(fixture.bondingManager.execute(minter.address, functionEncodedABI("trustedWithdrawETH(address,uint256)", ["address", "uint256"], [accounts[1], 100])))
+        })
 
-            const startBalance = web3.eth.getBalance(accounts[1])
-            await fixture.jobsManager.withdraw(true, accounts[1], {from: accounts[2]})
-            const endBalance = web3.eth.getBalance(accounts[1])
+        it("should fail if insufficient balance when caller is JobsManager", async () => {
+            await expectThrow(fixture.jobsManager.execute(minter.address, functionEncodedABI("trustedWithdrawETH(address,uint256)", ["address", "uint256"], [accounts[1], 100])))
+        })
 
-            assert.equal(endBalance.sub(startBalance).toNumber(), 100, "balance did not update correctly")
+        it("should transfer ETH to receiving address when caller is BondingManager", async () => {
+            await fixture.jobsManager.execute(minter.address, functionSig("depositETH()"), {from: accounts[1], value: 100})
+            await fixture.bondingManager.execute(minter.address, functionEncodedABI("trustedWithdrawETH(address,uint256)", ["address", "uint256"], [accounts[1], 100]))
+
+            assert.equal(web3.eth.getBalance(minter.address), 0, "wrong minter balance")
+        })
+
+        it("should transfer ETH to receiving address when caller is JobsManager", async () => {
+            await fixture.jobsManager.execute(minter.address, functionSig("depositETH()"), {from: accounts[1], value: 100})
+            await fixture.jobsManager.execute(minter.address, functionEncodedABI("trustedWithdrawETH(address,uint256)", ["address", "uint256"], [accounts[1], 100]))
+
+            assert.equal(web3.eth.getBalance(minter.address), 0, "wrong minter balance")
         })
     })
 
     describe("depositETH", () => {
-        it("should throw if sender is not jobs manager", async () => {
-            await expectThrow(minter.depositETH({from: accounts[1]}))
+        it("should fail if caller is not JobsManager", async () => {
+            await expectThrow(minter.depositETH({from: accounts[1], value: 100}))
         })
 
-        it("should receive ETH from the jobs manager", async () => {
-            const startBalance = web3.eth.getBalance(minter.address)
-            await fixture.jobsManager.deposit({from: accounts[0], value: 100})
-            const endBalance = web3.eth.getBalance(minter.address)
+        it("should receive ETH from JobsManager", async () => {
+            await fixture.jobsManager.execute(minter.address, functionSig("depositETH()"), {from: accounts[1], value: 100})
 
-            assert.equal(endBalance.sub(startBalance), 100, "minter balance did not update corretly")
-        })
-    })
-
-    describe("burnTokens", () => {
-        it("should throw if sender is not bonding manager", async () => {
-            await expectThrow(minter.burnTokens(100, {from: accounts[1]}))
-        })
-
-        it("should burn an amount of tokens", async () => {
-            await fixture.bondingManager.callBurnTokens(100)
-
-            const burned = await fixture.token.burned.call()
-            assert.equal(burned, 100, "wrong burned amount")
+            assert.equal(web3.eth.getBalance(minter.address), 100, "wrong minter balance")
         })
     })
 
     describe("setCurrentRewardTokens", () => {
-        it("should throw if sender is not rounds manager", async () => {
+        beforeEach(async () => {
+            // Set current supply
+            await fixture.token.setMockUint256(functionSig("totalSupply()"), 1000)
+        })
+
+        it("should fail if caller is not RoundsManager", async () => {
             await expectThrow(minter.setCurrentRewardTokens())
         })
 
-        it("should increase the inflation rate if the current bonding rate is below the target bonding rate", async () => {
-            await fixture.token.setTotalSupply(1000)
-            await fixture.bondingManager.setTotalBonded(400)
-
+        it("should increase the inflation rate if the current bonding rate is 0 (total supply = 0) and below the target bonding rate", async () => {
             const startInflation = await minter.inflation.call()
+
+            // Set total supply to 0
+            await fixture.token.setMockUint256(functionSig("totalSupply()"), 0)
             // Call setCurrentRewardTokens via RoundsManager
-            await fixture.roundsManager.callSetCurrentRewardTokens()
+            await fixture.roundsManager.execute(minter.address, functionSig("setCurrentRewardTokens()"))
+
+            const endInflation = await minter.inflation.call()
+
+            assert.equal(endInflation.sub(startInflation).toNumber(), await minter.inflationChange.call(), "inflation rate did not change correctly")
+        })
+
+        it("should increase the inflation rate if the current bonding rate is below the target bonding rate", async () => {
+            const startInflation = await minter.inflation.call()
+
+            // Set total bonded tokens
+            await fixture.bondingManager.setMockUint256(functionSig("getTotalBonded()"), 400)
+            // Call setCurrentRewardTokens via RoundsManager
+            await fixture.roundsManager.execute(minter.address, functionSig("setCurrentRewardTokens()"))
+
             const endInflation = await minter.inflation.call()
 
             assert.equal(endInflation.sub(startInflation).toNumber(), await minter.inflationChange.call(), "inflation rate did not change correctly")
         })
 
         it("should decrease the inflation rate if the current bonding rate is above the target bonding rate", async () => {
-            await fixture.token.setTotalSupply(1000)
-            await fixture.bondingManager.setTotalBonded(600)
-
             const startInflation = await minter.inflation.call()
+
+            // Set total bonded tokens
+            await fixture.bondingManager.setMockUint256(functionSig("getTotalBonded()"), 600)
             // Call setCurrentRewardTokens via RoundsManager
-            await fixture.roundsManager.callSetCurrentRewardTokens()
+            await fixture.roundsManager.execute(minter.address, functionSig("setCurrentRewardTokens()"))
+
             const endInflation = await minter.inflation.call()
 
             assert.equal(startInflation.sub(endInflation).toNumber(), await minter.inflationChange.call(), "inflation rate did not change correctly")
         })
 
         it("should set the inflation rate to 0 if the inflation change is greater than the inflation and the current bonding rate is above the target bonding rate", async () => {
-            minter = await fixture.deployAndRegister(Minter, "Minter", fixture.controller.address, INFLATION_CHANGE - 1, INFLATION_CHANGE, TARGET_BONDING_RATE)
-            fixture.minter = minter
-
-            await fixture.roundsManager.setMinter(minter.address)
-
-            await fixture.token.setTotalSupply(1000)
-            await fixture.bondingManager.setTotalBonded(600)
-
+            await minter.setInflationChange(INFLATION + 1)
+            // Set total bonded tokens
+            await fixture.bondingManager.setMockUint256(functionSig("getTotalBonded()"), 600)
             // Call setCurrentRewardTokens via RoundsManager
-            await fixture.roundsManager.callSetCurrentRewardTokens()
+            await fixture.roundsManager.execute(minter.address, functionSig("setCurrentRewardTokens()"))
+
             const endInflation = await minter.inflation.call()
 
             assert.equal(endInflation, 0, "inflation rate not set to 0")
         })
 
         it("should maintain the inflation rate if the current bonding rate is equal to the target bonding rate", async () => {
-            await fixture.token.setTotalSupply(1000)
-            await fixture.bondingManager.setTotalBonded(500)
-
             const startInflation = await minter.inflation.call()
+
+            await fixture.bondingManager.setMockUint256(functionSig("getTotalBonded()"), 500)
             // Call setCurrentRewardTokens via RoundsManager
-            await fixture.roundsManager.callSetCurrentRewardTokens()
+            await fixture.roundsManager.execute(minter.address, functionSig("setCurrentRewardTokens()"))
+
             const endInflation = await minter.inflation.call()
 
             assert.equal(startInflation.sub(endInflation).toNumber(), 0, "inflation rate did not stay the same")
+        })
+
+        it("should set currentMintableTokens based on the current inflation and current total token supply", async () => {
+            // Set total bonded tokens - we are at the target bonding rate so inflation does not move
+            await fixture.bondingManager.setMockUint256(functionSig("getTotalBonded()"), 500)
+            // Call setCurrentRewardTokens via RoundsManager
+            await fixture.roundsManager.execute(minter.address, functionSig("setCurrentRewardTokens()"))
+
+            const inflation = await minter.inflation.call()
+            const expCurrentMintableTokens = Math.floor((1000 * inflation.toNumber()) / PERC_DIVISOR)
+
+            assert.equal(await minter.currentMintableTokens.call(), expCurrentMintableTokens, "wrong currentMintableTokens")
+        })
+
+        it("should set currentMintedTokens = 0", async () => {
+            // Set total bonded tokens - we are at the target bonding rate so inflation does not move
+            await fixture.bondingManager.setMockUint256(functionSig("getTotalBonded()"), 500)
+            // Call setCurrentRewardTokens via RoundsManager
+            await fixture.roundsManager.execute(minter.address, functionSig("setCurrentRewardTokens()"))
+
+            assert.equal(await minter.currentMintedTokens.call(), 0, "wrong currentMintedTokens")
         })
     })
 })

--- a/test/unit/Minter.js
+++ b/test/unit/Minter.js
@@ -1,4 +1,4 @@
-import Fixture from "./helpers/fixture"
+import Fixture from "./helpers/Fixture"
 import BigNumber from "bignumber.js"
 import expectThrow from "../helpers/expectThrow"
 import {constants} from "../../utils/constants"

--- a/test/unit/Minter.js
+++ b/test/unit/Minter.js
@@ -109,6 +109,7 @@ contract("Minter", accounts => {
             await minter.migrateToNewMinter(newMinter.address)
 
             assert.equal(web3.eth.getBalance(newMinter.address), 100, "wrong new minter balance")
+            assert.equal(web3.eth.getBalance(minter.address), 0, "wrong old minter balance")
         })
     })
 


### PR DESCRIPTION
Fixes #171 

Also label ETH and token transfer functions in the Minter that always trust their caller as "trusted".