### PR TITLE
pm: Temporarily Remove ticket struct param

### DIFF
--- a/contracts/pm/TicketBroker.sol
+++ b/contracts/pm/TicketBroker.sol
@@ -152,7 +152,29 @@ contract TicketBroker {
         emit SignersRevocationRequested(msg.sender, _signers, revocationBlock);
     }
 
-    function redeemWinningTicket(Ticket memory _ticket, bytes _sig, uint256 _recipientRand) public {
+    function redeemWinningTicket(
+        address _recipient,
+        address _sender,
+        uint256 _faceValue,
+        uint256 _winProb,
+        uint256 _senderNonce,
+        bytes32 _recipientRandHash,
+        bytes _auxData,
+        bytes _sig,
+        uint256 _recipientRand
+    ) 
+        public
+    {
+        Ticket memory _ticket = Ticket({
+            recipient: _recipient,
+            sender: _sender,
+            faceValue: _faceValue,
+            winProb: _winProb,
+            senderNonce: _senderNonce,
+            recipientRandHash: _recipientRandHash,
+            auxData: _auxData
+        });
+
         bytes32 ticketHash = getTicketHash(_ticket);
 
         requireValidWinningTicket(_ticket, ticketHash, _sig, _recipientRand);

--- a/test/helpers/ticket.js
+++ b/test/helpers/ticket.js
@@ -1,5 +1,36 @@
 import {constants} from "../../utils/constants"
 
+const wrapRedeemWinningTicket = broker => {
+    return async (ticketObj, sig, recipientRand, txOpts) => {
+        if (txOpts == undefined) {
+            return broker.redeemWinningTicket(
+                ...ticketObjToArr(ticketObj),
+                sig,
+                recipientRand
+            )
+        } else {
+            return broker.redeemWinningTicket(
+                ...ticketObjToArr(ticketObj),
+                sig,
+                recipientRand,
+                txOpts
+            )
+        }
+    }
+}
+
+const ticketObjToArr = ticketObj => {
+    return [
+        ticketObj.recipient,
+        ticketObj.sender,
+        ticketObj.faceValue,
+        ticketObj.winProb,
+        ticketObj.senderNonce,
+        ticketObj.recipientRandHash,
+        ticketObj.auxData
+    ]
+}
+
 const createTicket = ticketObj => {
     ticketObj = ticketObj ? ticketObj : {}
 
@@ -50,6 +81,7 @@ const isSet = v => {
 }
 
 module.exports = {
+    wrapRedeemWinningTicket,
     createTicket,
     createWinningTicket,
     getTicketHash

--- a/test/unit/LivepeerETHTicketBroker.js
+++ b/test/unit/LivepeerETHTicketBroker.js
@@ -1,7 +1,7 @@
 import BN from "bn.js"
 import Fixture from "./helpers/Fixture"
 import expectThrow from "../helpers/expectThrow"
-import {createWinningTicket, getTicketHash} from "../helpers/ticket"
+import {wrapRedeemWinningTicket, createWinningTicket, getTicketHash} from "../helpers/ticket"
 import {functionSig} from "../../utils/helpers"
 
 const TicketBroker = artifacts.require("LivepeerETHTicketBroker")
@@ -9,6 +9,7 @@ const TicketBroker = artifacts.require("LivepeerETHTicketBroker")
 contract("LivepeerETHTicketBroker", accounts => {
     let fixture
     let broker
+    let redeemWinningTicket
 
     const sender = accounts[0]
     const recipient = accounts[1]
@@ -21,6 +22,8 @@ contract("LivepeerETHTicketBroker", accounts => {
         await fixture.deploy()
 
         broker = await TicketBroker.new(fixture.controller.address, 0, unlockPeriod, signerRevocationPeriod)
+
+        redeemWinningTicket = wrapRedeemWinningTicket(broker)
     })
 
     beforeEach(async () => {
@@ -86,7 +89,7 @@ contract("LivepeerETHTicketBroker", accounts => {
                 const ticket = createWinningTicket(recipient, sender, recipientRand, faceValue)
                 const senderSig = await web3.eth.sign(getTicketHash(ticket), sender)
 
-                await broker.redeemWinningTicket(ticket, senderSig, recipientRand, {from: recipient})
+                await redeemWinningTicket(ticket, senderSig, recipientRand, {from: recipient})
 
                 const events = await fixture.bondingManager.getPastEvents("UpdateTranscoderWithFees", {
                     fromBlock,
@@ -112,7 +115,7 @@ contract("LivepeerETHTicketBroker", accounts => {
                 const ticket = createWinningTicket(recipient, sender, recipientRand, faceValue)
                 const senderSig = await web3.eth.sign(getTicketHash(ticket), sender)
 
-                await broker.redeemWinningTicket(ticket, senderSig, recipientRand, {from: recipient})
+                await redeemWinningTicket(ticket, senderSig, recipientRand, {from: recipient})
 
                 const events = await fixture.bondingManager.getPastEvents("UpdateTranscoderWithFees", {
                     fromBlock,
@@ -138,7 +141,7 @@ contract("LivepeerETHTicketBroker", accounts => {
                 const ticket = createWinningTicket(recipient, sender, recipientRand, faceValue)
                 const senderSig = await web3.eth.sign(getTicketHash(ticket), sender)
 
-                await broker.redeemWinningTicket(ticket, senderSig, recipientRand, {from: recipient})
+                await redeemWinningTicket(ticket, senderSig, recipientRand, {from: recipient})
 
                 const events = await fixture.bondingManager.getPastEvents("UpdateTranscoderWithFees", {
                     fromBlock,
@@ -164,7 +167,7 @@ contract("LivepeerETHTicketBroker", accounts => {
                 const ticket = createWinningTicket(recipient, sender, recipientRand, faceValue)
                 const senderSig = await web3.eth.sign(getTicketHash(ticket), sender)
 
-                await broker.redeemWinningTicket(ticket, senderSig, recipientRand, {from: recipient})
+                await redeemWinningTicket(ticket, senderSig, recipientRand, {from: recipient})
 
 
                 const events = await fixture.minter.getPastEvents("TrustedBurnETH", {
@@ -189,7 +192,7 @@ contract("LivepeerETHTicketBroker", accounts => {
                 const ticket = createWinningTicket(recipient, sender, recipientRand, faceValue)
                 const senderSig = await web3.eth.sign(getTicketHash(ticket), sender)
 
-                await broker.redeemWinningTicket(ticket, senderSig, recipientRand, {from: recipient})
+                await redeemWinningTicket(ticket, senderSig, recipientRand, {from: recipient})
 
                 const events = await fixture.minter.getPastEvents("TrustedBurnETH", {
                     fromBlock,


### PR DESCRIPTION
Temporarily using individual struct fields as params instead of a ticket struct
in redeemWinningTicket() because the Go abigen tool for creating Go
specific contract bindings currently does not support struct params.