### PR TITLE
pm: ticket expiration validation

### DIFF
--- a/contracts/pm/TicketBroker.sol
+++ b/contracts/pm/TicketBroker.sol
@@ -6,13 +6,15 @@ import "./mixins/MixinContractRegistry.sol";
 import "./mixins/MixinReserve.sol";
 import "./mixins/MixinTicketBrokerCore.sol";
 import "./mixins/MixinTicketProcessor.sol";
+import "./mixins/MixinWrappers.sol";
 
 
 contract TicketBroker is
     MixinContractRegistry,
     MixinReserve,
     MixinTicketBrokerCore,
-    MixinTicketProcessor
+    MixinTicketProcessor,
+    MixinWrappers
 {
     constructor(
         address _controller,

--- a/contracts/pm/TicketBroker.sol
+++ b/contracts/pm/TicketBroker.sol
@@ -17,7 +17,8 @@ contract TicketBroker is
     constructor(
         address _controller,
         uint256 _freezePeriod,
-        uint256 _unlockPeriod
+        uint256 _unlockPeriod,
+        uint256 _ticketValidityPeriod
     )
         public
         MixinContractRegistry(_controller)
@@ -27,6 +28,7 @@ contract TicketBroker is
     {
         freezePeriod = _freezePeriod;
         unlockPeriod = _unlockPeriod;
+        ticketValidityPeriod = _ticketValidityPeriod;
     }
 
     /**
@@ -39,8 +41,17 @@ contract TicketBroker is
 
     /**
      * @dev Sets unlockPeriod value. Only callable by the Controller owner
+     * @param _unlockPeriod Value for unlockPeriod
      */
     function setUnlockPeriod(uint256 _unlockPeriod) external onlyControllerOwner {
         unlockPeriod = _unlockPeriod;
+    }
+
+    /**
+     * @dev Sets ticketValidityPeriod value. Only callable by the Controller owner
+     * @param _ticketValidityPeriod Value for ticketValidityPeriod
+     */
+    function setTicketValidityPeriod(uint256 _ticketValidityPeriod) external onlyControllerOwner {
+        ticketValidityPeriod = _ticketValidityPeriod;
     }
 }

--- a/contracts/pm/mixins/MixinTicketBrokerCore.sol
+++ b/contracts/pm/mixins/MixinTicketBrokerCore.sol
@@ -17,16 +17,6 @@ contract MixinTicketBrokerCore is MReserve, MTicketProcessor, MTicketBrokerCore 
         uint256 withdrawBlock;  // Block that sender can withdraw deposit & reserve
     }
 
-    struct Ticket {
-        address recipient;          // Address of ticket recipient
-        address sender;             // Address of ticket sender
-        uint256 faceValue;          // Face value of ticket paid to recipient if ticket wins
-        uint256 winProb;            // Probability ticket will win represented as winProb / (2^256 - 1)
-        uint256 senderNonce;        // Sender's monotonically increasing counter for each ticket
-        bytes32 recipientRandHash;  // keccak256 hash commitment to recipient's random value
-        bytes auxData;              // Auxilary data included in ticket used for additional validation
-    }
-
     // Number of blocks before a sender can withdraw after requesting an unlock
     uint256 public unlockPeriod;
 
