### PR TITLE
pm: remove LivepeerETHTicketBroker ticket expiration for MVS

### DIFF
--- a/contracts/pm/LivepeerETHTicketBroker.sol
+++ b/contracts/pm/LivepeerETHTicketBroker.sol
@@ -60,12 +60,7 @@ contract LivepeerETHTicketBroker is ManagerProxyTarget, TicketBroker {
     }
 
     // TODO: Stub for tests. Change to Livepeer specific logic
-    function requireValidTicketAuxData(bytes _auxData) internal view {
-        require(
-            getCreationTimestamp(_auxData).add(3 days) > block.timestamp,
-            "ticket is expired"
-        );
-    }
+    function requireValidTicketAuxData(bytes _auxData) internal view {}
 
     function minter() internal view returns (IMinter) {
         return IMinter(controller.getContract(keccak256("Minter")));
@@ -77,13 +72,6 @@ contract LivepeerETHTicketBroker is ManagerProxyTarget, TicketBroker {
 
     function roundsManager() internal view returns (IRoundsManager) {
         return IRoundsManager(controller.getContract(keccak256("RoundsManager")));
-    }
-
-    // TODO: Stub for tests. Change to Livepeer specific logic
-    function getCreationTimestamp(bytes _auxData) internal pure returns (uint256 creationTimestamp) {
-        assembly {
-            creationTimestamp := mload(add(_auxData, 32))
-        }
     }
 }
 

--- a/test/unit/LivepeerETHTicketBroker.js
+++ b/test/unit/LivepeerETHTicketBroker.js
@@ -1,8 +1,7 @@
 import BN from "bn.js"
 import Fixture from "./helpers/Fixture"
 import expectThrow from "../helpers/expectThrow"
-import {expectRevertWithReason} from "../helpers/expectFail"
-import {createTicket, createWinningTicket, getTicketHash} from "../helpers/ticket"
+import {createWinningTicket, getTicketHash} from "../helpers/ticket"
 import {functionSig} from "../../utils/helpers"
 
 const TicketBroker = artifacts.require("LivepeerETHTicketBroker")
@@ -74,24 +73,6 @@ contract("LivepeerETHTicketBroker", accounts => {
     })
 
     describe("redeemWinningTicket", () => {
-        // TODO: Test for stubbed logic. Reminder to update if necessary
-        // when using Livepeer specific logic for ticket auxilary data
-        // validation
-        it("reverts if ticket is expired", async () => {
-            await expectRevertWithReason(
-                broker.redeemWinningTicket(
-                    createTicket({
-                        recipient,
-                        sender,
-                        auxData: web3.utils.numberToHex(0)
-                    }),
-                    web3.utils.asciiToHex("sig"),
-                    5
-                ),
-                "ticket is expired"
-            )
-        })
-
         describe("winningTicketTransfer", () => {
             it("updates transcoder with fees on bonding manager with deposit when deposit < faceValue", async () => {
                 const currentRound = 17


### PR DESCRIPTION
Remove ticket expiration from LivepeerETHTicketBroker for MVS:

Note: The ticket data structure still contains the `auxData` field which is also used when generating the ticket hash. After this PR, LivepeerETHTicketBroker will not parse the field to execute a validation check, but the field will still be a part of the ticket.

See #267 for more background discussion and this [comment](https://github.com/livepeer/protocol/issues/267#issuecomment-449189086) for the currently proposed roadmap for the ticket expiration feature.