### PR TITLE
pm: Batch ticket redemption

### DIFF
--- a/contracts/pm/TicketBroker.sol
+++ b/contracts/pm/TicketBroker.sol
@@ -6,13 +6,15 @@ import "./mixins/MixinContractRegistry.sol";
 import "./mixins/MixinReserve.sol";
 import "./mixins/MixinTicketBrokerCore.sol";
 import "./mixins/MixinTicketProcessor.sol";
+import "./mixins/MixinWrappers.sol";
 
 
 contract TicketBroker is
     MixinContractRegistry,
     MixinReserve,
     MixinTicketBrokerCore,
-    MixinTicketProcessor
+    MixinTicketProcessor,
+    MixinWrappers
 {
     constructor(
         address _controller,

--- a/contracts/pm/mixins/MixinTicketBrokerCore.sol
+++ b/contracts/pm/mixins/MixinTicketBrokerCore.sol
@@ -17,16 +17,6 @@ contract MixinTicketBrokerCore is MReserve, MTicketProcessor, MTicketBrokerCore 
         uint256 withdrawBlock;  // Block that sender can withdraw deposit & reserve
     }
 
-    struct Ticket {
-        address recipient;          // Address of ticket recipient
-        address sender;             // Address of ticket sender
-        uint256 faceValue;          // Face value of ticket paid to recipient if ticket wins
-        uint256 winProb;            // Probability ticket will win represented as winProb / (2^256 - 1)
-        uint256 senderNonce;        // Sender's monotonically increasing counter for each ticket
-        bytes32 recipientRandHash;  // keccak256 hash commitment to recipient's random value
-        bytes auxData;              // Auxilary data included in ticket used for additional validation
-    }
-
     // Number of blocks before a sender can withdraw after requesting an unlock
     uint256 public unlockPeriod;
 
@@ -124,7 +114,7 @@ contract MixinTicketBrokerCore is MReserve, MTicketProcessor, MTicketBrokerCore 
 
     /**
      * @dev Redeems a winning ticket that has been signed by a sender and reveals the
-     * recipient recipeintRand that corresponds to the recipientRandHash included in the ticket
+     * recipient recipientRand that corresponds to the recipientRandHash included in the ticket
      * @param _ticket Winning ticket to be redeemed in order to claim payment
      * @param _sig Sender's signature over the hash of `_ticket`
      * @param _recipientRand The preimage for the recipientRandHash included in `_ticket`

--- a/contracts/pm/mixins/MixinWrappers.sol
+++ b/contracts/pm/mixins/MixinWrappers.sol
@@ -1,0 +1,72 @@
+pragma solidity ^0.4.25;
+// solium-disable-next-line
+pragma experimental ABIEncoderV2;
+
+import "./interfaces/MTicketBrokerCore.sol";
+
+
+contract MixinWrappers is MTicketBrokerCore {
+    /**
+     * @dev Redeems multiple winning tickets. The function will redeem all of the provided
+     * tickets and handle any failures gracefully without reverting the entire function
+     * @param _tickets Array of winning tickets to be redeemed in order to claim payment
+     * @param _sigs Array of sender signatures over the hash of tickets (`_sigs[i]` corresponds to `_tickets[i]`)
+     * @param _recipientRands Array of preimages for the recipientRandHash included in each ticket (`_recipientRands[i]` corresponds to `_tickets[i]`)
+     */
+    function batchRedeemWinningTickets(
+        Ticket[] memory _tickets,
+        bytes[] _sigs,
+        uint256[] _recipientRands
+    )
+        public
+    {
+        for (uint256 i = 0; i < _tickets.length; i++) {
+            redeemWinningTicketNoRevert(
+                _tickets[i],
+                _sigs[i],
+                _recipientRands[i]
+            );
+        }
+    }
+
+    /**
+     * @dev Redeems a winning ticket that has been signed by a sender and reveals the
+     * recipient recipientRand that corresponds to the recipientRandHash included in the ticket
+     * This function wraps `redeemWinningTicket()` and returns false if the underlying call reverts
+     * @param _ticket Winning ticket to be redeemed in order to claim payment
+     * @param _sig Sender's signature over the hash of `_ticket`
+     * @param _recipientRand The preimage for the recipientRandHash included in `_ticket`
+     * @return Boolean indicating whether the underlying `redeemWinningTicket()` call succeeded
+     */
+    function redeemWinningTicketNoRevert(
+        Ticket memory _ticket,
+        bytes _sig,
+        uint256 _recipientRand
+    )
+        internal
+        returns (bool success)
+    {
+        // ABI encode calldata for `redeemWinningTicket()`
+        // A tuple type is used to represent the Ticket struct in the function signature
+        bytes memory redeemWinningTicketCalldata = abi.encodeWithSignature(
+            "redeemWinningTicket((address,address,uint256,uint256,uint256,bytes32,bytes),bytes,uint256)",
+            _ticket,
+            _sig,
+            _recipientRand
+        );
+
+        // Call `redeemWinningTicket()`
+        assembly {
+            // call will return false upon hitting a revert
+            success := call(
+                gas,                                   // Forward all gas
+                address,                               // Address of this contract (calling self)
+                0,                                     // Send 0 ETH
+                add(redeemWinningTicketCalldata, 32),  // Start of calldata (skip first 32 bytes containing array length)
+                mload(redeemWinningTicketCalldata),    // Length of calldata (first 32 bytes contains array length)
+                0,                                     // Ignore start of output
+                0                                      // Ignore size of output
+            )
+        }
+    }
+}

--- a/contracts/pm/mixins/interfaces/MTicketBrokerCore.sol
+++ b/contracts/pm/mixins/interfaces/MTicketBrokerCore.sol
@@ -2,6 +2,16 @@ pragma solidity ^0.4.25;
 
 
 contract MTicketBrokerCore {
+    struct Ticket {
+        address recipient;          // Address of ticket recipient
+        address sender;             // Address of ticket sender
+        uint256 faceValue;          // Face value of ticket paid to recipient if ticket wins
+        uint256 winProb;            // Probability ticket will win represented as winProb / (2^256 - 1)
+        uint256 senderNonce;        // Sender's monotonically increasing counter for each ticket
+        bytes32 recipientRandHash;  // keccak256 hash commitment to recipient's random value
+        bytes auxData;              // Auxilary data included in ticket used for additional validation
+    }
+
     // Emitted when funds are added to a sender's deposit
     event DepositFunded(address indexed sender, uint256 amount);
     // Emitted when a winning ticket is redeemed


### PR DESCRIPTION
Closes #274 

`batchRedeemWinningTickets()` uses the `redeemWinningTicketNoRevert()` helper to redeem tickets without reverting the entire function when execution hits a revert in the underlying call. 

This PR does not implement the suggestion in #274 of validating each ticket, summing the face values of the tickets and then executing a single batch value transfer which would save some gas. Instead, each ticket redemption is distinct and involves its own associated value transfer. I chose to do this to keep things simple initially. Furthermore, in a Livepeer context, the value transfer involves sending the value to the recipient's (orchestrator) fee pool for the ticket's creation round and in cases where a batch of tickets have different creation rounds, there would need to be a separate value transfer for each creation round anyway. So, I'm leaving an investigation of gas related optimizations for later on.