@@ -124,7 +114,7 @@ contract MixinTicketBrokerCore is MReserve, MTicketProcessor, MTicketBrokerCore 
 
     /**
      * @dev Redeems a winning ticket that has been signed by a sender and reveals the
-     * recipient recipeintRand that corresponds to the recipientRandHash included in the ticket
+     * recipient recipientRand that corresponds to the recipientRandHash included in the ticket
      * @param _ticket Winning ticket to be redeemed in order to claim payment
      * @param _sig Sender's signature over the hash of `_ticket`
      * @param _recipientRand The preimage for the recipientRandHash included in `_ticket`

--- a/contracts/pm/mixins/MixinTicketBrokerCore.sol
+++ b/contracts/pm/mixins/MixinTicketBrokerCore.sol
@@ -175,7 +175,7 @@ contract MixinTicketBrokerCore is MReserve, MTicketProcessor, MTicketBrokerCore 
         }
 
         if (amountToTransfer > 0) {
-            winningTicketTransfer(_ticket.recipient, amountToTransfer);
+            winningTicketTransfer(_ticket.recipient, amountToTransfer, _ticket.auxData);
 
             emit WinningTicketTransfer(_ticket.sender, _ticket.recipient, amountToTransfer);
         }

--- a/contracts/pm/mixins/MixinWrappers.sol
+++ b/contracts/pm/mixins/MixinWrappers.sol
@@ -1,0 +1,72 @@
+pragma solidity ^0.4.25;
+// solium-disable-next-line
+pragma experimental ABIEncoderV2;
+
+import "./interfaces/MTicketBrokerCore.sol";
+
+
+contract MixinWrappers is MTicketBrokerCore {
+    /**
+     * @dev Redeems multiple winning tickets. The function will redeem all of the provided
+     * tickets and handle any failures gracefully without reverting the entire function
+     * @param _tickets Array of winning tickets to be redeemed in order to claim payment
+     * @param _sigs Array of sender signatures over the hash of tickets (`_sigs[i]` corresponds to `_tickets[i]`)
+     * @param _recipientRands Array of preimages for the recipientRandHash included in each ticket (`_recipientRands[i]` corresponds to `_tickets[i]`)
+     */
+    function batchRedeemWinningTickets(
+        Ticket[] memory _tickets,
+        bytes[] _sigs,
+        uint256[] _recipientRands
+    )
+        public
+    {
+        for (uint256 i = 0; i < _tickets.length; i++) {
+            redeemWinningTicketNoRevert(
+                _tickets[i],
+                _sigs[i],
+                _recipientRands[i]
+            );
+        }
+    }
+
+    /**
+     * @dev Redeems a winning ticket that has been signed by a sender and reveals the
+     * recipient recipientRand that corresponds to the recipientRandHash included in the ticket
+     * This function wraps `redeemWinningTicket()` and returns false if the underlying call reverts
+     * @param _ticket Winning ticket to be redeemed in order to claim payment
+     * @param _sig Sender's signature over the hash of `_ticket`
+     * @param _recipientRand The preimage for the recipientRandHash included in `_ticket`
+     * @return Boolean indicating whether the underlying `redeemWinningTicket()` call succeeded
+     */
+    function redeemWinningTicketNoRevert(
+        Ticket memory _ticket,
+        bytes _sig,
+        uint256 _recipientRand
+    )
+        internal
+        returns (bool success)
+    {
+        // ABI encode calldata for `redeemWinningTicket()`
+        // A tuple type is used to represent the Ticket struct in the function signature
+        bytes memory redeemWinningTicketCalldata = abi.encodeWithSignature(
+            "redeemWinningTicket((address,address,uint256,uint256,uint256,bytes32,bytes),bytes,uint256)",
+            _ticket,
+            _sig,
+            _recipientRand
+        );
+
+        // Call `redeemWinningTicket()`
+        assembly {
+            // call will return false upon hitting a revert
+            success := call(
+                gas,                                   // Forward all gas
+                address,                               // Address of this contract (calling self)
+                0,                                     // Send 0 ETH
+                add(redeemWinningTicketCalldata, 32),  // Start of calldata (skip first 32 bytes containing array length)
+                mload(redeemWinningTicketCalldata),    // Length of calldata (first 32 bytes contains array length)
+                0,                                     // Ignore start of output
+                0                                      // Ignore size of output
+            )
+        }
+    }
+}

