### PR TITLE
PM: senders can revoke signers

### DIFF
--- a/contracts/pm/ERC20TicketBroker.sol
+++ b/contracts/pm/ERC20TicketBroker.sol
@@ -13,9 +13,10 @@ contract ERC20TicketBroker is TicketBroker {
     constructor(
         address _token, 
         uint256 _minPenaltyEscrow,
-        uint256 _unlockPeriod
+        uint256 _unlockPeriod,
+        uint256 _signerRevocationPeriod 
     )
-        TicketBroker(_minPenaltyEscrow, _unlockPeriod)
+        TicketBroker(_minPenaltyEscrow, _unlockPeriod, _signerRevocationPeriod)
         public
     {
         token = ERC20(_token);

--- a/contracts/pm/ETHTicketBroker.sol
+++ b/contracts/pm/ETHTicketBroker.sol
@@ -8,9 +8,10 @@ import "./TicketBroker.sol";
 contract ETHTicketBroker is TicketBroker {
     constructor(
         uint256 _minPenaltyEscrow, 
-        uint256 _unlockPeriod
+        uint256 _unlockPeriod,
+        uint256 _signerRevocationPeriod
     ) 
-        TicketBroker(_minPenaltyEscrow, _unlockPeriod) 
+        TicketBroker(_minPenaltyEscrow, _unlockPeriod, _signerRevocationPeriod) 
         public 
     {}
 

--- a/contracts/pm/LivepeerETHTicketBroker.sol
+++ b/contracts/pm/LivepeerETHTicketBroker.sol
@@ -13,13 +13,14 @@ contract LivepeerETHTicketBroker is ManagerProxyTarget, TicketBroker {
     constructor(
         address _controller,
         uint256 _minPenaltyEscrow,
-        uint256 _unlockPeriod
+        uint256 _unlockPeriod,
+        uint256 _signerRevocationPeriod
     ) 
         Manager(_controller)
         // TODO: Consider using a initializer instead of an
         // explicit constructor in base TicketBroker since
         // upgradeable proxies do not use explicit constructors
-        TicketBroker(_minPenaltyEscrow, _unlockPeriod)
+        TicketBroker(_minPenaltyEscrow, _unlockPeriod, _signerRevocationPeriod)
         public
     {}
 
@@ -29,6 +30,10 @@ contract LivepeerETHTicketBroker is ManagerProxyTarget, TicketBroker {
 
     function setUnlockPeriod(uint256 _unlockPeriod) external onlyControllerOwner {
         unlockPeriod = _unlockPeriod;
+    }
+
+    function setSignerRevocationPeriod(uint256 _signerRevocationPeriod) external onlyControllerOwner {
+        signerRevocationPeriod = _signerRevocationPeriod;        
     }
 
     function processFunding(uint256 _amount) internal {

--- a/migrations/3_deploy_contracts.js
+++ b/migrations/3_deploy_contracts.js
@@ -30,7 +30,7 @@ module.exports = function(deployer, network) {
         // TODO: Consider using a initializer instead of an
         // explicit constructor in base TicketBroker since
         // upgradeable proxies do not use explicit constructors
-        const broker = await lpDeployer.deployProxyAndRegister(TicketBroker, "TicketBroker", controller.address, config.broker.minPenaltyEscrow, config.broker.unlockPeriod)
+        const broker = await lpDeployer.deployProxyAndRegister(TicketBroker, "TicketBroker", controller.address, config.broker.minPenaltyEscrow, config.broker.unlockPeriod, config.broker.signerRevocationPeriod)
         const bondingManager = await lpDeployer.deployProxyAndRegister(BondingManager, "BondingManager", controller.address)
 
         let roundsManager

--- a/migrations/migrations.config.js
+++ b/migrations/migrations.config.js
@@ -11,7 +11,8 @@ module.exports = {
     broker: {
         // TODO: Consider updating these values prior to deploying to testnet
         minPenaltyEscrow: (new BN(1)).mul(constants.TOKEN_UNIT).div(new BN(2)),
-        unlockPeriod: new BN(40320) // approximately 7 days worth of blocks
+        unlockPeriod: new BN(40320), // approximately 7 days worth of blocks
+        signerRevocationPeriod: new BN(40320) // approximately 7 days worth of blocks
     },
     roundsManager: {
         roundLength: 5760,

--- a/test/unit/LivepeerETHTicketBroker.js
+++ b/test/unit/LivepeerETHTicketBroker.js
@@ -1,5 +1,6 @@
 import BN from "bn.js"
 import Fixture from "./helpers/Fixture"
+import expectThrow from "../helpers/expectThrow"
 import {expectRevertWithReason} from "../helpers/expectFail"
 import {createTicket, createWinningTicket, getTicketHash} from "../helpers/ticket"
 import {functionSig} from "../../utils/helpers"
@@ -14,12 +15,13 @@ contract("LivepeerETHTicketBroker", accounts => {
     const recipient = accounts[1]
 
     const unlockPeriod = 20
+    const signerRevocationPeriod = 10
 
     before(async () => {
         fixture = new Fixture(web3)
         await fixture.deploy()
 
-        broker = await TicketBroker.new(fixture.controller.address, 0, unlockPeriod)
+        broker = await TicketBroker.new(fixture.controller.address, 0, unlockPeriod, signerRevocationPeriod)
     })
 
     beforeEach(async () => {
@@ -241,6 +243,21 @@ contract("LivepeerETHTicketBroker", accounts => {
                 assert.equal(event.returnValues.to, sender)
                 assert.equal(event.returnValues.amount.toString(), (deposit + penaltyEscrow).toString())
             })
+        })
+    })
+
+    describe("setSignerRevocationPeriod", () => {
+        it("reverts when called by an account that is not the owner", async () => {
+            await expectThrow(broker.setSignerRevocationPeriod(1234, {from: accounts[5]}))
+        })
+
+        it("works when called by the owner", async () => {
+            const expectedPeriod = signerRevocationPeriod + 12
+            await broker.setSignerRevocationPeriod(expectedPeriod, {from: accounts[0]})
+
+            const actualPeriod = await broker.signerRevocationPeriod.call()
+
+            assert.equal(actualPeriod.toString(), expectedPeriod.toString())
         })
     })
 })

--- a/test/unit/LivepeerETHTicketBroker.js
+++ b/test/unit/LivepeerETHTicketBroker.js
@@ -251,7 +251,7 @@ contract("LivepeerETHTicketBroker", accounts => {
             await expectThrow(broker.setSignerRevocationPeriod(1234, {from: accounts[5]}))
         })
 
-        it("works when called by the owner", async () => {
+        it("works when called by Controller owner", async () => {
             const expectedPeriod = signerRevocationPeriod + 12
             await broker.setSignerRevocationPeriod(expectedPeriod, {from: accounts[0]})
 

--- a/test/unit/LivepeerETHTicketBroker.js
+++ b/test/unit/LivepeerETHTicketBroker.js
@@ -15,7 +15,7 @@ contract("LivepeerETHTicketBroker", accounts => {
     const recipient = accounts[1]
 
     const unlockPeriod = 20
-    const signerRevocationPeriod = 10
+    const signerRevocationPeriod = 20
 
     before(async () => {
         fixture = new Fixture(web3)
@@ -247,7 +247,7 @@ contract("LivepeerETHTicketBroker", accounts => {
     })
 
     describe("setSignerRevocationPeriod", () => {
-        it("reverts when called by an account that is not the owner", async () => {
+        it("reverts when called by an account that is not the Controller owner", async () => {
             await expectThrow(broker.setSignerRevocationPeriod(1234, {from: accounts[5]}))
         })
 

--- a/test/unit/TicketBroker.js
+++ b/test/unit/TicketBroker.js
@@ -17,7 +17,7 @@ contract("TicketBroker", accounts => {
     const recipient = accounts[1]
 
     const unlockPeriod = 20
-    const signerRevocationPeriod = 10
+    const signerRevocationPeriod = 20
 
     before(async () => {
         fixture = new Fixture(web3)

--- a/test/unit/TicketBroker.js
+++ b/test/unit/TicketBroker.js
@@ -217,6 +217,12 @@ contract("TicketBroker", accounts => {
         })
     })
 
+    describe("isApprovedSigner", () => {
+        it("returns false for a signer that was never approved", async () => {
+            assert(!await broker.isApprovedSigner(sender, accounts[2]))
+        })
+    })
+
     describe("approveSigners", () => {
         const signers = accounts.slice(2, 4)
 

--- a/test/unit/TicketBroker.js
+++ b/test/unit/TicketBroker.js
@@ -227,6 +227,17 @@ contract("TicketBroker", accounts => {
             assert(await broker.isApprovedSigner(sender, signers[1]))
         })
 
+        it("re-approves signers that were revoked", async () => {
+            await broker.approveSigners(signers, {from: sender})
+            await broker.requestSignersRevocation(signers, {from: sender})
+            await fixture.rpc.wait(signerRevocationPeriod)
+
+            await broker.approveSigners(signers, {from: sender})
+
+            assert(await broker.isApprovedSigner(sender, signers[0]))
+            assert(await broker.isApprovedSigner(sender, signers[1]))
+        })
+
         it("emits a SignersApproved event", async () => {
             const txResult = await broker.approveSigners(signers, {from: sender})
 


### PR DESCRIPTION
We decided to create a separate param for the signer revocation delay
to decouple this concern from the `unlockPeriod`.
The reason we need a delayed revocation in the first place, is to allow
receivers of tickets to become aware of a pending revocation and make
sure they cash in any tickets signed by the soon-to-be-revoked signer
before those tickets become invalid.