### PR TITLE
Remove Docker push from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,7 @@ jobs:
       - run:
           name: Build docker image
           command: |
-            docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-            docker pull $IMAGE_LATEST
             npm run docker:build
-            npm run docker:push
       - run:
           name: Run linting
           command: npm run docker:run:lint


### PR DESCRIPTION
This PR removes Docker push from the CI workflow. At the moment, CI will build a Docker image with the contracts compiled and push the new image to DockerHub. Due to authorization issues (outdated Docker auth workflow), Docker push is causing CI to fail. We can remove Docker push from the CI workflow and instead turn on auto-build for Docker images using DockerHub separately instead of configuring CircleCI to push the image.