--- a/contracts/pm/mixins/interfaces/MTicketBrokerCore.sol
+++ b/contracts/pm/mixins/interfaces/MTicketBrokerCore.sol
@@ -2,6 +2,16 @@ pragma solidity ^0.4.25;
 
 
 contract MTicketBrokerCore {
+    struct Ticket {
+        address recipient;          // Address of ticket recipient
+        address sender;             // Address of ticket sender
+        uint256 faceValue;          // Face value of ticket paid to recipient if ticket wins
+        uint256 winProb;            // Probability ticket will win represented as winProb / (2^256 - 1)
+        uint256 senderNonce;        // Sender's monotonically increasing counter for each ticket
+        bytes32 recipientRandHash;  // keccak256 hash commitment to recipient's random value
+        bytes auxData;              // Auxilary data included in ticket used for additional validation
+    }
+
     // Emitted when funds are added to a sender's deposit
     event DepositFunded(address indexed sender, uint256 amount);
     // Emitted when a winning ticket is redeemed

--- a/contracts/pm/mixins/interfaces/MTicketProcessor.sol
+++ b/contracts/pm/mixins/interfaces/MTicketProcessor.sol
@@ -18,8 +18,9 @@ contract MTicketProcessor {
      * @dev Transfer funds for a recipient's winning ticket
      * @param _recipient Address of recipient
      * @param _amount Amount of funds for the winning ticket
+     * @param _auxData Auxilary data for the winning ticket
      */
-    function winningTicketTransfer(address _recipient, uint256 _amount) internal;
+    function winningTicketTransfer(address _recipient, uint256 _amount, bytes _auxData) internal;
 
     /**
      * @dev Validates a ticket's auxilary data (succeeds or reverts)

--- a/contracts/rounds/IRoundsManager.sol
+++ b/contracts/rounds/IRoundsManager.sol
@@ -6,7 +6,12 @@ pragma solidity ^0.4.25;
  */
 contract IRoundsManager {
     // Events
-    event NewRound(uint256 round);
+    event NewRound(uint256 indexed round, bytes32 blockHash);
+
+    // Deprecated events
+    // These event signatures can be used to construct the appropriate topic hashes to filter for past logs corresponding
+    // to these deprecated events.
+    // event NewRound(uint256 round)
 
     // External functions
     function initializeRound() external;
@@ -14,6 +19,7 @@ contract IRoundsManager {
     // Public functions
     function blockNum() public view returns (uint256);
     function blockHash(uint256 _block) public view returns (bytes32);
+    function blockHashForRound(uint256 _round) public view returns (bytes32);
     function currentRound() public view returns (uint256);
     function currentRoundStartBlock() public view returns (uint256);
     function currentRoundInitialized() public view returns (bool);

--- a/contracts/rounds/RoundsManager.sol
+++ b/contracts/rounds/RoundsManager.sol
@@ -30,6 +30,9 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
     // Start block of the round in which roundLength was last updated
     uint256 public lastRoundLengthUpdateStartBlock;
 
+    // Mapping round number => block hash for the round
+    mapping (uint256 => bytes32) internal _blockHashForRound;
+
     /**
      * @dev RoundsManager constructor. Only invokes constructor of base Manager contract with provided Controller address
      * @param _controller Address of Controller that this contract will be registered with
@@ -85,12 +88,15 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
 
         // Set current round as initialized
         lastInitializedRound = currRound;
+        // Store block hash for round
+        bytes32 roundBlockHash = blockHash(blockNum().sub(1));
+        _blockHashForRound[currRound] = roundBlockHash;
         // Set active transcoders for the round
         bondingManager().setActiveTranscoders();
         // Set mintable rewards for the round
         minter().setCurrentRewardTokens();
 
-        emit NewRound(currRound);
+        emit NewRound(currRound, roundBlockHash);
     }
 
     /**
@@ -111,6 +117,15 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
         require(currentBlock < 256 || _block >= currentBlock - 256);
 
         return blockhash(_block);
+    }
+
+    /**
+     * @dev Return blockhash for a round
+     * @param _round Round number
+     * @return Blockhash for `_round`
+     */
+    function blockHashForRound(uint256 _round) public view returns (bytes32) {
+        return _blockHashForRound[_round];
     }
 
     /**

--- a/migrations/3_deploy_contracts.js
+++ b/migrations/3_deploy_contracts.js
@@ -35,7 +35,8 @@ module.exports = function(deployer, network) {
             "TicketBroker",
             controller.address,
             config.broker.freezePeriod,
-            config.broker.unlockPeriod
+            config.broker.unlockPeriod,
+            config.broker.ticketValidityPeriod
         )
         const bondingManager = await lpDeployer.deployProxyAndRegister(BondingManager, "BondingManager", controller.address)
 
@@ -65,5 +66,6 @@ module.exports = function(deployer, network) {
         // Set TicketBroker parameters
         await broker.setUnlockPeriod(config.broker.unlockPeriod)
         await broker.setFreezePeriod(config.broker.freezePeriod)
+        await broker.setTicketValidityPeriod(config.broker.ticketValidityPeriod)
     })
 }

--- a/migrations/migrations.config.js
+++ b/migrations/migrations.config.js
@@ -12,6 +12,7 @@ module.exports = {
         // TODO: Consider updating these values prior to deploying to testnet
         unlockPeriod: new BN(40320), // approximately 7 days worth of blocks
         freezePeriod: new BN(2),
+        ticketValidityPeriod: new BN(2)
     },
     roundsManager: {
         roundLength: 5760,

--- a/test/helpers/ticket.js
+++ b/test/helpers/ticket.js
@@ -31,6 +31,9 @@ const ticketObjToArr = ticketObj => {
     ]
 }
 
+const DUMMY_TICKET_CREATION_ROUND = 10
+const DUMMY_TICKET_CREATION_ROUND_BLOCK_HASH = web3.utils.keccak256("foo")
+
 const createTicket = ticketObj => {
     ticketObj = ticketObj ? ticketObj : {}
 
@@ -41,18 +44,19 @@ const createTicket = ticketObj => {
         winProb: isSet(ticketObj.winProb) ? ticketObj.winProb : 0,
         senderNonce: isSet(ticketObj.senderNonce) ? ticketObj.senderNonce : 0,
         recipientRandHash: isSet(ticketObj.recipientRandHash) ? ticketObj.recipientRandHash : constants.NULL_BYTES,
-        auxData: isSet(ticketObj.auxData) ? ticketObj.auxData : web3.utils.numberToHex(getValidTimestamp())
+        auxData: isSet(ticketObj.auxData) ? ticketObj.auxData : defaultAuxData()
     }
 }
 
-const createWinningTicket = (recipient, sender, recipientRand, faceValue = 0) => {
+const createWinningTicket = (recipient, sender, recipientRand, faceValue = 0, auxData = defaultAuxData()) => {
     const recipientRandHash = web3.utils.soliditySha3(recipientRand)
     const ticketObj = {
         recipient,
         sender,
         faceValue,
         winProb: constants.MAX_UINT256.toString(),
-        recipientRandHash
+        recipientRandHash,
+        auxData
     }
 
     return createTicket(ticketObj)
@@ -70,10 +74,11 @@ const getTicketHash = ticketObj => {
     )
 }
 
-const getValidTimestamp = () => {
-    const result = new Date()
-    result.setDate(result.getDate() + 365)
-    return parseInt(result.getTime() / 1000)
+const defaultAuxData = () => {
+    return web3.eth.abi.encodeParameters(
+        ["uint256", "bytes32"],
+        [DUMMY_TICKET_CREATION_ROUND, DUMMY_TICKET_CREATION_ROUND_BLOCK_HASH]
+    )
 }
 
 const isSet = v => {
@@ -84,5 +89,7 @@ module.exports = {
     wrapRedeemWinningTicket,
     createTicket,
     createWinningTicket,
-    getTicketHash
+    getTicketHash,
+    DUMMY_TICKET_CREATION_ROUND,
+    DUMMY_TICKET_CREATION_ROUND_BLOCK_HASH
 }

--- a/test/helpers/ticket.js
+++ b/test/helpers/ticket.js
@@ -1,36 +1,5 @@
 import {constants} from "../../utils/constants"
 
-const wrapRedeemWinningTicket = broker => {
-    return async (ticketObj, sig, recipientRand, txOpts) => {
-        if (txOpts == undefined) {
-            return broker.redeemWinningTicket(
-                ...ticketObjToArr(ticketObj),
-                sig,
-                recipientRand
-            )
-        } else {
-            return broker.redeemWinningTicket(
-                ...ticketObjToArr(ticketObj),
-                sig,
-                recipientRand,
-                txOpts
-            )
-        }
-    }
-}
-
-const ticketObjToArr = ticketObj => {
-    return [
-        ticketObj.recipient,
-        ticketObj.sender,
-        ticketObj.faceValue,
-        ticketObj.winProb,
-        ticketObj.senderNonce,
-        ticketObj.recipientRandHash,
-        ticketObj.auxData
-    ]
-}
-
 const DUMMY_TICKET_CREATION_ROUND = 10
 const DUMMY_TICKET_CREATION_ROUND_BLOCK_HASH = web3.utils.keccak256("foo")
 
@@ -86,7 +55,6 @@ const isSet = v => {
 }
 
 module.exports = {
-    wrapRedeemWinningTicket,
     createTicket,
     createWinningTicket,
     getTicketHash,


### PR DESCRIPTION
Closes #281 via dfa2512
Closes #282 via 4306cd3

Also removed a now unneeded wrapper function in `ticket.js` because we have switched back to passing the `Ticket` struct into `redeemWinningTicket()` instead of passing in the individual `Ticket` fields