### PR TITLE
pm: claimableReserve function & tests

### DIFF
--- a/contracts/pm/mixins/MixinReserve.sol
+++ b/contracts/pm/mixins/MixinReserve.sol
@@ -43,6 +43,24 @@ contract MixinReserve is MContractRegistry, MReserve {
     }
 
     /**
+     * @dev Returns the amount of funds claimable by a claimant from a reserve
+     * @param _reserveHolder Address of reserve holder
+     * @param _claimant Address of claimant
+     * @return Amount of funds claimable by `_claimant`from the reserve for `_reserveHolder`
+     */
+    function claimableReserve(address _reserveHolder, address _claimant) public view returns (uint256) {
+        ReserveManager storage manager = reserveManagers[_reserveHolder];
+        Reserve storage reserve = manager.reserve;
+        if (reserveState(_reserveHolder) == ReserveState.NotFrozen) {
+            // TODO: Check if claimant is registered in current round
+            return reserve.fundsAdded.div(bondingManager().getTranscoderPoolSize());
+        } else {
+            // TODO: Check if claimant is registered during the freezeRound
+            return reserve.fundsAdded.div(reserve.recipientsInFreezeRound).sub(manager.claimedPerReserve[manager.reserveNonce][_claimant]);
+        }
+    }
+
+    /**
      * @dev Returns the amount of funds claimed by a claimant from a reserve
      * @param _reserveHolder Address of reserve holder
      * @param _claimant Address of claimant

--- a/contracts/pm/mixins/MixinReserve.sol
+++ b/contracts/pm/mixins/MixinReserve.sol
@@ -46,17 +46,20 @@ contract MixinReserve is MContractRegistry, MReserve {
      * @dev Returns the amount of funds claimable by a claimant from a reserve
      * @param _reserveHolder Address of reserve holder
      * @param _claimant Address of claimant
-     * @return Amount of funds claimable by `_claimant`from the reserve for `_reserveHolder`
+     * @return Amount of funds claimable by `_claimant` from the reserve for `_reserveHolder`
      */
     function claimableReserve(address _reserveHolder, address _claimant) public view returns (uint256) {
         ReserveManager storage manager = reserveManagers[_reserveHolder];
         Reserve storage reserve = manager.reserve;
         if (reserveState(_reserveHolder) == ReserveState.NotFrozen) {
             // TODO: Check if claimant is registered in current round
-            return reserve.fundsAdded.div(bondingManager().getTranscoderPoolSize());
+            uint256 poolSize = bondingManager().getTranscoderPoolSize();
+            return poolSize > 0 ? reserve.fundsAdded.div(poolSize) : 0;
         } else {
             // TODO: Check if claimant is registered during the freezeRound
-            return reserve.fundsAdded.div(reserve.recipientsInFreezeRound).sub(manager.claimedPerReserve[manager.reserveNonce][_claimant]);
+            return reserve.recipientsInFreezeRound > 0 ?
+                reserve.fundsAdded.div(reserve.recipientsInFreezeRound).sub(manager.claimedPerReserve[manager.reserveNonce][_claimant]) :
+                0;
         }
     }
 

--- a/test/unit/TicketBroker.js
+++ b/test/unit/TicketBroker.js
@@ -1735,4 +1735,93 @@ contract("TicketBroker", accounts => {
             assert.equal(event.returnValues.reserve.toString(), reserve.toString())
         })
     })
