### PR TITLE
Allow transcoders with insufficient delegated stake to set rewardCut, feeShare, price

### DIFF
--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.4.17;
  * TODO: switch to interface type
  */
 contract IBondingManager {
-    event TranscoderUpdate(address indexed transcoder, uint256 pendingRewardCut, uint256 pendingFeeShare, uint256 pendingPricePerSegment);
+    event TranscoderUpdate(address indexed transcoder, uint256 pendingRewardCut, uint256 pendingFeeShare, uint256 pendingPricePerSegment, bool registered);
     event TranscoderEvicted(address indexed transcoder);
     event TranscoderResigned(address indexed transcoder);
     event TranscoderSlashed(address indexed transcoder, address finder, uint256 penalty, uint256 finderReward);


### PR DESCRIPTION
Closes #191 

Allows a user campaigning to become a transcoder to still invoke `transcoder` to set rewardCut, feeShare and pricePerSegment even if the transcoder pool is full and they do not have sufficient delegated stake to join the pool