### PR TITLE
Implement LIP-11: Bond Event Details

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -279,6 +279,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         uint256 currentRound = roundsManager().currentRound();
         // Amount to delegate
         uint256 delegationAmount = _amount;
+        // Current delegate
+        address currentDelegate = del.delegateAddress;
 
         if (delegatorStatus(msg.sender) == DelegatorStatus.Unbonded) {
             // New delegate
@@ -300,12 +302,12 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             // Update amount to delegate with previous delegation amount
             delegationAmount = delegationAmount.add(del.bondedAmount);
             // Decrease old delegate's delegated amount
-            delegators[del.delegateAddress].delegatedAmount = delegators[del.delegateAddress].delegatedAmount.sub(del.bondedAmount);
+            delegators[currentDelegate].delegatedAmount = delegators[currentDelegate].delegatedAmount.sub(del.bondedAmount);
 
-            if (transcoderStatus(del.delegateAddress) == TranscoderStatus.Registered) {
+            if (transcoderStatus(currentDelegate) == TranscoderStatus.Registered) {
                 // Previously delegated to a transcoder
                 // Decrease old transcoder's total stake
-                transcoderPool.updateKey(del.delegateAddress, transcoderPool.getKey(del.delegateAddress).sub(del.bondedAmount), address(0), address(0));
+                transcoderPool.updateKey(currentDelegate, transcoderPool.getKey(currentDelegate).sub(del.bondedAmount), address(0), address(0));
             }
         }
 
@@ -331,7 +333,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             livepeerToken().transferFrom(msg.sender, minter(), _amount);
         }
 