+
+    describe("claimableReserve", () => {
+        it("returns 0 when the reserveHolder does not have a reserve", async () => {
+            const numRecipients = 10
+            await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
+            assert.equal((await broker.claimableReserve(constants.NULL_ADDRESS, constants.NULL_ADDRESS)).toString(), "0")
+        })
+        it("Returns claimable reserve for a claimaint if reserve is not frozen", async () => {
+            const numRecipients = 10
+            const deposit = 1000
+            const reserve = 1000
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
+            await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
+            await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+            await broker.fundDepositAndReserve(deposit, reserve, {from: sender, value: deposit+reserve})
+            assert.equal(
+                (await broker.claimableReserve(sender, recipient)).toString(10),
+                (reserve/numRecipients).toString(10)
+            )
+            const recipientRand = 5
+            const faceValue = 10
+            const ticket = createWinningTicket(recipient, sender, recipientRand, faceValue)
+            const senderSig = await web3.eth.sign(getTicketHash(ticket), sender)
+            // Redeem a winning ticket
+            await broker.redeemWinningTicket(ticket, senderSig, recipientRand, {from: recipient})
+            // Reserve allocated for recipient should still be 100 since ticket was drawn from deposit 
+            assert.equal(
+                (await broker.claimableReserve(sender, recipient)).toString(10),
+                "100"
+            )
+            // Ticket faceValue should be substracted from deposit
+            assert.equal(
+                (deposit-faceValue).toString(10),
+                (await broker.getSenderInfo(sender)).sender.deposit.toString(10)
+            )
+        })
+        it("Returns claimable reserve for a claimant after reserve has been frozen", async () => {
+            const numRecipients = 10
+            const reserve = 1000
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
+            await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
+            await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+            await broker.fundReserve({from: sender, value: reserve})
+
+            const recipientRand = 5
+            const faceValue = 10
+            const ticket = createWinningTicket(recipient, sender, recipientRand, faceValue)
+            const senderSig = await web3.eth.sign(getTicketHash(ticket), sender)
+            // Claim winning ticket - will freeze reserve (deposit = 0)
+            await broker.redeemWinningTicket(ticket, senderSig, recipientRand, {from: recipient})
+            // Assert reserve is frozen
+            await expectRevertWithReason(
+                broker.fundDeposit({from: sender, value: 1000}),
+                "sender's reserve is frozen"
+            )
+            // claimableReserve should be equal to reserve/numRecepients - faceValue
+            assert.equal(
+                (await broker.claimableReserve(sender, recipient)).toString(10),
+                (reserve/numRecipients - faceValue).toString(10)
+            )
+        })
+        it("Returns 0 if claimant has claimed all of his claimableReserve", async () => {
+            const numRecipients = 10
+            const reserve = 1000
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
+            await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
+            await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+            await broker.fundReserve({from: sender, value: 1000})
+
+            let recipientRand = 5
+            const faceValue = 100
+            let ticket = createWinningTicket(recipient, sender, recipientRand, faceValue)
+            let senderSig = await web3.eth.sign(getTicketHash(ticket), sender)
+
+            // Claim winning ticket - will freeze reserve (deposit = 0)
+            await broker.redeemWinningTicket(ticket, senderSig, recipientRand, {from: recipient})
+            // Assert reserve is frozen
+            await expectRevertWithReason(
+                broker.fundDeposit({from: sender, value: reserve}),
+                "sender's reserve is frozen"
+            )
+            assert.equal(
+                (await broker.claimableReserve(sender, recipient)).toString(10),
+                "0"
+            )
+        })
+        // TODO: If not frozen Returns 0 if Orchestrator is not registered during current round
+        // TODO: If frozen returns 0 if orchestrator is not registered during freezeRound
+    })
 })


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Implements a method `claimableReserve(address _claimaint, address _reserveHolder) returns (uint256 claimableReserve)` in `MixinReserve.sol` which returns the amount of funds claimable by a claimant/orchestrator from a reserveHolder/broadcaster's reserve

**How did you test each of these updates (required)**
Added unit tests for the added method 

**Additional Information (TODO)**

* At the moment we do not check if the claimant is actually registered as orchestrator in the current round (if the reserveHolder's reserve is not frozen) or that the claimant was/is registered as orchestrator during the freezeRound in case a reserveHolder's reserve has been frozen. 
This is due to the corresponding functionality not being implemented yet in BondingManager

* Unit tests once that functionality is implemented in the BondingManager.

