### PR TITLE
PM: use sender sig for winProb

### DIFF
--- a/contracts/pm/TicketBroker.sol
+++ b/contracts/pm/TicketBroker.sol
@@ -307,7 +307,7 @@ contract TicketBroker {
         );
 
         require(
-            isWinningTicket(_ticketHash, _recipientRand, _ticket.winProb),
+            isWinningTicket(_sig, _recipientRand, _ticket.winProb),
             "ticket did not win"
         );
     }
@@ -339,8 +339,8 @@ contract TicketBroker {
         );
     }
 
-    function isWinningTicket(bytes32 _ticketHash, uint256 _recipientRand, uint256 _winProb) internal pure returns (bool) {
-        return uint256(keccak256(abi.encodePacked(_ticketHash, _recipientRand))) < _winProb;
+    function isWinningTicket(bytes _sig, uint256 _recipientRand, uint256 _winProb) internal pure returns (bool) {
+        return uint256(keccak256(abi.encodePacked(_sig, _recipientRand))) < _winProb;
     }
 
     function _isUnlockInProgress(Sender memory sender) internal pure returns (bool) {


### PR DESCRIPTION
More detailed reasoning can be found here: https://github.com/livepeer/protocol/issues/268

In a nutshell, sender's signature over the ticket's content provides us
with the randomness we need, and at the same time relaxes the
requirements on `senderNonce` from having to be random to just having to
be unique (per `recipientRand` value).