### PR TITLE
PM: TicketBroker inheritance refactor

### DIFF
--- a/contracts/pm/ERC20TicketBroker.sol
+++ b/contracts/pm/ERC20TicketBroker.sol
@@ -21,37 +21,45 @@ contract ERC20TicketBroker is TicketBroker {
         token = ERC20(_token);
     }
 
+    // For ETH
+    function fundDeposit() external payable {
+        require(false, "ETH funding not supported. Please use an ERC20 token instead.");
+    }
+
+    function fundPenaltyEscrow() external payable {
+        require(false, "ETH funding not supported. Please use an ERC20 token instead.");
+    }
+
+    // For ERC20
+    function fundDeposit(uint256 _amount) external {
+        _fundDeposit(_amount);
+    }
+
+    function fundPenaltyEscrow(uint256 _amount) external {
+        _fundPenaltyEscrow(_amount);
+    }
+
     function fundAndApproveSigners(
         uint256 _depositAmount,
         uint256 _penaltyEscrowAmount,
         address[] _signers
     )
         external
-        processDeposit(msg.sender, _depositAmount)
-        processPenaltyEscrow(msg.sender, _penaltyEscrowAmount)
+        payable
     {
+        _fundDeposit(_depositAmount);
+        _fundPenaltyEscrow(_penaltyEscrowAmount);
         approveSigners(_signers);
-
-        require(
-            token.transferFrom(msg.sender, address(this), _depositAmount + _penaltyEscrowAmount),
-            "token transfer for deposit and penalty escrow failed"
-        );
     }
 
