### PR TITLE
Minor JobsManager fixes

### DIFF
--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -237,6 +237,8 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
 
         // End block must be in the future
         require(_endBlock > blockNum);
+        // Transcoding options must be valid
+        require(JobLib.validTranscodingOptions(_transcodingOptions));
 
         Job storage job = jobs[numJobs];
         job.jobId = numJobs;

--- a/contracts/jobs/JobsManager.sol
+++ b/contracts/jobs/JobsManager.sol
@@ -425,6 +425,9 @@ contract JobsManager is ManagerProxyTarget, IVerifiable, IJobsManager {
                 _dataHashes
             );
         } else {
+            // If price is 0, reject any value transfers
+            require(msg.value == 0);
+
             verifierContract.verify(
                 _jobId,
                 _claimId,

--- a/contracts/jobs/libraries/JobLib.sol
+++ b/contracts/jobs/libraries/JobLib.sol
@@ -16,6 +16,17 @@ library JobLib {
     uint8 constant VIDEO_PROFILE_SIZE = 8;
 
     /*
+     * @dev Checks if a transcoding options string is valid
+     * A transcoding options string is composed of video profile ids so its length
+     * must be a multiple of VIDEO_PROFILE_SIZE
+     * @param _transcodingOptions Transcoding options string
+     */
+    function validTranscodingOptions(string _transcodingOptions) public pure returns (bool) {
+        uint256 transcodingOptionsLength = bytes(_transcodingOptions).length;
+        return transcodingOptionsLength > 0 && transcodingOptionsLength % VIDEO_PROFILE_SIZE == 0;
+    }
+
+    /*
      * @dev Computes the amount of fees given total segments, total number of profiles and price per segment
      * @param _totalSegments # of segments
      * @param _transcodingOptions String containing video profiles for a job

--- a/migrations/3_deploy_contracts.js
+++ b/migrations/3_deploy_contracts.js
@@ -44,7 +44,7 @@ module.exports = function(deployer, network) {
         // Set JobsManager parameters
         await jobsManager.setVerificationRate(config.jobsManager.verificationRate)
         await jobsManager.setVerificationPeriod(config.jobsManager.verificationPeriod)
-        await jobsManager.setSlashingPeriod(config.jobsManager.slashingPeriod)
+        await jobsManager.setVerificationSlashingPeriod(config.jobsManager.verificationSlashingPeriod)
         await jobsManager.setFailedVerificationSlashAmount(config.jobsManager.failedVerificationSlashAmount)
         await jobsManager.setMissedVerificationSlashAmount(config.jobsManager.missedVerificationSlashAmount)
         await jobsManager.setDoubleClaimSegmentSlashAmount(config.jobsManager.doubleClaimSegmentSlashAmount)

--- a/migrations/migrations.config.js
+++ b/migrations/migrations.config.js
@@ -14,7 +14,7 @@ module.exports = {
     jobsManager: {
         verificationRate: 100,
         verificationPeriod: 50,
-        slashingPeriod: 50,
+        verificationSlashingPeriod: 50,
         failedVerificationSlashAmount: 1,
         missedVerificationSlashAmount: .1 * PERC_MULTIPLIER,
         doubleClaimSegmentSlashAmount: 3 * PERC_MULTIPLIER,

--- a/test/integration/JobAssignment.js
+++ b/test/integration/JobAssignment.js
@@ -1,4 +1,5 @@
 import {contractId} from "../../utils/helpers"
+import {createTranscodingOptions} from "../../utils/videoProfile"
 
 const Controller = artifacts.require("Controller")
 const BondingManager = artifacts.require("BondingManager")
@@ -80,7 +81,7 @@ contract("JobAssignment", accounts => {
         let nullAddressJobCount = 0
 
         const streamId = "foo"
-        const transcodingOptions = "0x123"
+        const transcodingOptions = createTranscodingOptions(["foo"])
         const maxPricePerSegment = 10
         const endBlock = (await roundsManager.blockNum()).add(1000)
 
@@ -157,7 +158,7 @@ contract("JobAssignment", accounts => {
         let nullAddressJobCount = 0
 
         const streamId = "foo"
-        const transcodingOptions = "0x123"
+        const transcodingOptions = createTranscodingOptions(["foo"])
         const maxPricePerSegment = 1
         const endBlock = (await roundsManager.blockNum()).add(1000)
 

--- a/test/unit/JobsManager.js
+++ b/test/unit/JobsManager.js
@@ -2,6 +2,7 @@ import Fixture from "./helpers/Fixture"
 import expectThrow from "../helpers/expectThrow"
 import {functionSig, functionEncodedABI} from "../../utils/helpers"
 import {constants} from "../../utils/constants"
+import {createTranscodingOptions} from "../../utils/videoProfile"
 import MerkleTree from "../../utils/merkleTree"
 import Segment from "../../utils/segment"
 import batchTranscodeReceiptHashes from "../../utils/batchTranscodeReceipts"
@@ -192,7 +193,7 @@ contract("JobsManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("blockNum()"), currentBlock)
 
             await jobsManager.deposit({from: broadcaster, value: 1000})
-            const transcodingOptions = web3.sha3("foo").slice(0, 10) // 0x + first 4 bytes
+            const transcodingOptions = createTranscodingOptions(["foo"])
             await jobsManager.job("foo", transcodingOptions, 1, endBlock, {from: broadcaster})
         })
 
@@ -216,7 +217,7 @@ contract("JobsManager", accounts => {
         const broadcaster = accounts[0]
         const currentBlock = 100
         const currentRound = 2
-        const transcodingOptions = web3.sha3("foo").slice(0, 10) // 0x + first 4 bytes
+        const transcodingOptions = createTranscodingOptions(["foo"])
 
         beforeEach(async () => {
             await fixture.roundsManager.setMockUint256(functionSig("blockNum()"), currentBlock)
@@ -225,6 +226,14 @@ contract("JobsManager", accounts => {
 
         it("should fail if end block is not in the future", async () => {
             await expectThrow(jobsManager.job("foo", transcodingOptions, 1, currentBlock, {from: broadcaster}))
+        })
+
+        it("should fail if transcodingOptions is invalid (not a multiple of video profile id size)", async () => {
+            await expectThrow(jobsManager.job("foo", "bar", 1, currentBlock + 50, {from: broadcaster}))
+        })
+
+        it("should fail if transcodingOptions is invalid (0 length)", async () => {
+            await expectThrow(jobsManager.job("foo", "", 1, currentBlock + 50, {from: broadcaster}))
         })
 
         it("should create a transcode job", async () => {
@@ -281,7 +290,7 @@ contract("JobsManager", accounts => {
         const transcoder = accounts[1]
         const currentBlock = 100
         const currentRound = 2
-        const transcodingOptions = web3.sha3("foo").slice(0, 10) // 0x + first 4 bytes
+        const transcodingOptions = createTranscodingOptions(["foo"])
         const segmentRange = [0, 3]
         const claimRoot = web3.sha3("foo")
 
@@ -334,7 +343,7 @@ contract("JobsManager", accounts => {
         it("should transfer fees to job escrow and decrease broadcaster deposit", async () => {
             await jobsManager.claimWork(1, segmentRange, claimRoot, {from: transcoder})
 
-            const fees = (transcodingOptions.slice(2).length / 8) * (segmentRange[1] - segmentRange[0] + 1)
+            const fees = (transcodingOptions.length / 8) * (segmentRange[1] - segmentRange[0] + 1)
 
             const jInfo = await jobsManager.getJob(1)
             assert.equal(jInfo[8].toNumber(), fees, "wrong job escrow")
@@ -379,7 +388,7 @@ contract("JobsManager", accounts => {
         const transcoder = accounts[1]
         const currentBlock = 100
         const currentRound = 2
-        const transcodingOptions = web3.sha3("foo").slice(0, 10) // 0x + first 4 bytes
+        const transcodingOptions = createTranscodingOptions(["foo"])
         const segmentRange = [0, 3]
 
         // Segment data hashes
@@ -502,7 +511,7 @@ contract("JobsManager", accounts => {
         const transcoder = accounts[1]
         const currentBlock = 100
         const currentRound = 2
-        const transcodingOptions = web3.sha3("foo").slice(0, 10)
+        const transcodingOptions = createTranscodingOptions(["foo"])
         const segmentRange = [0, 3]
         const claimRoot = web3.sha3("foo")
 
@@ -569,7 +578,7 @@ contract("JobsManager", accounts => {
         const transcoder = accounts[1]
         const currentBlock = 100
         const currentRound = 2
-        const transcodingOptions = web3.sha3("foo").slice(0, 10)
+        const transcodingOptions = createTranscodingOptions(["foo"])
         const segmentRange = [0, 3]
         const claimRoot = web3.sha3("foo")
 
@@ -666,7 +675,7 @@ contract("JobsManager", accounts => {
         const transcoder = accounts[1]
         const currentBlock = 100
         const currentRound = 2
-        const transcodingOptions = web3.sha3("foo").slice(0, 10)
+        const transcodingOptions = createTranscodingOptions(["foo"])
         const segmentRange = [0, 3]
         const claimRoot = web3.sha3("foo")
 
@@ -721,7 +730,7 @@ contract("JobsManager", accounts => {
         const watcher = accounts[2]
         const currentBlock = 100
         const currentRound = 2
-        const transcodingOptions = web3.sha3("foo").slice(0, 10)
+        const transcodingOptions = createTranscodingOptions(["foo"])
         const segmentRange = [0, 3]
 
         // Segment data hashes
@@ -869,7 +878,7 @@ contract("JobsManager", accounts => {
         const watcher = accounts[2]
         const currentBlock = 100
         const currentRound = 2
-        const transcodingOptions = web3.sha3("foo").slice(0, 10)
+        const transcodingOptions = createTranscodingOptions(["foo"])
         const claimRoot = web3.sha3("foo")
 
         beforeEach(async () => {
@@ -968,7 +977,7 @@ contract("JobsManager", accounts => {
         const broadcaster = accounts[0]
         const currentBlock = 100
         const currentRound = 2
-        const transcodingOptions = web3.sha3("foo").slice(0, 10) // 0x + first 4 bytes
+        const transcodingOptions = createTranscodingOptions(["foo"])
 
         beforeEach(async () => {
             await fixture.roundsManager.setMockUint256(functionSig("blockNum()"), currentBlock)
@@ -994,7 +1003,7 @@ contract("JobsManager", accounts => {
         const transcoder = accounts[1]
         const currentBlock = 100
         const currentRound = 2
-        const transcodingOptions = web3.sha3("foo").slice(0, 10) // 0x + first 4 bytes
+        const transcodingOptions = createTranscodingOptions(["foo"])
         const segmentRange = [0, 3]
 
         // Segment data hashes

--- a/test/unit/JobsManager.js
+++ b/test/unit/JobsManager.js
@@ -478,6 +478,11 @@ contract("JobsManager", accounts => {
             await expectThrow(jobsManager.verify(1, 0, 0, dataStorageHash, correctDataHashes, correctSig, badProof, {from: transcoder}))
         })
 
+        it("should fail if non-zero value is provided when the price of verification is 0", async () => {
+            await fixture.verifier.setMockUint256(functionSig("getPrice()"), 0)
+            await expectThrow(jobsManager.verify(1, 0, 0, dataStorageHash, correctDataHashes, correctSig, correctProof, {from: transcoder, value: 100}))
+        })
+
         it("should mark segment as submitted for verification", async () => {
             await jobsManager.verify(1, 0, 0, dataStorageHash, correctDataHashes, correctSig, correctProof, {from: transcoder})
 


### PR DESCRIPTION
Fixes #176 
Fixes #169 

Changes the `slashingPeriod` parameter to `verificationSlashingPeriod` to make it more clear that this parameter defines the length of the slashing period specifically for verification related faults (i.e. missed verification) and to eliminate any potential confusion with regards to when slashing can happen (slashing for non-verification related faults like double claiming segments can occur at any time).