-        Bond(_to, msg.sender);
+        Bond(_to, currentDelegate, msg.sender, _amount, del.bondedAmount);
     }
 
     /**

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -11,7 +11,7 @@ contract IBondingManager {
     event TranscoderResigned(address indexed transcoder);
     event TranscoderSlashed(address indexed transcoder, address finder, uint256 penalty, uint256 finderReward);
     event Reward(address indexed transcoder, uint256 amount);
-    event Bond(address indexed delegate, address indexed delegator);
+    event Bond(address indexed newDelegate, address indexed oldDelegate, address indexed delegator, uint256 additionalAmount, uint256 bondedAmount);
     event Unbond(address indexed delegate, address indexed delegator, uint256 unbondingLockId, uint256 amount, uint256 withdrawRound);
     event Rebond(address indexed delegate, address indexed delegator, uint256 unbondingLockId, uint256 amount);
     event WithdrawStake(address indexed delegator, uint256 unbondingLockId, uint256 amount, uint256 withdrawRound);

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -444,6 +444,22 @@ contract("BondingManager", accounts => {
                 assert.equal(endTotalBonded.sub(startTotalBonded), 1000, "wrong change in totalBonded")
             })
 
+            it("should fire a Bond event when bonding from unbonded", async () => {
+                const e = bondingManager.Bond({})
+
+                e.watch(async (err, result) => {
+                    e.stopWatching()
+
+                    assert.equal(result.args.newDelegate, transcoder0, "wrong newDelegate in Bond event")
+                    assert.equal(result.args.oldDelegate, constants.NULL_ADDRESS, "wrong oldDelegate in Bond event")
+                    assert.equal(result.args.delegator, delegator, "wrong delegator in Bond event")
+                    assert.equal(result.args.additionalAmount, 1000, "wrong additionalAmount in Bond event")
+                    assert.equal(result.args.bondedAmount, 1000, "wrong bondedAmount in Bond event")
+                })
+
+                await bondingManager.bond(1000, transcoder0, {from: delegator})
+            })
+
             describe("delegate is a registered transcoder", () => {
                 it("should increase transcoder's delegated stake in pool", async () => {
                     const startTranscoderTotalStake = await bondingManager.transcoderTotalStake(transcoder0)
@@ -535,6 +551,22 @@ contract("BondingManager", accounts => {
                         assert.equal(endTotalBonded.sub(startTotalBonded), 0, "totalBonded change should be 0")
                     })
 
+                    it("should fire a Bond event when changing delegates", async () => {
+                        const e = bondingManager.Bond({})
+
+                        e.watch(async (err, result) => {
+                            e.stopWatching()
+
+                            assert.equal(result.args.newDelegate, transcoder1, "wrong newDelegate in Bond event")
+                            assert.equal(result.args.oldDelegate, transcoder0, "wrong oldDelegate in Bond event")
+                            assert.equal(result.args.delegator, delegator, "wrong delegator in Bond event")
+                            assert.equal(result.args.additionalAmount, 0, "wrong additionalAmount in Bond event")
+                            assert.equal(result.args.bondedAmount, 2000, "wrong bondedAmount in Bond event")
+                        })
+
+                        await bondingManager.bond(0, transcoder1, {from: delegator})
+                    })
+
                     describe("new delegate is registered transcoder", () => {
                         it("should increase transcoder's total stake in pool with current bonded stake", async () => {
                             const startTranscoderTotalStake = await bondingManager.transcoderTotalStake(transcoder1)
@@ -581,6 +613,22 @@ contract("BondingManager", accounts => {
                         assert.equal(endTotalBonded.sub(startTotalBonded), 1000, "wrong change in totalBonded")
                     })
 
+                    it("should fire a Bond event when increasing bonded stake and changing delegates", async () => {
+                        const e = bondingManager.Bond({})
+
+                        e.watch(async (err, result) => {
+                            e.stopWatching()
+
+                            assert.equal(result.args.newDelegate, transcoder1, "wrong newDelegate in Bond event")
+                            assert.equal(result.args.oldDelegate, transcoder0, "wrong oldDelegate in Bond event")
+                            assert.equal(result.args.delegator, delegator, "wrong delegator in Bond event")
+                            assert.equal(result.args.additionalAmount, 1000, "wrong additionalAmount in Bond event")
+                            assert.equal(result.args.bondedAmount, 3000, "wrong bondedAmount in Bond event")
+                        })
+
+                        await bondingManager.bond(1000, transcoder1, {from: delegator})
+                    })
+
                     describe("new delegate is registered transcoder", () => {
                         it("should increase transcoder's total stake in pool with current bonded stake + provided amount", async () => {
                             const startTranscoderTotalStake = await bondingManager.transcoderTotalStake(transcoder1)
@@ -622,6 +670,22 @@ contract("BondingManager", accounts => {
                     const endTotalBonded = await bondingManager.getTotalBonded()
 
                     assert.equal(endTotalBonded.sub(startTotalBonded), 1000, "wrong change in totalBonded")
+                })
+
+                it("should fire a Bond event when increasing bonded amount", async () => {
+                    const e = bondingManager.Bond({})
+
+                    e.watch(async (err, result) => {
+                        e.stopWatching()
+
+                        assert.equal(result.args.newDelegate, transcoder0, "wrong newDelegate in Bond event")
+                        assert.equal(result.args.oldDelegate, transcoder0, "wrong oldDelegate in Bond event")
+                        assert.equal(result.args.delegator, delegator, "wrong delegator in Bond event")
+                        assert.equal(result.args.additionalAmount, 1000, "wrong additionalAmount in Bond event")
+                        assert.equal(result.args.bondedAmount, 3000, "wrong bondedAmount in Bond event")
+                    })
+
+                    await bondingManager.bond(1000, transcoder0, {from: delegator})
                 })
             })
         })


### PR DESCRIPTION
Implementation for [LIP-11](https://github.com/livepeer/LIPs/blob/master/LIPs/LIP-11.md).

Note: Decided to use the name `bondedAmount` instead of `delegationAmount` (which is used in the spec) for the `Bond()` event signature because it feels clearer - the value should reflect the delegator's current bonded amount at the end of the state transition execution of the `bond()` function.