-    function fundDeposit(uint256 _amount) 
-        external
-        processDeposit(msg.sender, _amount)
-    {
+    function processDeposit(uint256 _amount) internal {
         require(
             token.transferFrom(msg.sender, address(this), _amount),
             "token transfer for deposit failed"
         );
     }
 
-    function fundPenaltyEscrow(uint256 _amount)
-        external
-        processPenaltyEscrow(msg.sender, _amount)
-    {
+    function processPenaltyEscrow(uint256 _amount) internal {
         require(
             token.transferFrom(msg.sender, address(this), _amount),
             "token transfer for penalty escrow failed"

--- a/contracts/pm/ERC20TicketBroker.sol
+++ b/contracts/pm/ERC20TicketBroker.sol
@@ -21,22 +21,19 @@ contract ERC20TicketBroker is TicketBroker {
         token = ERC20(_token);
     }
 
-    // For ETH
-    function fundDeposit() external payable {
-        require(false, "ETH funding not supported. Please use an ERC20 token instead.");
-    }
-
-    function fundPenaltyEscrow() external payable {
-        require(false, "ETH funding not supported. Please use an ERC20 token instead.");
-    }
-
     // For ERC20
-    function fundDeposit(uint256 _amount) external {
-        _fundDeposit(_amount);
+    function fundDeposit(uint256 _amount)
+        external 
+        processDeposit(msg.sender, _amount)
+    {
+        processFunding(_amount);
     }
 
-    function fundPenaltyEscrow(uint256 _amount) external {
-        _fundPenaltyEscrow(_amount);
+    function fundPenaltyEscrow(uint256 _amount) 
+        external
+        processPenaltyEscrow(msg.sender, _amount)
+    {
+        processFunding(_amount);
     }
 
     function fundAndApproveSigners(
@@ -46,23 +43,18 @@ contract ERC20TicketBroker is TicketBroker {
     )
         external
         payable
+        processDeposit(msg.sender, _depositAmount)
+        processPenaltyEscrow(msg.sender, _penaltyEscrowAmount)
     {
-        _fundDeposit(_depositAmount);
-        _fundPenaltyEscrow(_penaltyEscrowAmount);
         approveSigners(_signers);
+        processFunding(_depositAmount + _penaltyEscrowAmount);
     }
 
-    function processDeposit(uint256 _amount) internal {
+    function processFunding(uint256 _amount) internal {
+        require(msg.value == 0, "ETH funding not supported. Please use an ERC20 token instead.");
         require(
             token.transferFrom(msg.sender, address(this), _amount),
-            "token transfer for deposit failed"
-        );
-    }
-
-    function processPenaltyEscrow(uint256 _amount) internal {
-        require(
-            token.transferFrom(msg.sender, address(this), _amount),
-            "token transfer for penalty escrow failed"
+            "token transfer failed"
         );
     }
 

--- a/contracts/pm/ETHTicketBroker.sol
+++ b/contracts/pm/ETHTicketBroker.sol
@@ -14,9 +14,7 @@ contract ETHTicketBroker is TicketBroker {
         public 
     {}
 
-    function processDeposit(uint256 _amount) internal {}
-
-    function processPenaltyEscrow(uint256 _amount) internal {}
+    function processFunding(uint256 _amount) internal {}
 
     function withdrawTransfer(address _sender, uint256 _amount) internal {
         _sender.transfer(_amount);

--- a/contracts/pm/ETHTicketBroker.sol
+++ b/contracts/pm/ETHTicketBroker.sol
@@ -14,31 +14,9 @@ contract ETHTicketBroker is TicketBroker {
         public 
     {}
 
-    function fundAndApproveSigners(
-        uint256 _depositAmount,
-        uint256 _penaltyEscrowAmount,
-        address[] _signers
-    )
-        external
-        payable
-        checkDepositPenaltyEscrowETHValueSplit(_depositAmount, _penaltyEscrowAmount)
-        processDeposit(msg.sender, _depositAmount)
-        processPenaltyEscrow(msg.sender, _penaltyEscrowAmount)
-    {
-        approveSigners(_signers);
-    }
+    function processDeposit(uint256 _amount) internal {}
 
-    function fundDeposit() 
-        external
-        payable
-        processDeposit(msg.sender, msg.value)
-    {}
-
-    function fundPenaltyEscrow()
-        external
-        payable
-        processPenaltyEscrow(msg.sender, msg.value)
-    {}
+    function processPenaltyEscrow(uint256 _amount) internal {}
 
     function withdrawTransfer(address _sender, uint256 _amount) internal {
         _sender.transfer(_amount);

--- a/contracts/pm/LivepeerETHTicketBroker.sol
+++ b/contracts/pm/LivepeerETHTicketBroker.sol
@@ -31,35 +31,12 @@ contract LivepeerETHTicketBroker is ManagerProxyTarget, TicketBroker {
         unlockPeriod = _unlockPeriod;
     }
 
-    function fundAndApproveSigners(
-        uint256 _depositAmount,
-        uint256 _penaltyEscrowAmount,
-        address[] _signers
-    )
-        external
-        payable
-        checkDepositPenaltyEscrowETHValueSplit(_depositAmount, _penaltyEscrowAmount)
-        processDeposit(msg.sender, _depositAmount)
-        processPenaltyEscrow(msg.sender, _penaltyEscrowAmount)
-    {
-        approveSigners(_signers);
-        minter().trustedDepositETH.value(msg.value)();
+    function processDeposit(uint256 _amount) internal {
+        minter().trustedDepositETH.value(_amount)();
     }
 
-    function fundDeposit()
-        external
-        payable
-        processDeposit(msg.sender, msg.value)
-    {
-        minter().trustedDepositETH.value(msg.value)();
-    }
-
-    function fundPenaltyEscrow()
-        external
-        payable
-        processPenaltyEscrow(msg.sender, msg.value)
-    {
-        minter().trustedDepositETH.value(msg.value)();
+    function processPenaltyEscrow(uint256 _amount) internal {
+        minter().trustedDepositETH.value(_amount)();
     }
 
     function withdrawTransfer(address _sender, uint256 _amount) internal {

--- a/contracts/pm/LivepeerETHTicketBroker.sol
+++ b/contracts/pm/LivepeerETHTicketBroker.sol
@@ -31,11 +31,7 @@ contract LivepeerETHTicketBroker is ManagerProxyTarget, TicketBroker {
         unlockPeriod = _unlockPeriod;
     }
 
-    function processDeposit(uint256 _amount) internal {
-        minter().trustedDepositETH.value(_amount)();
-    }
-
-    function processPenaltyEscrow(uint256 _amount) internal {
+    function processFunding(uint256 _amount) internal {
         minter().trustedDepositETH.value(_amount)();
     }
 


### PR DESCRIPTION
So far we've used two different approaches for reusing code from
`TicketBroker` in its subtypes: one where only subtypes implement
functions and use modifiers to reuse `TicketBroker`'s flow of
requirements and accounting, and another approach where `TicketBroker`
implements a public/external function that contains the entire flow,
and calls an abstract method that each subtype implements according to
their needs.

The first approach (using modifiers) resulted in code duplication, i.e.
having to use the exact same modifiers in more than one contract, which
also resulted in duplicate test code.

To get out of this code duplication we're refactoring to the second
approach across the board.

The main cost is the complication introduced in the ERC20 implementation,
but since it's just an example and not a priority, it seems like the
better choice, for the benefit of simplifying the more mainstream
usecase with ETH.