### PR TITLE
Disallow transcoders delegating toward other transcoders

### DIFF
--- a/test/integration/Delegation.js
+++ b/test/integration/Delegation.js
@@ -1,7 +1,7 @@
 import {contractId} from "../../utils/helpers"
 import {constants} from "../../utils/constants"
 import BigNumber from "bignumber.js"
-import expectThrow from "../helpers/expectThrow";
+import expectThrow from "../helpers/expectThrow"
 
 const Controller = artifacts.require("Controller")
 const BondingManager = artifacts.require("BondingManager")

--- a/test/integration/Delegation.js
+++ b/test/integration/Delegation.js
@@ -1,6 +1,7 @@
 import {contractId} from "../../utils/helpers"
 import {constants} from "../../utils/constants"
 import BigNumber from "bignumber.js"
+import expectThrow from "../helpers/expectThrow";
 
 const Controller = artifacts.require("Controller")
 const BondingManager = artifacts.require("BondingManager")
@@ -115,6 +116,10 @@ contract("Delegation", accounts => {
         assert.equal(endBond.sub(startBond), 1000, "delegator 1 bonded amount did not increase correctly")
     })
 
+    it("transcoder 1 tries to bond to transcoder 2 and fails", async () => {
+        await expectThrow(bondingManager.bond(0, transcoder2, {from: transcoder1}))
+    })
+
     it("delegator 1 unbonds and withdraws its stake", async () => {
         const unbondingPeriod = await bondingManager.unbondingPeriod.call()
 
@@ -132,6 +137,7 @@ contract("Delegation", accounts => {
         assert.equal(dInfo[5], currentRound.add(unbondingPeriod).toNumber(), "wrong withdraw round")
         assert.equal(dInfo[6], currentRound.toNumber(), "wrong last claim round")
         assert.equal((await bondingManager.getDelegator(transcoder1))[3], 1000, "wrong transcoder delegated amount")
+        assert.equal(await bondingManager.transcoderTotalStake(transcoder1), 1000, "wrong transcoder total stake")
 
         // Fast forward through unbonding period
         await roundsManager.mineBlocks(unbondingPeriod.mul(roundLength).toNumber())
@@ -169,6 +175,7 @@ contract("Delegation", accounts => {
         assert.equal(dInfo[5], currentRound.add(unbondingPeriod).toNumber(), "wrong withdraw round")
         assert.equal(dInfo[6], currentRound.toNumber(), "wrong last claim round")
         assert.equal((await bondingManager.getDelegator(transcoder2))[3], 1000, "wrong transcoder delegated amount")
+        assert.equal(await bondingManager.transcoderTotalStake(transcoder2), 1000, "wrong transcoder total stake")
 
         // Delegator 2 bonds to transcoder 1 before unbonding period is over
         await bondingManager.bond(0, transcoder1, {from: delegator2})
@@ -200,6 +207,7 @@ contract("Delegation", accounts => {
         assert.equal(dInfo[5], currentRound.add(unbondingPeriod).toNumber(), "wrong withdraw round")
         assert.equal(dInfo[6], currentRound.toNumber(), "wrong last claim round")
         assert.equal((await bondingManager.getDelegator(transcoder2))[3], 1000, "wrong transcoder delegated amount")
+        assert.equal(await bondingManager.transcoderTotalStake(transcoder2), 1000, "wrong transcoder total stake")
 
         await roundsManager.mineBlocks(roundLength.toNumber() * 1000)
         await roundsManager.initializeRound()
@@ -215,5 +223,6 @@ contract("Delegation", accounts => {
         assert.equal(dInfo[5], 0, "wrong withdraw round")
         assert.equal(dInfo[6], currentRound.toNumber(), "wrong last claim round")
         assert.equal((await bondingManager.getDelegator(transcoder2))[3], 2000, "wrong transcoder delegated amount")
+        assert.equal(await bondingManager.transcoderTotalStake(transcoder2), 2000, "wrong transcoder total stake")
     })
 })

--- a/test/integration/SystemPause.js
+++ b/test/integration/SystemPause.js
@@ -1,0 +1,109 @@
+import {contractId} from "../../utils/helpers"
+import {constants} from "../../utils/constants"
+import BigNumber from "bignumber.js"
+import expectThrow from "../helpers/expectThrow"
+
+const Controller = artifacts.require("Controller")
+const BondingManager = artifacts.require("BondingManager")
+const AdjustableRoundsManager = artifacts.require("AdjustableRoundsManager")
+const LivepeerToken = artifacts.require("LivepeerToken")
+
+contract("System Pause", accounts => {
+    const TOKEN_UNIT = 10 ** 18
+
+    let controller
+    let bondingManager
+    let roundsManager
+    let token
+
+    let transcoder1
+    let delegator1
+    let delegator2
+
+    let roundLength
+
+    before(async () => {
+        transcoder1 = accounts[0]
+        delegator1 = accounts[2]
+        delegator2 = accounts[3]
+
+        controller = await Controller.deployed()
+        await controller.unpause()
+
+        const bondingManagerAddr = await controller.getContract(contractId("BondingManager"))
+        bondingManager = await BondingManager.at(bondingManagerAddr)
+
+        const roundsManagerAddr = await controller.getContract(contractId("RoundsManager"))
+        roundsManager = await AdjustableRoundsManager.at(roundsManagerAddr)
+
+        const tokenAddr = await controller.getContract(contractId("LivepeerToken"))
+        token = await LivepeerToken.at(tokenAddr)
+
+        const transferAmount = new BigNumber(10).times(TOKEN_UNIT)
+        await token.transfer(transcoder1, transferAmount, {from: accounts[0]})
+        await token.transfer(delegator1, transferAmount, {from: accounts[0]})
+        await token.transfer(delegator2, transferAmount, {from: accounts[0]})
+
+        roundLength = await roundsManager.roundLength.call()
+        await roundsManager.mineBlocks(roundLength.toNumber() * 1000)
+        await roundsManager.initializeRound()
+    })
+
+    it("registers transcoder 1 that self bonds", async () => {
+        await token.approve(bondingManager.address, 1000, {from: transcoder1})
+        await bondingManager.bond(1000, transcoder1, {from: transcoder1})
+        await bondingManager.transcoder(0, 5, 100, {from: transcoder1})
+
+        assert.equal(await bondingManager.transcoderStatus(transcoder1), 1, "wrong transcoder status")
+    })
+
+    it("delegator 1 bonds to transcoder 1", async () => {
+        await token.approve(bondingManager.address, 1000, {from: delegator1})
+        await bondingManager.bond(500, transcoder1, {from: delegator1})
+
+        const bond = (await bondingManager.getDelegator(delegator1))[0]
+        assert.equal(bond, 500, "delegator 1 bonded amount incorrect")
+    })
+
+    it("delegator 2 bonds to transcoder 1", async () => {
+        await token.approve(bondingManager.address, 1000, {from: delegator2})
+        await bondingManager.bond(500, transcoder1, {from: delegator2})
+
+        const bond = (await bondingManager.getDelegator(delegator2))[0]
+        assert.equal(bond, 500, "delegator 2 bonded amount incorrect")
+    })
+
+    it("transcoder calls reward, system is paused and resumed 5 rounds later", async () => {
+        await roundsManager.mineBlocks(roundLength)
+        await roundsManager.initializeRound()
+
+        const pauseRound = await roundsManager.currentRound()
+        await bondingManager.reward({from: transcoder1})
+        const pauseRoundReward = (await bondingManager.getTranscoderEarningsPoolForRound(transcoder1, pauseRound))[0]
+
+        await controller.pause()
+        await roundsManager.mineBlocks(roundLength * 5)
+        await controller.unpause()
+        await roundsManager.initializeRound()
+
+        const currentRound = await roundsManager.currentRound()
+        const t1RewardShare = pauseRoundReward.div(2).floor()
+        const d1RewardShare = pauseRoundReward.div(4).floor()
+        const d2RewardShare = pauseRoundReward.div(4).floor()
+
+        const startT1Info = await bondingManager.getDelegator(transcoder1)
+        await bondingManager.claimEarnings(currentRound, {from: transcoder1})
+        const endT1Info = await bondingManager.getDelegator(transcoder1)
+        assert.equal(endT1Info[0].sub(startT1Info[0]), t1RewardShare.toNumber(), "wrong bonded amount for transcoder 1")
+
+        const startD1Info = await bondingManager.getDelegator(delegator1)
+        await bondingManager.claimEarnings(currentRound, {from: delegator1})
+        const endD1Info = await bondingManager.getDelegator(delegator1)
+        assert.equal(endD1Info[0].sub(startD1Info[0]), d1RewardShare.toNumber(), "wrong bonded amount for delegator 1")
+
+        const startD2Info = await bondingManager.getDelegator(delegator2)
+        await bondingManager.claimEarnings(currentRound, {from: delegator2})
+        const endD2Info = await bondingManager.getDelegator(delegator2)
+        assert.equal(endD2Info[0].sub(startD2Info[0]), d2RewardShare.toNumber(), "wrong bonded amount for delegator 2")
+    })
+})

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -512,6 +512,10 @@ contract("BondingManager", accounts => {
             })
 
             describe("caller is changing delegate", () => {
+                it("should fail if caller is a registered transcoder", async () => {
+                    await expectThrow(bondingManager.bond(0, transcoder1, {from: transcoder0}))
+                })
+
                 it("should set startRound to next round", async () => {
                     await bondingManager.bond(0, transcoder1, {from: delegator})
 
@@ -690,6 +694,17 @@ contract("BondingManager", accounts => {
                     assert.isNotOk(await bondingManager.isActiveTranscoder(transcoder, currentRound + 1), "should set active transcoder as inactive for the round")
                     assert.equal(startTotalActiveStake.sub(endTotalActiveStake).toNumber(), 2000, "should decrease total active stake by total stake of transcoder")
                 })
+            })
+        })
+
+        describe("delegate is not self and is a registered transcoder", () => {
+            it("should decrease transcoder's delegated stake", async () => {
+                const startTranscoderTotalStake = await bondingManager.transcoderTotalStake(transcoder)
+                await bondingManager.unbond({from: delegator})
+                const endTranscoderTotalStake = await bondingManager.transcoderTotalStake(transcoder)
+
+                const dInfo = await bondingManager.getDelegator(delegator)
+                assert.equal(startTranscoderTotalStake.sub(endTranscoderTotalStake), dInfo[0].toNumber(), "should decrease transcoder total stake")
             })
         })
     })


### PR DESCRIPTION
- Restrict transcoders from delegating toward other transcoders
- Update accounting in `unbond()` to always reduce delegated stake if delegate is a registered transcoder