### PR TITLE
Emit correct delegate address in Unbond event when fully unbonding

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -356,6 +356,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         // Amount to unbond must be less than or equal to current bonded amount 
         require(_amount <= del.bondedAmount);
 
+        address currentDelegate = del.delegateAddress;
         uint256 currentRound = roundsManager().currentRound();
         uint256 withdrawRound = currentRound.add(unbondingPeriod);
         uint256 unbondingLockId = del.nextUnbondingLockId;
@@ -397,7 +398,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             }
         } 
 
-        Unbond(del.delegateAddress, msg.sender, unbondingLockId, _amount, withdrawRound);
+        Unbond(currentDelegate, msg.sender, unbondingLockId, _amount, withdrawRound);
     }
 
     /**


### PR DESCRIPTION
- Keep track of a delegator's current delegate prior to fully unbonding so that the `Unbond` event can be emitted with the tracked delegate address (as opposed to the current behavior of emitting the event with the null address). Fixes #232 
- Add unit tests for the fields included in the `Unbond` event when partial unbonding and fully unbonding.