### PR TITLE
PM: Allow sender to approve signers

### DIFF
--- a/contracts/pm/ERC20TicketBroker.sol
+++ b/contracts/pm/ERC20TicketBroker.sol
@@ -21,6 +21,23 @@ contract ERC20TicketBroker is TicketBroker {
         token = ERC20(_token);
     }
 
+    function fundAndApproveSigners(
+        uint256 _depositAmount,
+        uint256 _penaltyEscrowAmount,
+        address[] _signers
+    )
+        external
+        processDeposit(msg.sender, _depositAmount)
+        processPenaltyEscrow(msg.sender, _penaltyEscrowAmount)
+    {
+        approveSigners(_signers);
+
+        require(
+            token.transferFrom(msg.sender, address(this), _depositAmount + _penaltyEscrowAmount),
+            "token transfer for deposit and penalty escrow failed"
+        );
+    }
+
     function fundDeposit(uint256 _amount) 
         external
         processDeposit(msg.sender, _amount)

--- a/contracts/pm/ETHTicketBroker.sol
+++ b/contracts/pm/ETHTicketBroker.sol
@@ -14,6 +14,20 @@ contract ETHTicketBroker is TicketBroker {
         public 
     {}
 
+    function fundAndApproveSigners(
+        uint256 _depositAmount,
+        uint256 _penaltyEscrowAmount,
+        address[] _signers
+    )
+        external
+        payable
+        checkDepositPenaltyEscrowETHValueSplit(_depositAmount, _penaltyEscrowAmount)
+        processDeposit(msg.sender, _depositAmount)
+        processPenaltyEscrow(msg.sender, _penaltyEscrowAmount)
+    {
+        approveSigners(_signers);
+    }
+
     function fundDeposit() 
         external
         payable

--- a/contracts/pm/LivepeerETHTicketBroker.sol
+++ b/contracts/pm/LivepeerETHTicketBroker.sol
@@ -31,6 +31,21 @@ contract LivepeerETHTicketBroker is ManagerProxyTarget, TicketBroker {
         unlockPeriod = _unlockPeriod;
     }
 
+    function fundAndApproveSigners(
+        uint256 _depositAmount,
+        uint256 _penaltyEscrowAmount,
+        address[] _signers
+    )
+        external
+        payable
+        checkDepositPenaltyEscrowETHValueSplit(_depositAmount, _penaltyEscrowAmount)
+        processDeposit(msg.sender, _depositAmount)
+        processPenaltyEscrow(msg.sender, _penaltyEscrowAmount)
+    {
+        approveSigners(_signers);
+        minter().trustedDepositETH.value(msg.value)();
+    }
+
     function fundDeposit()
         external
         payable

--- a/contracts/pm/TicketBroker.sol
+++ b/contracts/pm/TicketBroker.sol
@@ -11,6 +11,7 @@ contract TicketBroker {
         uint256 deposit;
         uint256 penaltyEscrow;
         uint256 withdrawBlock;
+        mapping (address => bool) signers;
     }
 
     struct Ticket {
@@ -31,6 +32,7 @@ contract TicketBroker {
 
     event DepositFunded(address indexed sender, uint256 amount);
     event PenaltyEscrowFunded(address indexed sender, uint256 amount);
+    event SignersApproved(address indexed sender, address[] approvedSigners);
     event WinningTicketRedeemed(
         address indexed sender,
         address indexed recipient,
@@ -75,6 +77,16 @@ contract TicketBroker {
     constructor(uint256 _minPenaltyEscrow, uint256 _unlockPeriod) internal {
         minPenaltyEscrow = _minPenaltyEscrow;
         unlockPeriod = _unlockPeriod;
+    }
+
+    function approveSigners(address[] _signers) public {
+        Sender storage sender = senders[msg.sender];
+
+        for (uint256 i = 0; i < _signers.length; i++) {
+            sender.signers[_signers[i]] = true;
+        }
+
+        emit SignersApproved(msg.sender, _signers);
     }
 
     function redeemWinningTicket(Ticket memory _ticket, bytes _sig, uint256 _recipientRand) public {
@@ -179,16 +191,16 @@ contract TicketBroker {
         return _isUnlockInProgress(sender);
     }
 
+    function isApprovedSigner(address _sender, address _signer) public view returns (bool) {
+        return senders[_sender].signers[_signer];
+    }
+
     function _cancelUnlock(Sender storage _sender, address _senderAddress) internal {
         require(_isUnlockInProgress(_sender), "no unlock request in progress");
 
         _sender.withdrawBlock = 0;
 
         emit UnlockCancelled(_senderAddress);
-    }
-
-    function _isUnlockInProgress(Sender memory sender) internal pure returns (bool) {
-        return sender.withdrawBlock > 0;
     }
 
     // Override
@@ -235,6 +247,19 @@ contract TicketBroker {
         );
     }
 
+    function isValidTicketSig(
+        address _sender,
+        bytes _sig,
+        bytes32 _ticketHash
+    )
+        internal
+        view
+        returns (bool)
+    {
+        address signer = ECDSA.recover(ECDSA.toEthSignedMessageHash(_ticketHash), _sig);
+        return signer != address(0) && (_sender == signer || isApprovedSigner(_sender, signer));
+    }
+
     function getTicketHash(Ticket memory _ticket) internal pure returns (bytes32) {
         return keccak256(
             abi.encodePacked(
@@ -253,8 +278,7 @@ contract TicketBroker {
         return uint256(keccak256(abi.encodePacked(_ticketHash, _recipientRand))) < _winProb;
     }
 
-    function isValidTicketSig(address _sender, bytes _sig, bytes32 _ticketHash) internal pure returns (bool) {
-        address signer = ECDSA.recover(ECDSA.toEthSignedMessageHash(_ticketHash), _sig);
-        return signer != address(0) && _sender == signer;
+    function _isUnlockInProgress(Sender memory sender) internal pure returns (bool) {
+        return sender.withdrawBlock > 0;
     }
 }

--- a/contracts/pm/TicketBroker.sol
+++ b/contracts/pm/TicketBroker.sol
@@ -48,6 +48,15 @@ contract TicketBroker {
     event UnlockCancelled(address indexed sender);
     event Withdrawal(address indexed sender, uint256 deposit, uint256 penaltyEscrow);
 
+    modifier checkDepositPenaltyEscrowETHValueSplit(uint256 _depositAmount, uint256 _penaltyEscrowAmount) {
+        require(
+            msg.value == _depositAmount + _penaltyEscrowAmount,
+            "msg.value does not equal sum of deposit amount and penalty escrow amount"
+        );
+
+        _;
+    }
+
     modifier processDeposit(address _sender, uint256 _amount) {
         Sender storage sender = senders[_sender];
         sender.deposit += _amount;

--- a/test/unit/LivepeerETHTicketBroker.js
+++ b/test/unit/LivepeerETHTicketBroker.js
@@ -181,6 +181,107 @@ contract("LivepeerETHTicketBroker", accounts => {
         })
     })
 
+    describe("fundAndApproveSigners", () => {
+        const signers = accounts.slice(2, 4)
+
+        it("reverts if msg.value < sum of deposit amount and penalty escrow amount", async () => {
+            const deposit = 500
+            const penaltyEscrow = 1000
+
+            await expectRevertWithReason(
+                broker.fundAndApproveSigners(
+                    deposit,
+                    penaltyEscrow,
+                    signers,
+                    {from: sender, value: deposit + penaltyEscrow - 1}
+                ),
+                "msg.value does not equal sum of deposit amount and penalty escrow amount"
+            )
+        })
+
+        it("reverts if msg.value > sum of deposit amount and penalty escrow amount", async () => {
+            const deposit = 500
+            const penaltyEscrow = 1000
+
+            await expectRevertWithReason(
+                broker.fundAndApproveSigners(
+                    deposit,
+                    penaltyEscrow,
+                    signers,
+                    {from: sender, value: deposit + penaltyEscrow + 1}
+                ),
+                "msg.value does not equal sum of deposit amount and penalty escrow amount"
+            )
+        })
+
+        it("approves addresses as signers for sender", async () => {
+            const deposit = 500
+            const penaltyEscrow = 1000
+
+            await broker.fundAndApproveSigners(
+                deposit,
+                penaltyEscrow,
+                signers,
+                {from: sender, value: deposit + penaltyEscrow}
+            )
+
+            assert(await broker.isApprovedSigner(sender, signers[0]))
+            assert(await broker.isApprovedSigner(sender, signers[1]))
+        })
+
+        it("grows the Minter's ETH balance by sum of deposit and penalty escrow amounts", async () => {
+            const deposit = 500
+            const penaltyEscrow = 1000
+            const startMinterBalance = new BN(await web3.eth.getBalance(fixture.minter.address))
+
+            await broker.fundAndApproveSigners(
+                deposit,
+                penaltyEscrow,
+                signers,
+                {from: sender, value: deposit + penaltyEscrow}
+            )
+
+            const endMinterBalance = new BN(await web3.eth.getBalance(fixture.minter.address))
+
+            assert.equal(endMinterBalance.sub(startMinterBalance).toString(), (deposit + penaltyEscrow).toString())
+        })
+
+        it("reduces the sender's ETH balance by sum of deposit and penalty escrow amounts", async () => {
+            const deposit = 500
+            const penaltyEscrow = 1000
+            const startSenderBalance = new BN(await web3.eth.getBalance(sender))
+
+            const txResult = await broker.fundAndApproveSigners(
+                deposit,
+                penaltyEscrow,
+                signers,
+                {from: sender, value: deposit + penaltyEscrow}
+            )
+
+            const endSenderBalance = new BN(await web3.eth.getBalance(sender))
+            const txCost = await calcTxCost(txResult)
+
+            assert.equal(startSenderBalance.sub(endSenderBalance).sub(txCost).toString(), (deposit + penaltyEscrow).toString())
+        })
+
+        it("tracks sender's ETH deposit and penalty escrow", async () => {
+            const deposit = 500
+            const penaltyEscrow = 1000
+
+            await broker.fundAndApproveSigners(
+                deposit,
+                penaltyEscrow,
+                signers,
+                {from: sender, value: deposit + penaltyEscrow}
+            )
+
+            const endSender = await broker.senders.call(sender)
+
+            assert.equal(endSender.deposit.toString(), deposit.toString())
+            assert.equal(endSender.penaltyEscrow.toString(), penaltyEscrow.toString())
+        })
+    })
+
     describe("redeemWinningTicket", () => {
         // TODO: Test for stubbed logic. Reminder to update if necessary
         // when using Livepeer specific logic for ticket auxilary data

--- a/test/unit/TicketBroker.js
+++ b/test/unit/TicketBroker.js
@@ -257,6 +257,107 @@ contract("TicketBroker", accounts => {
         })
     })
 
+    describe("fundAndApproveSigners", () => {
+        const signers = accounts.slice(2, 4)
+
+        it("reverts if msg.value < sum of deposit amount and penalty escrow amount", async () => {
+            const deposit = 500
+            const penaltyEscrow = 1000
+
+            await expectRevertWithReason(
+                broker.fundAndApproveSigners(
+                    deposit,
+                    penaltyEscrow,
+                    signers,
+                    {from: sender, value: deposit + penaltyEscrow - 1}
+                ),
+                "msg.value does not equal sum of deposit amount and penalty escrow amount"
+            )
+        })
+
+        it("reverts if msg.value > sum of deposit amount and penalty escrow amount", async () => {
+            const deposit = 500
+            const penaltyEscrow = 1000
+
+            await expectRevertWithReason(
+                broker.fundAndApproveSigners(
+                    deposit,
+                    penaltyEscrow,
+                    signers,
+                    {from: sender, value: deposit + penaltyEscrow + 1}
+                ),
+                "msg.value does not equal sum of deposit amount and penalty escrow amount"
+            )
+        })
+
+        it("approves addresses as signers for sender", async () => {
+            const deposit = 500
+            const penaltyEscrow = 1000
+
+            await broker.fundAndApproveSigners(
+                deposit,
+                penaltyEscrow,
+                signers,
+                {from: sender, value: deposit + penaltyEscrow}
+            )
+
+            assert(await broker.isApprovedSigner(sender, signers[0]))
+            assert(await broker.isApprovedSigner(sender, signers[1]))
+        })
+
+        it("grows the broker's ETH balance by sum of deposit and penalty escrow amounts", async () => {
+            const deposit = 500
+            const penaltyEscrow = 1000
+            const startBrokerBalance = new BN(await web3.eth.getBalance(broker.address))
+
+            await broker.fundAndApproveSigners(
+                deposit,
+                penaltyEscrow,
+                signers,
+                {from: sender, value: deposit + penaltyEscrow}
+            )
+
+            const endBrokerBalance = new BN(await web3.eth.getBalance(broker.address))
+
+            assert.equal(endBrokerBalance.sub(startBrokerBalance).toString(), (deposit + penaltyEscrow).toString())
+        })
+
+        it("reduces the sender's ETH balance by sum of deposit and penalty escrow amounts", async () => {
+            const deposit = 500
+            const penaltyEscrow = 1000
+            const startSenderBalance = new BN(await web3.eth.getBalance(sender))
+
+            const txResult = await broker.fundAndApproveSigners(
+                deposit,
+                penaltyEscrow,
+                signers,
+                {from: sender, value: deposit + penaltyEscrow}
+            )
+
+            const endSenderBalance = new BN(await web3.eth.getBalance(sender))
+            const txCost = await calcTxCost(txResult)
+
+            assert.equal(startSenderBalance.sub(endSenderBalance).sub(txCost).toString(), (deposit + penaltyEscrow).toString())
+        })
+
+        it("tracks sender's ETH deposit and penalty escrow", async () => {
+            const deposit = 500
+            const penaltyEscrow = 1000
+
+            await broker.fundAndApproveSigners(
+                deposit,
+                penaltyEscrow,
+                signers,
+                {from: sender, value: deposit + penaltyEscrow}
+            )
+
+            const endSender = await broker.senders.call(sender)
+
+            assert.equal(endSender.deposit.toString(), deposit.toString())
+            assert.equal(endSender.penaltyEscrow.toString(), penaltyEscrow.toString())
+        })
+    })
+
     describe("redeemWinningTicket", () => {
         it("reverts if ticket's recipient is null address", async () => {
             await expectRevertWithReason(
@@ -642,6 +743,29 @@ contract("TicketBroker", accounts => {
 
             assert.equal(startBrokerBalance.sub(endBrokerBalance).toString(), faceValue.toString())
             assert.equal(endRecipientBalance.sub(startRecipientBalance).add(txCost).toString(), faceValue.toString())
+            assert.equal(endDeposit, (deposit - faceValue).toString())
+        })
+
+        it("can be called by an account that is not the recipient", async () => {
+            const thirdParty = accounts[2]
+            const deposit = 1500
+            await broker.fundDeposit({from: sender, value: deposit})
+
+            const recipientRand = 5
+            const faceValue = 1000
+            const ticket = createWinningTicket(recipient, sender, recipientRand, faceValue)
+            const senderSig = await web3.eth.sign(getTicketHash(ticket), sender)
+            const startBrokerBalance = new BN(await web3.eth.getBalance(broker.address))
+            const startRecipientBalance = new BN(await web3.eth.getBalance(recipient))
+
+            await broker.redeemWinningTicket(ticket, senderSig, recipientRand, {from: thirdParty})
+
+            const endBrokerBalance = new BN(await web3.eth.getBalance(broker.address))
+            const endRecipientBalance = new BN(await web3.eth.getBalance(recipient))
+            const endDeposit = (await broker.senders.call(sender)).deposit.toString()
+
+            assert.equal(startBrokerBalance.sub(endBrokerBalance).toString(), faceValue.toString())
+            assert.equal(endRecipientBalance.sub(startRecipientBalance).toString(), faceValue.toString())
             assert.equal(endDeposit, (deposit - faceValue).toString())
         })
 


### PR DESCRIPTION
Implements signer approval by a sender.

This PR does not implement signer revocation by a sender which can be addressed separately. See #252 for more details.