### PR TITLE
bondingManager: make DLL in place representation of active set

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Livepeer Protocol consists of the on-chain smart contracts that govern the l
 
 The protocol is outlined in the
 [Livepeer Whitepaper](http://github.com/livepeer/wiki/blob/master/WHITEPAPER.md)
-and is more formally specified in the [Protocol Specification](http://github.com/livepeer/wiki/blob/master/SPEC.md).
+and is more formally specified in the [Protocol Specification](https://github.com/livepeer/wiki/tree/master/spec).
 
 The current status is that this is a near complete implementation of the
 initial pass at the Livepeer protocol which accounts for the alpha

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -25,7 +25,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     // Time between unbonding and possible withdrawl in rounds
     uint64 public unbondingPeriod;
     // Number of active transcoders
-    uint256 public numActiveTranscoders;
+    uint256 public numActiveTranscodersDEPRECATED;
     // Max number of rounds that a caller can claim earnings for at once
     uint256 public maxEarningsClaimsRounds;
 
@@ -88,6 +88,11 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     // Keep track of active transcoder set for each round
     mapping (uint256 => ActiveTranscoderSet) public activeTranscoderSet;
 
+    // The total active stake (sum of the stake of active set members) for the current round
+    uint256 public currentRoundTotalActiveStake;
+    // The total active stake (sum of the stake of active set members) for the next round
+    uint256 public nextRoundTotalActiveStake;
+
     // Check if sender is TicketBroker
     modifier onlyTicketBroker() {
         require(msg.sender == controller.getContract(keccak256("TicketBroker")));
@@ -129,27 +134,11 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Set max number of registered transcoders. Only callable by Controller owner
-     * @param _numTranscoders Max number of registered transcoders
-     */
-    function setNumTranscoders(uint256 _numTranscoders) external onlyControllerOwner {
-        // Max number of transcoders must be greater than or equal to number of active transcoders
-        require(_numTranscoders >= numActiveTranscoders);
-
-        transcoderPool.setMaxSize(_numTranscoders);
-
-        emit ParameterUpdate("numTranscoders");
-    }
-
-    /**
      * @dev Set number of active transcoders. Only callable by Controller owner
      * @param _numActiveTranscoders Number of active transcoders
      */
     function setNumActiveTranscoders(uint256 _numActiveTranscoders) external onlyControllerOwner {
-        // Number of active transcoders cannot exceed max number of transcoders
-        require(_numActiveTranscoders <= transcoderPool.getMaxSize());
-
-        numActiveTranscoders = _numActiveTranscoders;
+        transcoderPool.setMaxSize(_numActiveTranscoders);
 
         emit ParameterUpdate("numActiveTranscoders");
     }
@@ -177,6 +166,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         Transcoder storage t = transcoders[msg.sender];
         Delegator storage del = delegators[msg.sender];
 
+        uint256 currentRound = roundsManager().currentRound();
+
         // No transcoder operations can take place during the round lock period
         require(
             !roundsManager().currentRoundLocked(),
@@ -194,26 +185,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         t.pendingRewardCut = _rewardCut;
         t.pendingFeeShare = _feeShare;
 
-        uint256 delegatedAmount = del.delegatedAmount;
-
-        // Check if transcoder is not already registered
-        if (transcoderStatus(msg.sender) == TranscoderStatus.NotRegistered) {
-            if (!transcoderPool.isFull()) {
-                // If pool is not full add new transcoder
-                transcoderPool.insert(msg.sender, delegatedAmount, address(0), address(0));
-            } else {
-                address lastTranscoder = transcoderPool.getLast();
-
-                if (delegatedAmount > transcoderTotalStake(lastTranscoder)) {
-                    // If pool is full and caller has more delegated stake than the transcoder in the pool with the least delegated stake:
-                    // - Evict transcoder in pool with least delegated stake
-                    // - Add caller to pool
-                    transcoderPool.remove(lastTranscoder);
-                    transcoderPool.insert(msg.sender, delegatedAmount, address(0), address(0));
-
-                    emit TranscoderEvicted(lastTranscoder);
-                }
-            }
+        if (!transcoderPool.contains(msg.sender)) {
+            tryToJoinActiveSet(msg.sender, del.delegatedAmount, currentRound);
         }
 
         emit TranscoderUpdate(msg.sender, _rewardCut, _feeShare, transcoderPool.contains(msg.sender));
@@ -248,44 +221,46 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             del.startRound = currentRound.add(1);
             // Unbonded state = no existing delegate and no bonded stake
             // Thus, delegation amount = provided amount
-        } else if (del.delegateAddress != address(0) && _to != del.delegateAddress) {
+        } else if (currentDelegate != address(0) && currentDelegate != _to) {
             // A registered transcoder cannot delegate its bonded stake toward another address
             // because it can only be delegated toward itself
             // In the future, if delegation towards another registered transcoder as an already
             // registered transcoder becomes useful (i.e. for transitive delegation), this restriction
             // could be removed
-            require(transcoderStatus(msg.sender) == TranscoderStatus.NotRegistered);
+            require(!isRegisteredTranscoder(msg.sender), "registered transcoders can't delegate towards other addresses");
             // Changing delegate
             // Set start round
             del.startRound = currentRound.add(1);
             // Update amount to delegate with previous delegation amount
             delegationAmount = delegationAmount.add(del.bondedAmount);
-            // Decrease old delegate's delegated amount
-            delegators[currentDelegate].delegatedAmount = delegators[currentDelegate].delegatedAmount.sub(del.bondedAmount);
 
-            if (transcoderStatus(currentDelegate) == TranscoderStatus.Registered) {
+            if (isRegisteredTranscoder(currentDelegate)) {
                 // Previously delegated to a transcoder
                 // Decrease old transcoder's total stake
-                transcoderPool.updateKey(currentDelegate, transcoderTotalStake(currentDelegate).sub(del.bondedAmount), address(0), address(0));
+                decreaseTranscoderTotalStake(currentDelegate, del.bondedAmount);
             }
+
+            // Decrease old delegate's delegated amount
+            delegators[currentDelegate].delegatedAmount = delegators[currentDelegate].delegatedAmount.sub(del.bondedAmount);
         }
 
         // Delegation amount must be > 0 - cannot delegate to someone without having bonded stake
-        require(delegationAmount > 0);
+        require(delegationAmount > 0, "delegation amount must be greater than 0");
         // Update delegate
         del.delegateAddress = _to;
+        // Update bonded amount
+        del.bondedAmount = del.bondedAmount.add(_amount);
+        
+        if (isRegisteredTranscoder(_to)) {
+            // Delegated to a transcoder
+            // Increase transcoder's total stake
+            increaseTranscoderTotalStake(_to, delegationAmount);
+        }
+
         // Update current delegate's delegated amount with delegation amount
         delegators[_to].delegatedAmount = delegators[_to].delegatedAmount.add(delegationAmount);
 
-        if (transcoderStatus(_to) == TranscoderStatus.Registered) {
-            // Delegated to a transcoder
-            // Increase transcoder's total stake
-            transcoderPool.updateKey(_to, transcoderTotalStake(del.delegateAddress).add(delegationAmount), address(0), address(0));
-        }
-
         if (_amount > 0) {
-            // Update bonded amount
-            del.bondedAmount = del.bondedAmount.add(_amount);
             // Transfer the LPT to the Minter
             livepeerToken().transferFrom(msg.sender, minter(), _amount);
         }
@@ -304,14 +279,14 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         autoClaimEarnings
     {
         // Caller must be in bonded state
-        require(delegatorStatus(msg.sender) == DelegatorStatus.Bonded);
+        require(delegatorStatus(msg.sender) == DelegatorStatus.Bonded, "caller must be bonded");
 
         Delegator storage del = delegators[msg.sender];
 
         // Amount must be greater than 0
-        require(_amount > 0);
+        require(_amount > 0, "unbonding amount must be greater than 0");
         // Amount to unbond must be less than or equal to current bonded amount 
-        require(_amount <= del.bondedAmount);
+        require(_amount <= del.bondedAmount, "amount is greater than bonded amount");
 
         address currentDelegate = del.delegateAddress;
         uint256 currentRound = roundsManager().currentRound();
@@ -327,17 +302,15 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         del.nextUnbondingLockId = unbondingLockId.add(1);
         // Decrease delegator's bonded amount
         del.bondedAmount = del.bondedAmount.sub(_amount);
-        // Decrease delegate's delegated amount
-        delegators[del.delegateAddress].delegatedAmount = delegators[del.delegateAddress].delegatedAmount.sub(_amount);
 
-        if (transcoderStatus(del.delegateAddress) == TranscoderStatus.Registered && (del.delegateAddress != msg.sender || del.bondedAmount > 0)) {
-            // A transcoder's delegated stake within the registered pool needs to be decreased if:
-            // - The caller's delegate is a registered transcoder
-            // - Caller is not delegated to self OR caller is delegated to self and has a non-zero bonded amount
-            // If the caller is delegated to self and has a zero bonded amount, it will be removed from the 
-            // transcoder pool so its delegated stake within the pool does not need to be decreased
-            transcoderPool.updateKey(del.delegateAddress, transcoderTotalStake(del.delegateAddress).sub(_amount), address(0), address(0));
-        }
+        if (currentDelegate != msg.sender || del.bondedAmount > 0) {
+            decreaseTranscoderTotalStake(currentDelegate, _amount);
+        } else {
+            resignTranscoder(msg.sender);
+        }   
+
+        // Decrease delegate's delegated amount
+        delegators[currentDelegate].delegatedAmount = delegators[currentDelegate].delegatedAmount.sub(_amount);
 
         // Check if delegator has a zero bonded amount
         // If so, update its delegation status
@@ -346,11 +319,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             del.delegateAddress = address(0);
             // Delegator does not have a start round if it is no longer delegated to anyone
             del.startRound = 0;
-
-            if (transcoderStatus(msg.sender) == TranscoderStatus.Registered) {
-                // If caller is a registered transcoder and is no longer bonded, resign
-                resignTranscoder(msg.sender);
-            }
         } 
 
         emit Unbond(currentDelegate, msg.sender, unbondingLockId, _amount, withdrawRound);
@@ -370,7 +338,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         autoClaimEarnings
     {
         // Caller must not be an unbonded delegator
-        require(delegatorStatus(msg.sender) != DelegatorStatus.Unbonded);
+        require(delegatorStatus(msg.sender) != DelegatorStatus.Unbonded, "caller must be bonded");
 
         // Process rebond using unbonding lock
         processRebond(msg.sender, _unbondingLockId);
@@ -456,7 +424,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      */
     function setActiveTranscoders() external whenSystemNotPaused onlyRoundsManager {
         uint256 currentRound = roundsManager().currentRound();
-        uint256 activeSetSize = Math.min(numActiveTranscoders, transcoderPool.getSize());
+        uint256 activeSetSize = transcoderPool.getSize();
 
         uint256 totalStake = 0;
         address currentTranscoder = transcoderPool.getFirst();
@@ -525,7 +493,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         onlyTicketBroker
     {
         // Transcoder must be registered
-        require(transcoderStatus(_transcoder) == TranscoderStatus.Registered);
+        require(isRegisteredTranscoder(_transcoder));
 
         Transcoder storage t = transcoders[_transcoder];
 
@@ -556,19 +524,15 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         if (del.bondedAmount > 0) {
             uint256 penalty = MathUtils.percOf(delegators[_transcoder].bondedAmount, _slashAmount);
 
+            // If registered transcoder, resign it
+            resignTranscoder(_transcoder);
+
             // Decrease bonded stake
             del.bondedAmount = del.bondedAmount.sub(penalty);
 
-            // If still bonded
-            // - Decrease delegate's delegated amount
-            // - Decrease total bonded tokens
+            // If still bonded decrease delegate's delegated amount
             if (delegatorStatus(_transcoder) == DelegatorStatus.Bonded) {
                 delegators[del.delegateAddress].delegatedAmount = delegators[del.delegateAddress].delegatedAmount.sub(penalty);
-            }
-
-            // If registered transcoder, resign it
-            if (transcoderStatus(_transcoder) == TranscoderStatus.Registered) {
-                resignTranscoder(_transcoder);
             }
 
             // Account for penalty
@@ -605,6 +569,13 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         require(_endRound <= roundsManager().currentRound());
 
         updateDelegatorWithEarnings(msg.sender, _endRound);
+    }
+
+    /**
+     * @dev Called during round initialization 
+     */
+    function setCurrentRoundTotalActiveStake() external onlyRoundsManager {
+        currentRoundTotalActiveStake = nextRoundTotalActiveStake;
     }
 
     /**
@@ -668,9 +639,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * @param _transcoder Address of a transcoder
      */
     function activeTranscoderTotalStake(address _transcoder, uint256 _round) public view returns (uint256) {
-        // Must be active transcoder
-        require(activeTranscoderSet[_round].isActive[_transcoder]);
-
+        // will return 0 if transcoder is not active
         return transcoders[_transcoder].earningsPoolPerRound[_round].totalStake;
     }
 
@@ -679,19 +648,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * @param _transcoder Address of transcoder
      */
     function transcoderTotalStake(address _transcoder) public view returns (uint256) {
-        return transcoderPool.getKey(_transcoder);
-    }
-
-    /*
-     * @dev Computes transcoder status
-     * @param _transcoder Address of transcoder
-     */
-    function transcoderStatus(address _transcoder) public view returns (TranscoderStatus) {
-        if (transcoderPool.contains(_transcoder)) {
-            return TranscoderStatus.Registered;
-        } else {
-            return TranscoderStatus.NotRegistered;
-        }
+        return delegators[_transcoder].delegatedAmount;
     }
 
     /**
@@ -747,7 +704,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     )
         public
         view
-        returns (uint256 rewardPool, uint256 feePool, uint256 totalStake, uint256 claimableStake, uint256 transcoderRewardCut, uint256 transcoderFeeShare, uint256 transcoderRewardPool, uint256 transcoderFeePool, bool hasTranscoderRewardFeePool)
+        returns (uint256 rewardPool, uint256 feePool, uint256 totalStake, uint256 claimableStake, uint256 transcoderRewardCut, uint256 transcoderFeeShare, uint256 transcoderRewardPool, uint256 transcoderFeePool, bool hasTranscoderRewardFeePool, bool active)
     {
         EarningsPool.Data storage earningsPool = transcoders[_transcoder].earningsPoolPerRound[_round];
 
@@ -760,6 +717,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         transcoderRewardPool = earningsPool.transcoderRewardPool;
         transcoderFeePool = earningsPool.transcoderFeePool;
         hasTranscoderRewardFeePool = earningsPool.hasTranscoderRewardFeePool;
+        active = earningsPool.active;
     }
 
     /**
@@ -850,20 +808,12 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Return total active stake for a round
-     * @param _round Round number
-     */
-    function getTotalActiveStake(uint256 _round) public view returns (uint256) {
-        return activeTranscoderSet[_round].totalStake;
-    }
-
-    /**
      * @dev Return whether a transcoder was active during a round
      * @param _transcoder Transcoder address
      * @param _round Round number
      */
     function isActiveTranscoder(address _transcoder, uint256 _round) public view returns (bool) {
-        return activeTranscoderSet[_round].isActive[_transcoder];
+        return transcoders[_transcoder].earningsPoolPerRound[_round].active;
     }
 
     /**
@@ -871,7 +821,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * @param _transcoder Transcoder address
      */
     function isRegisteredTranscoder(address _transcoder) public view returns (bool) {
-        return transcoderStatus(_transcoder) == TranscoderStatus.Registered;
+        return delegators[_transcoder].delegateAddress == _transcoder && delegatorStatus(_transcoder) == DelegatorStatus.Bonded;
     }
 
     /**
@@ -884,21 +834,68 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         return delegators[_delegator].unbondingLocks[_unbondingLockId].withdrawRound > 0;
     }
 
+    function increaseTranscoderTotalStake(address _transcoder, uint256 _amount) internal {
+        uint256 newStake = transcoderTotalStake(_transcoder).add(_amount);
+        // If the transcoder is already in the active set update its stake and return
+        if (transcoderPool.contains(_transcoder)) {
+            transcoderPool.updateKey(_transcoder, newStake, address(0), address(0));
+            nextRoundTotalActiveStake = nextRoundTotalActiveStake.add(_amount);
+            return;
+        }
+
+        // Check if the transcoder is eligible to join the active set in the update round
+        tryToJoinActiveSet(_transcoder, newStake, roundsManager().currentRound());
+    }
+
+    function decreaseTranscoderTotalStake(address _transcoder, uint256 _amount) internal {
+        if (!transcoderPool.contains(_transcoder)) {
+            return;
+        }
+
+        uint256 newStake = transcoderTotalStake(_transcoder).sub(_amount);
+
+        transcoderPool.updateKey(_transcoder, newStake, address(0), address(0));
+        nextRoundTotalActiveStake = nextRoundTotalActiveStake.sub(_amount);
+    }
+
+    function tryToJoinActiveSet(address _transcoder, uint256 _totalStake, uint256 _currentRound) internal {
+        uint256 nextRound = _currentRound.add(1);
+        uint256 pendingNextRoundTotalActiveStake = nextRoundTotalActiveStake;
+
+        if (transcoderPool.isFull()) {
+            address lastTranscoder = transcoderPool.getLast();
+            uint256 lastStake = transcoderTotalStake(lastTranscoder);
+
+            // If the pool is full and the transcoder has less stake than the least stake transcoder in the pool
+            // then the transcoder is unable to join the active set for the next round
+            if (_totalStake <= lastStake) {
+                return;
+            }
+
+            // Evict the least stake transcoder from the active set for the next round
+            transcoderPool.remove(lastTranscoder);
+            transcoders[lastTranscoder].earningsPoolPerRound[nextRound].deactivateStake();
+            pendingNextRoundTotalActiveStake = pendingNextRoundTotalActiveStake.sub(lastStake);
+
+            emit TranscoderEvicted(lastTranscoder);
+        }
+
+        transcoderPool.insert(_transcoder, _totalStake, address(0), address(0));
+        transcoders[_transcoder].earningsPoolPerRound[nextRound].activateStake(_totalStake);
+        pendingNextRoundTotalActiveStake = pendingNextRoundTotalActiveStake.add(_totalStake);
+
+        nextRoundTotalActiveStake = pendingNextRoundTotalActiveStake;
+    }
+
     /**
      * @dev Remove transcoder
      */
     function resignTranscoder(address _transcoder) internal {
+        uint256 transcoderStake = transcoderTotalStake(_transcoder);
+        decreaseTranscoderTotalStake(_transcoder, transcoderStake);
         uint256 currentRound = roundsManager().currentRound();
-        if (activeTranscoderSet[currentRound].isActive[_transcoder]) {
-            // Decrease total active stake for the round
-            activeTranscoderSet[currentRound].totalStake = activeTranscoderSet[currentRound].totalStake.sub(activeTranscoderTotalStake(_transcoder, currentRound));
-            // Set transcoder as inactive
-            activeTranscoderSet[currentRound].isActive[_transcoder] = false;
-        }
-
-        // Remove transcoder from pools
-        transcoderPool.remove(_transcoder);
-
+        transcoders[_transcoder].earningsPoolPerRound[currentRound].deactivateStake();
+        currentRoundTotalActiveStake = currentRoundTotalActiveStake.sub(transcoderStake);
         emit TranscoderResigned(_transcoder);
     }
 
@@ -982,13 +979,14 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         // Increase delegate's delegated amount
         delegators[del.delegateAddress].delegatedAmount = delegators[del.delegateAddress].delegatedAmount.add(amount);
 
-        if (transcoderStatus(del.delegateAddress) == TranscoderStatus.Registered) {
-            // If delegate is a registered transcoder increase its delegated stake in registered pool
-            transcoderPool.updateKey(del.delegateAddress, transcoderTotalStake(del.delegateAddress).add(amount), address(0), address(0));
-        }
-
         // Delete lock
         delete del.unbondingLocks[_unbondingLockId];
+
+        if (isRegisteredTranscoder(del.delegateAddress)) {
+            // If delegate is a registered transcoder increase its delegated stake in registered pool
+            increaseTranscoderTotalStake(del.delegateAddress, amount);
+        }
+
 
         emit Rebond(del.delegateAddress, _delegator, _unbondingLockId, amount);
     }

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -93,6 +93,9 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     // The total active stake (sum of the stake of active set members) for the next round
     uint256 public nextRoundTotalActiveStake;
 
+    // Keep track of the last stake update round for a transcoder
+    mapping(address => uint256) public lastActiveStakeUpdateRound;
+
     // Check if sender is TicketBroker
     modifier onlyTicketBroker() {
         require(msg.sender == controller.getContract(keccak256("TicketBroker")));
@@ -704,7 +707,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     )
         public
         view
-        returns (uint256 rewardPool, uint256 feePool, uint256 totalStake, uint256 claimableStake, uint256 transcoderRewardCut, uint256 transcoderFeeShare, uint256 transcoderRewardPool, uint256 transcoderFeePool, bool hasTranscoderRewardFeePool, bool active)
+        returns (uint256 rewardPool, uint256 feePool, uint256 totalStake, uint256 claimableStake, uint256 transcoderRewardCut, uint256 transcoderFeeShare, uint256 transcoderRewardPool, uint256 transcoderFeePool, bool hasTranscoderRewardFeePool)
     {
         EarningsPool.Data storage earningsPool = transcoders[_transcoder].earningsPoolPerRound[_round];
 
@@ -717,7 +720,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         transcoderRewardPool = earningsPool.transcoderRewardPool;
         transcoderFeePool = earningsPool.transcoderFeePool;
         hasTranscoderRewardFeePool = earningsPool.hasTranscoderRewardFeePool;
-        active = earningsPool.active;
     }
 
     /**
@@ -807,13 +809,12 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         return totalBonded;
     }
 
-    /**
-     * @dev Return whether a transcoder was active during a round
+   /**
+     * @dev Return whether a transcoder is active for the current round
      * @param _transcoder Transcoder address
-     * @param _round Round number
      */
-    function isActiveTranscoder(address _transcoder, uint256 _round) public view returns (bool) {
-        return transcoders[_transcoder].earningsPoolPerRound[_round].active;
+    function isActiveTranscoder(address _transcoder) public view returns (bool) {
+        return lastActiveStakeUpdateRound[_transcoder] != 0 && lastActiveStakeUpdateRound[_transcoder] <= roundsManager().currentRound();
     }
 
     /**
@@ -836,15 +837,18 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
     function increaseTranscoderTotalStake(address _transcoder, uint256 _amount) internal {
         uint256 newStake = transcoderTotalStake(_transcoder).add(_amount);
+        uint256 currentRound = roundsManager().currentRound();
+        uint256 nextRound = currentRound.add(1);
+
         // If the transcoder is already in the active set update its stake and return
         if (transcoderPool.contains(_transcoder)) {
             transcoderPool.updateKey(_transcoder, newStake, address(0), address(0));
             nextRoundTotalActiveStake = nextRoundTotalActiveStake.add(_amount);
-            return;
+            lastActiveStakeUpdateRound[_transcoder] = nextRound;
+        } else {
+            // Check if the transcoder is eligible to join the active set in the update round
+            tryToJoinActiveSet(_transcoder, newStake, currentRound);
         }
-
-        // Check if the transcoder is eligible to join the active set in the update round
-        tryToJoinActiveSet(_transcoder, newStake, roundsManager().currentRound());
     }
 
     function decreaseTranscoderTotalStake(address _transcoder, uint256 _amount) internal {
@@ -853,9 +857,15 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         }
 
         uint256 newStake = transcoderTotalStake(_transcoder).sub(_amount);
+        uint256 nextRound = roundsManager().currentRound().add(1);
 
         transcoderPool.updateKey(_transcoder, newStake, address(0), address(0));
         nextRoundTotalActiveStake = nextRoundTotalActiveStake.sub(_amount);
+        if (transcoderPool.contains(_transcoder)) {
+            lastActiveStakeUpdateRound[_transcoder] = nextRound;
+        } else {
+            lastActiveStakeUpdateRound[_transcoder] = 0;
+        }
     }
 
     function tryToJoinActiveSet(address _transcoder, uint256 _totalStake, uint256 _currentRound) internal {
@@ -875,6 +885,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             // Evict the least stake transcoder from the active set for the next round
             transcoderPool.remove(lastTranscoder);
             transcoders[lastTranscoder].earningsPoolPerRound[nextRound].deactivateStake();
+            lastActiveStakeUpdateRound[lastTranscoder] = 0;
             pendingNextRoundTotalActiveStake = pendingNextRoundTotalActiveStake.sub(lastStake);
 
             emit TranscoderEvicted(lastTranscoder);
@@ -883,7 +894,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         transcoderPool.insert(_transcoder, _totalStake, address(0), address(0));
         transcoders[_transcoder].earningsPoolPerRound[nextRound].activateStake(_totalStake);
         pendingNextRoundTotalActiveStake = pendingNextRoundTotalActiveStake.add(_totalStake);
-
+        lastActiveStakeUpdateRound[_transcoder] = nextRound;
         nextRoundTotalActiveStake = pendingNextRoundTotalActiveStake;
     }
 

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -31,14 +31,14 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
     // Represents a transcoder's current state
     struct Transcoder {
-        uint256 lastRewardRound;                             // Last round that the transcoder called reward
-        uint256 rewardCut;                                   // % of reward paid to transcoder by a delegator
-        uint256 feeShare;                                    // % of fees paid to delegators by transcoder
-        uint256 pricePerSegment;                             // Price per segment (denominated in LPT units) for a stream
-        uint256 pendingRewardCut;                            // Pending reward cut for next round if the transcoder is active
-        uint256 pendingFeeShare;                             // Pending fee share for next round if the transcoder is active
-        uint256 pendingPricePerSegment;                      // Pending price per segment for next round if the transcoder is active
-        mapping (uint256 => EarningsPool.Data) earningsPoolPerRound;  // Mapping of round => earnings pool for the round
+        uint256 lastRewardRound;                                        // Last round that the transcoder called reward
+        uint256 rewardCut;                                              // % of reward paid to transcoder by a delegator
+        uint256 feeShare;                                               // % of fees paid to delegators by transcoder
+        uint256 pricePerSegmentDEPRECATED;                              // DEPRECATED - DO NOT USE
+        uint256 pendingRewardCut;                                       // Pending reward cut for next round if the transcoder is active
+        uint256 pendingFeeShare;                                        // Pending fee share for next round if the transcoder is active
+        uint256 pendingPricePerSegmentDEPRECATED;                       // DEPRECATED - DO NOT USE
+        mapping (uint256 => EarningsPool.Data) earningsPoolPerRound;    // Mapping of round => earnings pool for the round
     }
 
     // The various states a transcoder can be in
@@ -168,9 +168,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * @dev The sender is declaring themselves as a candidate for active transcoding.
      * @param _rewardCut % of reward paid to transcoder by a delegator
      * @param _feeShare % of fees paid to delegators by a transcoder
-     * @param _pricePerSegment Price per segment (denominated in Wei) for a stream
      */
-    function transcoder(uint256 _rewardCut, uint256 _feeShare, uint256 _pricePerSegment)
+    function transcoder(uint256 _rewardCut, uint256 _feeShare)
         external
         whenSystemNotPaused
         currentRoundInitialized
@@ -178,88 +177,46 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         Transcoder storage t = transcoders[msg.sender];
         Delegator storage del = delegators[msg.sender];
 
-        if (roundsManager().currentRoundLocked()) {
-            // If it is the lock period of the current round
-            // the lowest price previously set by any transcoder
-            // becomes the price floor and the caller can lower its
-            // own price to a point greater than or equal to the price floor
+        // No transcoder operations can take place during the round lock period
+        require(
+            !roundsManager().currentRoundLocked(),
+            "can't update transcoder params, current round is locked"
+        );
 
-            // Caller must already be a registered transcoder
-            require(transcoderStatus(msg.sender) == TranscoderStatus.Registered);
-            // Provided rewardCut value must equal the current pendingRewardCut value
-            // This value cannot change during the lock period
-            require(_rewardCut == t.pendingRewardCut);
-            // Provided feeShare value must equal the current pendingFeeShare value
-            // This value cannot change during the lock period
-            require(_feeShare == t.pendingFeeShare);
+        // Reward cut must be a valid percentage
+        require(MathUtils.validPerc(_rewardCut));
+        // Fee share must be a valid percentage
+        require(MathUtils.validPerc(_feeShare));
 
-            // Iterate through the transcoder pool to find the price floor
-            // Since the caller must be a registered transcoder, the transcoder pool size will always at least be 1
-            // Thus, we can safely set the initial price floor to be the pendingPricePerSegment of the first
-            // transcoder in the pool
-            address currentTranscoder = transcoderPool.getFirst();
-            uint256 priceFloor = transcoders[currentTranscoder].pendingPricePerSegment;
-            for (uint256 i = 0; i < transcoderPool.getSize(); i++) {
-                if (transcoders[currentTranscoder].pendingPricePerSegment < priceFloor) {
-                    priceFloor = transcoders[currentTranscoder].pendingPricePerSegment;
-                }
+        // Must have a non-zero amount bonded to self
+        require(del.delegateAddress == msg.sender && del.bondedAmount > 0);
 
-                currentTranscoder = transcoderPool.getNext(currentTranscoder);
-            }
+        t.pendingRewardCut = _rewardCut;
+        t.pendingFeeShare = _feeShare;
 
-            // Provided pricePerSegment must be greater than or equal to the price floor and
-            // less than or equal to the previously set pricePerSegment by the caller
-            require(_pricePerSegment >= priceFloor && _pricePerSegment <= t.pendingPricePerSegment);
+        uint256 delegatedAmount = del.delegatedAmount;
 
-            t.pendingPricePerSegment = _pricePerSegment;
+        // Check if transcoder is not already registered
+        if (transcoderStatus(msg.sender) == TranscoderStatus.NotRegistered) {
+            if (!transcoderPool.isFull()) {
+                // If pool is not full add new transcoder
+                transcoderPool.insert(msg.sender, delegatedAmount, address(0), address(0));
+            } else {
+                address lastTranscoder = transcoderPool.getLast();
 
-            emit TranscoderUpdate(msg.sender, t.pendingRewardCut, t.pendingFeeShare, _pricePerSegment, true);
-        } else {
-            // It is not the lock period of the current round
-            // Caller is free to change rewardCut, feeShare, pricePerSegment as it pleases
-            // If caller is not a registered transcoder, it can also register and join the transcoder pool
-            // if it has sufficient delegated stake
-            // If caller is not a registered transcoder and does not have sufficient delegated stake
-            // to join the transcoder pool, it can change rewardCut, feeShare, pricePerSegment
-            // as information signals to delegators in an effort to camapaign and accumulate
-            // more delegated stake
-
-            // Reward cut must be a valid percentage
-            require(MathUtils.validPerc(_rewardCut));
-            // Fee share must be a valid percentage
-            require(MathUtils.validPerc(_feeShare));
-
-            // Must have a non-zero amount bonded to self
-            require(del.delegateAddress == msg.sender && del.bondedAmount > 0);
-
-            t.pendingRewardCut = _rewardCut;
-            t.pendingFeeShare = _feeShare;
-            t.pendingPricePerSegment = _pricePerSegment;
-
-            uint256 delegatedAmount = del.delegatedAmount;
-
-            // Check if transcoder is not already registered
-            if (transcoderStatus(msg.sender) == TranscoderStatus.NotRegistered) {
-                if (!transcoderPool.isFull()) {
-                    // If pool is not full add new transcoder
+                if (delegatedAmount > transcoderTotalStake(lastTranscoder)) {
+                    // If pool is full and caller has more delegated stake than the transcoder in the pool with the least delegated stake:
+                    // - Evict transcoder in pool with least delegated stake
+                    // - Add caller to pool
+                    transcoderPool.remove(lastTranscoder);
                     transcoderPool.insert(msg.sender, delegatedAmount, address(0), address(0));
-                } else {
-                    address lastTranscoder = transcoderPool.getLast();
 
-                    if (delegatedAmount > transcoderTotalStake(lastTranscoder)) {
-                        // If pool is full and caller has more delegated stake than the transcoder in the pool with the least delegated stake:
-                        // - Evict transcoder in pool with least delegated stake
-                        // - Add caller to pool
-                        transcoderPool.remove(lastTranscoder);
-                        transcoderPool.insert(msg.sender, delegatedAmount, address(0), address(0));
-
-                        emit TranscoderEvicted(lastTranscoder);
-                    }
+                    emit TranscoderEvicted(lastTranscoder);
                 }
             }
-
-            emit TranscoderUpdate(msg.sender, _rewardCut, _feeShare, _pricePerSegment, transcoderPool.contains(msg.sender));
         }
+
+        emit TranscoderUpdate(msg.sender, _rewardCut, _feeShare, transcoderPool.contains(msg.sender));
     }
 
     /**
@@ -511,13 +468,11 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             uint256 stake = transcoderTotalStake(currentTranscoder);
             uint256 rewardCut = transcoders[currentTranscoder].pendingRewardCut;
             uint256 feeShare = transcoders[currentTranscoder].pendingFeeShare;
-            uint256 pricePerSegment = transcoders[currentTranscoder].pendingPricePerSegment;
 
             Transcoder storage t = transcoders[currentTranscoder];
             // Set pending rates as current rates
             t.rewardCut = rewardCut;
             t.feeShare = feeShare;
-            t.pricePerSegment = pricePerSegment;
             // Initialize token pool
             t.earningsPoolPerRound[currentRound].init(stake, rewardCut, feeShare);
 
@@ -636,50 +591,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             }
         } else {
             emit TranscoderSlashed(_transcoder, _finder, 0, 0);
-        }
-    }
-
-    /**
-     * @dev Pseudorandomly elect a currently active transcoder that charges a price per segment less than or equal to the max price per segment for a job
-     * Returns address of elected active transcoder and its price per segment
-     * @param _maxPricePerSegment Max price (in LPT base units) per segment of a stream
-     * @param _blockHash Job creation block hash used as a pseudorandom seed for assigning an active transcoder
-     * @param _round Job creation round
-     */
-    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _blockHash, uint256 _round) external view returns (address) {
-        uint256 activeSetSize = activeTranscoderSet[_round].transcoders.length;
-        // Create array to store available transcoders charging an acceptable price per segment
-        address[] memory availableTranscoders = new address[](activeSetSize);
-        // Keep track of the actual number of available transcoders
-        uint256 numAvailableTranscoders = 0;
-        // Keep track of total stake of available transcoders
-        uint256 totalAvailableTranscoderStake = 0;
-
-        for (uint256 i = 0; i < activeSetSize; i++) {
-            address activeTranscoder = activeTranscoderSet[_round].transcoders[i];
-            // If a transcoder is active and charges an acceptable price per segment add it to the array of available transcoders
-            if (activeTranscoderSet[_round].isActive[activeTranscoder] && transcoders[activeTranscoder].pricePerSegment <= _maxPricePerSegment) {
-                availableTranscoders[numAvailableTranscoders] = activeTranscoder;
-                numAvailableTranscoders++;
-                totalAvailableTranscoderStake = totalAvailableTranscoderStake.add(activeTranscoderTotalStake(activeTranscoder, _round));
-            }
-        }
-
-        if (numAvailableTranscoders == 0) {
-            // There is no currently available transcoder that charges a price per segment less than or equal to the max price per segment for a job
-            return address(0);
-        } else {
-            // Pseudorandomly pick an available transcoder weighted by its stake relative to the total stake of all available transcoders
-            uint256 r = uint256(_blockHash) % totalAvailableTranscoderStake;
-            uint256 s = 0;
-            uint256 j = 0;
-
-            while (s <= r && j < numAvailableTranscoders) {
-                s = s.add(activeTranscoderTotalStake(availableTranscoders[j], _round));
-                j++;
-            }
-
-            return availableTranscoders[j - 1];
         }
     }
 
@@ -814,17 +725,15 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     )
         public
         view
-        returns (uint256 lastRewardRound, uint256 rewardCut, uint256 feeShare, uint256 pricePerSegment, uint256 pendingRewardCut, uint256 pendingFeeShare, uint256 pendingPricePerSegment)
+        returns (uint256 lastRewardRound, uint256 rewardCut, uint256 feeShare, uint256 pendingRewardCut, uint256 pendingFeeShare)
     {
         Transcoder storage t = transcoders[_transcoder];
 
         lastRewardRound = t.lastRewardRound;
         rewardCut = t.rewardCut;
         feeShare = t.feeShare;
-        pricePerSegment = t.pricePerSegment;
         pendingRewardCut = t.pendingRewardCut;
         pendingFeeShare = t.pendingFeeShare;
-        pendingPricePerSegment = t.pendingPricePerSegment;
     }
 
     /**

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -39,6 +39,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         uint256 pendingFeeShare;                                        // Pending fee share for next round if the transcoder is active
         uint256 pendingPricePerSegmentDEPRECATED;                       // DEPRECATED - DO NOT USE
         mapping (uint256 => EarningsPool.Data) earningsPoolPerRound;    // Mapping of round => earnings pool for the round
+        uint256 lastActiveStakeUpdateRound;                             // Round for which the stake was last updated
+        uint256 activationRound;                                         // Round in which the transcoder became active - 0 if inactive
     }
 
     // The various states a transcoder can be in
@@ -92,9 +94,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     uint256 public currentRoundTotalActiveStake;
     // The total active stake (sum of the stake of active set members) for the next round
     uint256 public nextRoundTotalActiveStake;
-
-    // Keep track of the last stake update round for a transcoder
-    mapping(address => uint256) public lastActiveStakeUpdateRound;
 
     // Check if sender is TicketBroker
     modifier onlyTicketBroker() {
@@ -169,8 +168,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         Transcoder storage t = transcoders[msg.sender];
         Delegator storage del = delegators[msg.sender];
 
-        uint256 currentRound = roundsManager().currentRound();
-
         // No transcoder operations can take place during the round lock period
         require(
             !roundsManager().currentRoundLocked(),
@@ -189,7 +186,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         t.pendingFeeShare = _feeShare;
 
         if (!transcoderPool.contains(msg.sender)) {
-            tryToJoinActiveSet(msg.sender, del.delegatedAmount, currentRound);
+            tryToJoinActiveSet(msg.sender, del.delegatedAmount, roundsManager().currentRound());
         }
 
         emit TranscoderUpdate(msg.sender, _rewardCut, _feeShare, transcoderPool.contains(msg.sender));
@@ -237,14 +234,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             // Update amount to delegate with previous delegation amount
             delegationAmount = delegationAmount.add(del.bondedAmount);
 
-            if (isRegisteredTranscoder(currentDelegate)) {
-                // Previously delegated to a transcoder
-                // Decrease old transcoder's total stake
-                decreaseTranscoderTotalStake(currentDelegate, del.bondedAmount);
-            }
-
-            // Decrease old delegate's delegated amount
-            delegators[currentDelegate].delegatedAmount = delegators[currentDelegate].delegatedAmount.sub(del.bondedAmount);
+            decreaseTranscoderTotalStake(currentDelegate, del.bondedAmount);
         }
 
         // Delegation amount must be > 0 - cannot delegate to someone without having bonded stake
@@ -254,14 +244,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         // Update bonded amount
         del.bondedAmount = del.bondedAmount.add(_amount);
         
-        if (isRegisteredTranscoder(_to)) {
-            // Delegated to a transcoder
-            // Increase transcoder's total stake
-            increaseTranscoderTotalStake(_to, delegationAmount);
-        }
-
-        // Update current delegate's delegated amount with delegation amount
-        delegators[_to].delegatedAmount = delegators[_to].delegatedAmount.add(delegationAmount);
+        increaseTotalStake(_to, delegationAmount);
 
         if (_amount > 0) {
             // Transfer the LPT to the Minter
@@ -310,10 +293,9 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             decreaseTranscoderTotalStake(currentDelegate, _amount);
         } else {
             resignTranscoder(msg.sender);
+            // Decrease delegate's delegated amount
+            delegators[currentDelegate].delegatedAmount = delegators[currentDelegate].delegatedAmount.sub(_amount);
         }   
-
-        // Decrease delegate's delegated amount
-        delegators[currentDelegate].delegatedAmount = delegators[currentDelegate].delegatedAmount.sub(_amount);
 
         // Check if delegator has a zero bonded amount
         // If so, update its delegation status
@@ -495,8 +477,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         whenSystemNotPaused
         onlyTicketBroker
     {
-        // Transcoder must be registered
-        require(isRegisteredTranscoder(_transcoder));
+        require(isRegisteredTranscoder(_transcoder), "transcoder must be registered");
 
         Transcoder storage t = transcoders[_transcoder];
 
@@ -575,7 +556,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Called during round initialization 
+     * @dev Called during round initialization to set the total active stake for the round
      */
     function setCurrentRoundTotalActiveStake() external onlyRoundsManager {
         currentRoundTotalActiveStake = nextRoundTotalActiveStake;
@@ -685,7 +666,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     )
         public
         view
-        returns (uint256 lastRewardRound, uint256 rewardCut, uint256 feeShare, uint256 pendingRewardCut, uint256 pendingFeeShare)
+        returns (uint256 lastRewardRound, uint256 rewardCut, uint256 feeShare, uint256 pendingRewardCut, uint256 pendingFeeShare, uint256 activationRound)
     {
         Transcoder storage t = transcoders[_transcoder];
 
@@ -694,6 +675,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         feeShare = t.feeShare;
         pendingRewardCut = t.pendingRewardCut;
         pendingFeeShare = t.pendingFeeShare;
+        activationRound = t.activationRound;
     }
 
     /**
@@ -809,12 +791,21 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         return totalBonded;
     }
 
+    /**
+     * @dev Return the round for which a transcoder's stake was last updated
+     * @param _transcoder Transcoder address
+     */
+    function lastActiveStakeUpdateRound(address _transcoder) public view returns (uint256) {
+        return transcoders[_transcoder].lastActiveStakeUpdateRound;
+    }
+
    /**
      * @dev Return whether a transcoder is active for the current round
      * @param _transcoder Transcoder address
      */
     function isActiveTranscoder(address _transcoder) public view returns (bool) {
-        return lastActiveStakeUpdateRound[_transcoder] != 0 && lastActiveStakeUpdateRound[_transcoder] <= roundsManager().currentRound();
+        uint256 activationRound = transcoders[_transcoder].activationRound;
+        return activationRound != 0 && activationRound <= roundsManager().currentRound();
     }
 
     /**
@@ -822,7 +813,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * @param _transcoder Transcoder address
      */
     function isRegisteredTranscoder(address _transcoder) public view returns (bool) {
-        return delegators[_transcoder].delegateAddress == _transcoder && delegatorStatus(_transcoder) == DelegatorStatus.Bonded;
+        Delegator storage d = delegators[_transcoder];
+        return d.delegateAddress == _transcoder && d.bondedAmount > 0;
     }
 
     /**
@@ -835,37 +827,43 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         return delegators[_delegator].unbondingLocks[_unbondingLockId].withdrawRound > 0;
     }
 
-    function increaseTranscoderTotalStake(address _transcoder, uint256 _amount) internal {
-        uint256 newStake = transcoderTotalStake(_transcoder).add(_amount);
-        uint256 currentRound = roundsManager().currentRound();
-        uint256 nextRound = currentRound.add(1);
+    function increaseTotalStake(address _transcoder, uint256 _amount) internal {
+        if (isRegisteredTranscoder(_transcoder)) {
+            uint256 newStake = transcoderTotalStake(_transcoder).add(_amount);
+            uint256 currentRound = roundsManager().currentRound();
+            uint256 nextRound = currentRound.add(1);
 
-        // If the transcoder is already in the active set update its stake and return
-        if (transcoderPool.contains(_transcoder)) {
-            transcoderPool.updateKey(_transcoder, newStake, address(0), address(0));
-            nextRoundTotalActiveStake = nextRoundTotalActiveStake.add(_amount);
-            lastActiveStakeUpdateRound[_transcoder] = nextRound;
-        } else {
-            // Check if the transcoder is eligible to join the active set in the update round
-            tryToJoinActiveSet(_transcoder, newStake, currentRound);
+            // If the transcoder is already in the active set update its stake and return
+            if (transcoderPool.contains(_transcoder)) {
+                transcoderPool.updateKey(_transcoder, newStake, address(0), address(0));
+                nextRoundTotalActiveStake = nextRoundTotalActiveStake.add(_amount);
+                transcoders[_transcoder].lastActiveStakeUpdateRound = nextRound;
+            } else {
+                // Check if the transcoder is eligible to join the active set in the update round
+                tryToJoinActiveSet(_transcoder, newStake, currentRound);
+            }
         }
+
+        // Increase delegate's delegated amount
+        delegators[_transcoder].delegatedAmount = delegators[_transcoder].delegatedAmount.add(_amount);
     }
 
     function decreaseTranscoderTotalStake(address _transcoder, uint256 _amount) internal {
-        if (!transcoderPool.contains(_transcoder)) {
-            return;
+        if (isRegisteredTranscoder(_transcoder)) {
+            if (!transcoderPool.contains(_transcoder)) {
+                return;
+            }
+
+            uint256 newStake = transcoderTotalStake(_transcoder).sub(_amount);
+            uint256 nextRound = roundsManager().currentRound().add(1);
+
+            transcoderPool.updateKey(_transcoder, newStake, address(0), address(0));
+            nextRoundTotalActiveStake = nextRoundTotalActiveStake.sub(_amount);
+            transcoders[_transcoder].lastActiveStakeUpdateRound = nextRound;
         }
 
-        uint256 newStake = transcoderTotalStake(_transcoder).sub(_amount);
-        uint256 nextRound = roundsManager().currentRound().add(1);
-
-        transcoderPool.updateKey(_transcoder, newStake, address(0), address(0));
-        nextRoundTotalActiveStake = nextRoundTotalActiveStake.sub(_amount);
-        if (transcoderPool.contains(_transcoder)) {
-            lastActiveStakeUpdateRound[_transcoder] = nextRound;
-        } else {
-            lastActiveStakeUpdateRound[_transcoder] = 0;
-        }
+        // Decrease old delegate's delegated amount
+        delegators[_transcoder].delegatedAmount = delegators[_transcoder].delegatedAmount.sub(_amount);
     }
 
     function tryToJoinActiveSet(address _transcoder, uint256 _totalStake, uint256 _currentRound) internal {
@@ -885,7 +883,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             // Evict the least stake transcoder from the active set for the next round
             transcoderPool.remove(lastTranscoder);
             transcoders[lastTranscoder].earningsPoolPerRound[nextRound].deactivateStake();
-            lastActiveStakeUpdateRound[lastTranscoder] = 0;
+            transcoders[lastTranscoder].activationRound = 0;
             pendingNextRoundTotalActiveStake = pendingNextRoundTotalActiveStake.sub(lastStake);
 
             emit TranscoderEvicted(lastTranscoder);
@@ -894,7 +892,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         transcoderPool.insert(_transcoder, _totalStake, address(0), address(0));
         transcoders[_transcoder].earningsPoolPerRound[nextRound].activateStake(_totalStake);
         pendingNextRoundTotalActiveStake = pendingNextRoundTotalActiveStake.add(_totalStake);
-        lastActiveStakeUpdateRound[_transcoder] = nextRound;
+        transcoders[_transcoder].lastActiveStakeUpdateRound = nextRound;
+        transcoders[_transcoder].activationRound = nextRound;
         nextRoundTotalActiveStake = pendingNextRoundTotalActiveStake;
     }
 
@@ -903,10 +902,12 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      */
     function resignTranscoder(address _transcoder) internal {
         uint256 transcoderStake = transcoderTotalStake(_transcoder);
-        decreaseTranscoderTotalStake(_transcoder, transcoderStake);
         uint256 currentRound = roundsManager().currentRound();
+        transcoderPool.remove(_transcoder);
         transcoders[_transcoder].earningsPoolPerRound[currentRound].deactivateStake();
         currentRoundTotalActiveStake = currentRoundTotalActiveStake.sub(transcoderStake);
+        nextRoundTotalActiveStake = nextRoundTotalActiveStake.sub(transcoderStake);
+        transcoders[_transcoder].activationRound = 0;
         emit TranscoderResigned(_transcoder);
     }
 
@@ -987,17 +988,11 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         uint256 amount = lock.amount;
         // Increase delegator's bonded amount
         del.bondedAmount = del.bondedAmount.add(amount);
-        // Increase delegate's delegated amount
-        delegators[del.delegateAddress].delegatedAmount = delegators[del.delegateAddress].delegatedAmount.add(amount);
 
         // Delete lock
         delete del.unbondingLocks[_unbondingLockId];
 
-        if (isRegisteredTranscoder(del.delegateAddress)) {
-            // If delegate is a registered transcoder increase its delegated stake in registered pool
-            increaseTranscoderTotalStake(del.delegateAddress, amount);
-        }
-
+        increaseTotalStake(del.delegateAddress, amount);
 
         emit Rebond(del.delegateAddress, _delegator, _unbondingLockId, amount);
     }

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -28,7 +28,8 @@ contract IBondingManager {
     function setActiveTranscoders() external;
     function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external;
     function slashTranscoder(address _transcoder, address _finder, uint256 _slashAmount, uint256 _finderFee) external;
-
+    function setCurrentRoundTotalActiveStake() external;
+    
     // Public functions
     function getTranscoderPoolSize() public view returns (uint256);
     function transcoderTotalStake(address _transcoder) public view returns (uint256);

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.4.25;
  * TODO: switch to interface type
  */
 contract IBondingManager {
-    event TranscoderUpdate(address indexed transcoder, uint256 pendingRewardCut, uint256 pendingFeeShare, uint256 pendingPricePerSegment, bool registered);
+    event TranscoderUpdate(address indexed transcoder, uint256 pendingRewardCut, uint256 pendingFeeShare, bool registered);
     event TranscoderEvicted(address indexed transcoder);
     event TranscoderResigned(address indexed transcoder);
     event TranscoderSlashed(address indexed transcoder, address finder, uint256 penalty, uint256 finderReward);
@@ -28,7 +28,6 @@ contract IBondingManager {
     function setActiveTranscoders() external;
     function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external;
     function slashTranscoder(address _transcoder, address _finder, uint256 _slashAmount, uint256 _finderFee) external;
-    function electActiveTranscoder(uint256 _maxPricePerSegment, bytes32 _blockHash, uint256 _round) external view returns (address);
 
     // Public functions
     function getTranscoderPoolSize() public view returns (uint256);

--- a/contracts/bonding/libraries/EarningsPool.sol
+++ b/contracts/bonding/libraries/EarningsPool.sol
@@ -27,7 +27,6 @@ library EarningsPool {
         uint256 transcoderRewardPool;      // Transcoder rewards. If `hasTranscoderRewardFeePool` is false, this should always be 0
         uint256 transcoderFeePool;         // Transcoder fees. If `hasTranscoderRewardFeePool` is false, this should always be 0
         bool hasTranscoderRewardFeePool;   // Flag to indicate if the earnings pool has separate transcoder reward and fee pools
-        bool active;
     }
 
     /**
@@ -59,13 +58,11 @@ library EarningsPool {
     function activateStake(EarningsPool.Data storage earningsPool, uint256 _stake) internal {
         earningsPool.totalStake = _stake;
         earningsPool.claimableStake = _stake;
-        earningsPool.active = true;
     }
 
     function deactivateStake(EarningsPool.Data storage earningsPool) internal {
         earningsPool.totalStake = 0;
         earningsPool.claimableStake = 0;
-        earningsPool.active = false;
     }
 
     /** 

--- a/contracts/bonding/libraries/EarningsPool.sol
+++ b/contracts/bonding/libraries/EarningsPool.sol
@@ -27,6 +27,7 @@ library EarningsPool {
         uint256 transcoderRewardPool;      // Transcoder rewards. If `hasTranscoderRewardFeePool` is false, this should always be 0
         uint256 transcoderFeePool;         // Transcoder fees. If `hasTranscoderRewardFeePool` is false, this should always be 0
         bool hasTranscoderRewardFeePool;   // Flag to indicate if the earnings pool has separate transcoder reward and fee pools
+        bool active;
     }
 
     /**
@@ -53,6 +54,18 @@ library EarningsPool {
      */
     function hasClaimableShares(EarningsPool.Data storage earningsPool) internal view returns (bool) {
         return earningsPool.claimableStake > 0;
+    }
+
+    function activateStake(EarningsPool.Data storage earningsPool, uint256 _stake) internal {
+        earningsPool.totalStake = _stake;
+        earningsPool.claimableStake = _stake;
+        earningsPool.active = true;
+    }
+
+    function deactivateStake(EarningsPool.Data storage earningsPool) internal {
+        earningsPool.totalStake = 0;
+        earningsPool.claimableStake = 0;
+        earningsPool.active = false;
     }
 
     /** 

--- a/contracts/rounds/RoundsManager.sol
+++ b/contracts/rounds/RoundsManager.sol
@@ -93,7 +93,7 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
         _blockHashForRound[currRound] = roundBlockHash;
         // Set active transcoders for the round
         bondingManager().setActiveTranscoders();
-        // set total active stake for the round
+        // Set total active stake for the round
         bondingManager().setCurrentRoundTotalActiveStake();
         // Set mintable rewards for the round
         minter().setCurrentRewardTokens();

--- a/contracts/rounds/RoundsManager.sol
+++ b/contracts/rounds/RoundsManager.sol
@@ -93,6 +93,8 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
         _blockHashForRound[currRound] = roundBlockHash;
         // Set active transcoders for the round
         bondingManager().setActiveTranscoders();
+        // set total active stake for the round
+        bondingManager().setCurrentRoundTotalActiveStake();
         // Set mintable rewards for the round
         minter().setCurrentRewardTokens();
 

--- a/migrations/3_deploy_contracts.js
+++ b/migrations/3_deploy_contracts.js
@@ -55,7 +55,6 @@ module.exports = function(deployer, network) {
 
         // Set BondingManager parameters
         await bondingManager.setUnbondingPeriod(config.bondingManager.unbondingPeriod)
-        await bondingManager.setNumTranscoders(config.bondingManager.numTranscoders)
         await bondingManager.setNumActiveTranscoders(config.bondingManager.numActiveTranscoders)
         await bondingManager.setMaxEarningsClaimsRounds(config.bondingManager.maxEarningsClaimsRounds)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "dev": true,
       "requires": {
-        "xtend": "4.0.1"
+        "xtend": "~4.0.0"
       }
     },
     "accepts": {
@@ -31,7 +31,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.21",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       },
       "dependencies": {
@@ -47,7 +47,7 @@
           "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
           "dev": true,
           "requires": {
-            "mime-db": "1.37.0"
+            "mime-db": "~1.37.0"
           }
         }
       }
@@ -64,10 +64,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "amdefine": {
@@ -95,8 +95,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "aproba": {
@@ -111,8 +111,8 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -121,7 +121,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -130,7 +130,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -163,9 +163,9 @@
       "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert-plus": {
@@ -186,7 +186,7 @@
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.14.0"
       }
     },
     "async-each": {
@@ -196,10 +196,11 @@
       "dev": true
     },
     "async-eventemitter": {
-      "version": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+      "version": "0.2.3",
+      "resolved": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
       "dev": true,
       "requires": {
-        "async": "2.6.0"
+        "async": "^2.4.0"
       }
     },
     "async-limiter": {
@@ -232,9 +233,9 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
         "babel-runtime": {
@@ -243,8 +244,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.1",
-            "regenerator-runtime": "0.11.0"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           },
           "dependencies": {
             "regenerator-runtime": {
@@ -275,30 +276,30 @@
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.24.1",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+        "babel-plugin-transform-es2015-object-super": "^6.24.1",
+        "babel-plugin-transform-es2015-parameters": "^6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+        "babel-plugin-transform-regenerator": "^6.24.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -319,9 +320,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-helper-call-delegate": {
@@ -330,10 +331,10 @@
           "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
           "dev": true,
           "requires": {
-            "babel-helper-hoist-variables": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-define-map": {
@@ -342,10 +343,10 @@
           "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.4"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-helper-function-name": {
@@ -354,11 +355,11 @@
           "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
           "dev": true,
           "requires": {
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-get-function-arity": {
@@ -367,8 +368,8 @@
           "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-hoist-variables": {
@@ -377,8 +378,8 @@
           "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-optimise-call-expression": {
@@ -387,8 +388,8 @@
           "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-regex": {
@@ -397,9 +398,9 @@
           "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-helper-replace-supers": {
@@ -408,12 +409,12 @@
           "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
           "dev": true,
           "requires": {
-            "babel-helper-optimise-call-expression": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-messages": {
@@ -422,7 +423,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-check-es2015-constants": {
@@ -431,7 +432,7 @@
           "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-arrow-functions": {
@@ -440,7 +441,7 @@
           "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -449,7 +450,7 @@
           "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-block-scoping": {
@@ -458,11 +459,11 @@
           "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-plugin-transform-es2015-classes": {
@@ -471,15 +472,15 @@
           "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
           "dev": true,
           "requires": {
-            "babel-helper-define-map": "6.26.0",
-            "babel-helper-function-name": "6.24.1",
-            "babel-helper-optimise-call-expression": "6.24.1",
-            "babel-helper-replace-supers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-define-map": "^6.24.1",
+            "babel-helper-function-name": "^6.24.1",
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-computed-properties": {
@@ -488,8 +489,8 @@
           "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-destructuring": {
@@ -498,7 +499,7 @@
           "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
@@ -507,8 +508,8 @@
           "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-for-of": {
@@ -517,7 +518,7 @@
           "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-function-name": {
@@ -526,9 +527,9 @@
           "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-literals": {
@@ -537,7 +538,7 @@
           "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-modules-amd": {
@@ -546,9 +547,9 @@
           "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
           "dev": true,
           "requires": {
-            "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
@@ -557,10 +558,10 @@
           "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
           "dev": true,
           "requires": {
-            "babel-plugin-transform-strict-mode": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-plugin-transform-strict-mode": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-types": "^6.26.0"
           }
         },
         "babel-plugin-transform-es2015-modules-systemjs": {
@@ -569,9 +570,9 @@
           "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
           "dev": true,
           "requires": {
-            "babel-helper-hoist-variables": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-modules-umd": {
@@ -580,9 +581,9 @@
           "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
           "dev": true,
           "requires": {
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-object-super": {
@@ -591,8 +592,8 @@
           "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
           "dev": true,
           "requires": {
-            "babel-helper-replace-supers": "6.24.1",
-            "babel-runtime": "6.26.0"
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-parameters": {
@@ -601,12 +602,12 @@
           "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
           "dev": true,
           "requires": {
-            "babel-helper-call-delegate": "6.24.1",
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-call-delegate": "^6.24.1",
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
@@ -615,8 +616,8 @@
           "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-spread": {
@@ -625,7 +626,7 @@
           "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-sticky-regex": {
@@ -634,9 +635,9 @@
           "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
           "dev": true,
           "requires": {
-            "babel-helper-regex": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-template-literals": {
@@ -645,7 +646,7 @@
           "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
@@ -654,7 +655,7 @@
           "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-unicode-regex": {
@@ -663,9 +664,9 @@
           "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
           "dev": true,
           "requires": {
-            "babel-helper-regex": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "regexpu-core": "2.0.0"
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "regexpu-core": "^2.0.0"
           }
         },
         "babel-plugin-transform-regenerator": {
@@ -674,7 +675,7 @@
           "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
           "dev": true,
           "requires": {
-            "regenerator-transform": "0.10.1"
+            "regenerator-transform": "^0.10.0"
           }
         },
         "babel-plugin-transform-strict-mode": {
@@ -683,8 +684,8 @@
           "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-runtime": {
@@ -693,8 +694,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.1",
-            "regenerator-runtime": "0.11.0"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           }
         },
         "babel-template": {
@@ -703,11 +704,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -716,15 +717,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -733,10 +734,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -751,11 +752,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "core-js": {
@@ -797,7 +798,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "invariant": {
@@ -806,7 +807,7 @@
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "js-tokens": {
@@ -833,7 +834,7 @@
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "ms": {
@@ -866,9 +867,9 @@
           "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "private": "0.1.7"
+            "babel-runtime": "^6.18.0",
+            "babel-types": "^6.19.0",
+            "private": "^0.1.6"
           }
         },
         "regexpu-core": {
@@ -877,9 +878,9 @@
           "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
           "dev": true,
           "requires": {
-            "regenerate": "1.3.3",
-            "regjsgen": "0.2.0",
-            "regjsparser": "0.1.5"
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
           }
         },
         "regjsgen": {
@@ -894,7 +895,7 @@
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "dev": true,
           "requires": {
-            "jsesc": "0.5.0"
+            "jsesc": "~0.5.0"
           }
         },
         "strip-ansi": {
@@ -903,7 +904,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -926,10 +927,10 @@
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-decorators": "6.24.1",
-        "babel-preset-stage-3": "6.24.1"
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-decorators": "^6.24.1",
+        "babel-preset-stage-3": "^6.24.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -950,9 +951,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-helper-bindify-decorators": {
@@ -961,9 +962,9 @@
           "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-explode-class": {
@@ -972,10 +973,10 @@
           "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
           "dev": true,
           "requires": {
-            "babel-helper-bindify-decorators": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-bindify-decorators": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-function-name": {
@@ -984,11 +985,11 @@
           "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
           "dev": true,
           "requires": {
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-get-function-arity": {
@@ -997,8 +998,8 @@
           "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-messages": {
@@ -1007,7 +1008,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-syntax-class-properties": {
@@ -1034,10 +1035,10 @@
           "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-plugin-syntax-class-properties": "6.13.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-plugin-syntax-class-properties": "^6.8.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-decorators": {
@@ -1046,11 +1047,11 @@
           "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
           "dev": true,
           "requires": {
-            "babel-helper-explode-class": "6.24.1",
-            "babel-plugin-syntax-decorators": "6.13.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-explode-class": "^6.24.1",
+            "babel-plugin-syntax-decorators": "^6.13.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-runtime": {
@@ -1059,8 +1060,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.1",
-            "regenerator-runtime": "0.11.0"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           }
         },
         "babel-template": {
@@ -1069,11 +1070,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -1082,15 +1083,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -1099,10 +1100,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -1117,11 +1118,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "core-js": {
@@ -1163,7 +1164,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "invariant": {
@@ -1172,7 +1173,7 @@
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "js-tokens": {
@@ -1193,7 +1194,7 @@
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "ms": {
@@ -1214,7 +1215,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -1237,11 +1238,11 @@
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-generator-functions": "6.24.1",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-object-rest-spread": "6.26.0"
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-generator-functions": "^6.24.1",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+        "babel-plugin-transform-object-rest-spread": "^6.22.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1262,9 +1263,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -1273,9 +1274,9 @@
           "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
           "dev": true,
           "requires": {
-            "babel-helper-explode-assignable-expression": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-explode-assignable-expression": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-explode-assignable-expression": {
@@ -1284,9 +1285,9 @@
           "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-function-name": {
@@ -1295,11 +1296,11 @@
           "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
           "dev": true,
           "requires": {
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-get-function-arity": {
@@ -1308,8 +1309,8 @@
           "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-remap-async-to-generator": {
@@ -1318,11 +1319,11 @@
           "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-messages": {
@@ -1331,7 +1332,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-syntax-async-functions": {
@@ -1370,9 +1371,9 @@
           "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
           "dev": true,
           "requires": {
-            "babel-helper-remap-async-to-generator": "6.24.1",
-            "babel-plugin-syntax-async-generators": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-helper-remap-async-to-generator": "^6.24.1",
+            "babel-plugin-syntax-async-generators": "^6.5.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-async-to-generator": {
@@ -1381,9 +1382,9 @@
           "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
           "dev": true,
           "requires": {
-            "babel-helper-remap-async-to-generator": "6.24.1",
-            "babel-plugin-syntax-async-functions": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-helper-remap-async-to-generator": "^6.24.1",
+            "babel-plugin-syntax-async-functions": "^6.8.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-exponentiation-operator": {
@@ -1392,9 +1393,9 @@
           "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
           "dev": true,
           "requires": {
-            "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-            "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+            "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-object-rest-spread": {
@@ -1403,8 +1404,8 @@
           "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
           "dev": true,
           "requires": {
-            "babel-plugin-syntax-object-rest-spread": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+            "babel-runtime": "^6.26.0"
           }
         },
         "babel-runtime": {
@@ -1413,8 +1414,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.1",
-            "regenerator-runtime": "0.11.0"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           }
         },
         "babel-template": {
@@ -1423,11 +1424,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -1436,15 +1437,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -1453,10 +1454,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -1471,11 +1472,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "core-js": {
@@ -1517,7 +1518,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "invariant": {
@@ -1526,7 +1527,7 @@
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "js-tokens": {
@@ -1547,7 +1548,7 @@
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "ms": {
@@ -1568,7 +1569,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -1591,13 +1592,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1618,9 +1619,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-core": {
@@ -1629,25 +1630,25 @@
           "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.0",
-            "babel-helpers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "convert-source-map": "1.5.0",
-            "debug": "2.6.9",
-            "json5": "0.5.1",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.7",
-            "slash": "1.0.0",
-            "source-map": "0.5.7"
+            "babel-code-frame": "^6.26.0",
+            "babel-generator": "^6.26.0",
+            "babel-helpers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "convert-source-map": "^1.5.0",
+            "debug": "^2.6.8",
+            "json5": "^0.5.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4",
+            "path-is-absolute": "^1.0.1",
+            "private": "^0.1.7",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.6"
           }
         },
         "babel-generator": {
@@ -1656,14 +1657,14 @@
           "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
           "dev": true,
           "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.6",
+            "trim-right": "^1.0.1"
           }
         },
         "babel-helpers": {
@@ -1672,8 +1673,8 @@
           "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-messages": {
@@ -1682,7 +1683,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-runtime": {
@@ -1691,8 +1692,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.1",
-            "regenerator-runtime": "0.11.0"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           }
         },
         "babel-template": {
@@ -1701,11 +1702,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -1714,15 +1715,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -1731,10 +1732,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -1755,7 +1756,7 @@
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -1765,11 +1766,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "concat-map": {
@@ -1805,7 +1806,7 @@
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "escape-string-regexp": {
@@ -1832,7 +1833,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "home-or-tmp": {
@@ -1841,8 +1842,8 @@
           "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.1"
           }
         },
         "invariant": {
@@ -1851,7 +1852,7 @@
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "is-finite": {
@@ -1860,7 +1861,7 @@
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "js-tokens": {
@@ -1893,7 +1894,7 @@
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "minimatch": {
@@ -1902,7 +1903,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "ms": {
@@ -1953,7 +1954,7 @@
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "slash": {
@@ -1974,7 +1975,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "^0.5.6"
           }
         },
         "strip-ansi": {
@@ -1983,7 +1984,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -2031,7 +2032,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bignumber.js": {
@@ -2058,7 +2059,7 @@
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "block-stream": {
@@ -2067,7 +2068,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "bluebird": {
@@ -2089,15 +2090,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.16"
       },
       "dependencies": {
         "iconv-lite": {
@@ -2106,7 +2107,7 @@
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "qs": {
@@ -2123,7 +2124,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "brace-expansion": {
@@ -2132,7 +2133,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -2142,9 +2143,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "brorand": {
@@ -2165,12 +2166,12 @@
       "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -2179,9 +2180,9 @@
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.1.1",
-        "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -2190,9 +2191,9 @@
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-rsa": {
@@ -2201,8 +2202,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sha3": {
@@ -2211,7 +2212,7 @@
       "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
       "dev": true,
       "requires": {
-        "js-sha3": "0.3.1"
+        "js-sha3": "^0.3.1"
       }
     },
     "browserify-sign": {
@@ -2220,13 +2221,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.0"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "bs58": {
@@ -2235,7 +2236,7 @@
       "integrity": "sha1-1MJjiL9IBMrHFBQbGUWqR+XrJI4=",
       "dev": true,
       "requires": {
-        "base-x": "1.1.0"
+        "base-x": "^1.1.0"
       }
     },
     "bs58check": {
@@ -2244,8 +2245,8 @@
       "integrity": "sha1-xSVABzdJEXcU+gQsMEfrj5FRy/g=",
       "dev": true,
       "requires": {
-        "bs58": "3.1.0",
-        "create-hash": "1.1.3"
+        "bs58": "^3.1.0",
+        "create-hash": "^1.1.0"
       }
     },
     "buffer-crc32": {
@@ -2296,12 +2297,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "check-error": {
@@ -2316,7 +2317,7 @@
       "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
       "dev": true,
       "requires": {
-        "functional-red-black-tree": "1.0.1"
+        "functional-red-black-tree": "^1.0.1"
       }
     },
     "chokidar": {
@@ -2325,15 +2326,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "chownr": {
@@ -2348,8 +2349,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "cliui": {
@@ -2358,9 +2359,9 @@
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2375,7 +2376,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -2404,8 +2405,8 @@
       "integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
       "dev": true,
       "requires": {
-        "bs58": "2.0.1",
-        "create-hash": "1.1.3"
+        "bs58": "^2.0.1",
+        "create-hash": "^1.1.1"
       },
       "dependencies": {
         "bs58": {
@@ -2428,7 +2429,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "command-exists": {
@@ -2497,8 +2498,8 @@
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "vary": "1.1.2"
+        "object-assign": "^4",
+        "vary": "^1"
       }
     },
     "coveralls": {
@@ -2507,12 +2508,12 @@
       "integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
       "dev": true,
       "requires": {
-        "growl": "1.10.5",
-        "js-yaml": "3.12.0",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.7",
-        "minimist": "1.2.0",
-        "request": "2.88.0"
+        "growl": "~> 1.10.0",
+        "js-yaml": "^3.11.0",
+        "lcov-parse": "^0.0.10",
+        "log-driver": "^1.2.7",
+        "minimist": "^1.2.0",
+        "request": "^2.85.0"
       },
       "dependencies": {
         "aws4": {
@@ -2533,9 +2534,9 @@
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
+            "asynckit": "^0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "2.1.20"
+            "mime-types": "^2.1.12"
           }
         },
         "growl": {
@@ -2550,8 +2551,8 @@
           "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
           "dev": true,
           "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
+            "ajv": "^5.3.0",
+            "har-schema": "^2.0.0"
           }
         },
         "js-yaml": {
@@ -2560,8 +2561,8 @@
           "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "log-driver": {
@@ -2582,7 +2583,7 @@
           "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
           "dev": true,
           "requires": {
-            "mime-db": "1.36.0"
+            "mime-db": "~1.36.0"
           }
         },
         "oauth-sign": {
@@ -2603,26 +2604,26 @@
           "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.8.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.2",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.1.0",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.20",
-            "oauth-sign": "0.9.0",
-            "performance-now": "2.1.0",
-            "qs": "6.5.2",
-            "safe-buffer": "5.1.2",
-            "tough-cookie": "2.4.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.3.2"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
           }
         },
         "safe-buffer": {
@@ -2637,8 +2638,8 @@
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "dev": true,
           "requires": {
-            "psl": "1.1.29",
-            "punycode": "1.4.1"
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
           }
         },
         "uuid": {
@@ -2655,8 +2656,8 @@
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -2665,10 +2666,10 @@
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.9"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -2677,22 +2678,23 @@
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.9"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cross-spawn": {
-      "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-        "shebang-command": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -2701,7 +2703,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -2710,7 +2712,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -2721,17 +2723,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.0",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.0",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "diffie-hellman": "5.0.2",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.14",
-        "public-encrypt": "4.0.0",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.3"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "crypto-js": {
@@ -2746,7 +2748,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "death": {
@@ -2782,14 +2784,14 @@
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "decompress-tarbz2": "4.1.1",
-        "decompress-targz": "4.1.1",
-        "decompress-unzip": "4.0.1",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.3.0",
-        "pify": "2.3.0",
-        "strip-dirs": "2.1.0"
+        "decompress-tar": "^4.0.0",
+        "decompress-tarbz2": "^4.0.0",
+        "decompress-targz": "^4.0.0",
+        "decompress-unzip": "^4.0.1",
+        "graceful-fs": "^4.1.10",
+        "make-dir": "^1.0.0",
+        "pify": "^2.3.0",
+        "strip-dirs": "^2.0.0"
       }
     },
     "decompress-response": {
@@ -2798,7 +2800,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "decompress-tar": {
@@ -2807,9 +2809,9 @@
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "dev": true,
       "requires": {
-        "file-type": "5.2.0",
-        "is-stream": "1.1.0",
-        "tar-stream": "1.5.5"
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0",
+        "tar-stream": "^1.5.2"
       },
       "dependencies": {
         "is-stream": {
@@ -2826,11 +2828,11 @@
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "file-type": "6.2.0",
-        "is-stream": "1.1.0",
-        "seek-bzip": "1.0.5",
-        "unbzip2-stream": "1.3.1"
+        "decompress-tar": "^4.1.0",
+        "file-type": "^6.1.0",
+        "is-stream": "^1.1.0",
+        "seek-bzip": "^1.0.5",
+        "unbzip2-stream": "^1.0.9"
       },
       "dependencies": {
         "file-type": {
@@ -2853,9 +2855,9 @@
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "file-type": "5.2.0",
-        "is-stream": "1.1.0"
+        "decompress-tar": "^4.1.1",
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0"
       },
       "dependencies": {
         "is-stream": {
@@ -2872,10 +2874,10 @@
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "dev": true,
       "requires": {
-        "file-type": "3.9.0",
-        "get-stream": "2.3.1",
-        "pify": "2.3.0",
-        "yauzl": "2.10.0"
+        "file-type": "^3.8.0",
+        "get-stream": "^2.2.0",
+        "pify": "^2.3.0",
+        "yauzl": "^2.4.2"
       },
       "dependencies": {
         "file-type": {
@@ -2890,8 +2892,8 @@
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -2902,7 +2904,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-equal": {
@@ -2929,7 +2931,7 @@
       "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "dev": true,
       "requires": {
-        "abstract-leveldown": "2.6.3"
+        "abstract-leveldown": "~2.6.0"
       }
     },
     "define-properties": {
@@ -2938,8 +2940,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "defined": {
@@ -2972,8 +2974,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -3000,9 +3002,9 @@
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "dom-walk": {
@@ -3017,9 +3019,9 @@
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.1.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6"
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
       }
     },
     "duplexer3": {
@@ -3035,7 +3037,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ee-first": {
@@ -3050,13 +3052,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "encodeurl": {
@@ -3071,7 +3073,7 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.19"
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -3080,7 +3082,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "eol": {
@@ -3095,7 +3097,7 @@
       "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
       "dev": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -3104,7 +3106,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -3113,11 +3115,11 @@
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -3126,9 +3128,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "escape-html": {
@@ -3149,11 +3151,11 @@
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
       },
       "dependencies": {
         "esprima": {
@@ -3175,7 +3177,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -3186,43 +3188,43 @@
       "integrity": "sha1-/29fUZOEiifum2J74+c/ucteZi4=",
       "dev": true,
       "requires": {
-        "ajv": "5.2.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.1.0",
-        "concat-stream": "1.6.0",
-        "cross-spawn": "5.1.0",
-        "debug": "3.0.1",
-        "doctrine": "2.0.0",
-        "eslint-scope": "3.7.1",
-        "espree": "3.5.1",
-        "esquery": "1.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.5",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.4.1",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.1",
-        "text-table": "0.2.0"
+        "ajv": "^5.2.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.0.1",
+        "doctrine": "^2.0.0",
+        "eslint-scope": "^3.7.1",
+        "espree": "^3.5.1",
+        "esquery": "^1.0.0",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^9.17.0",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^4.0.1",
+        "text-table": "~0.2.0"
       },
       "dependencies": {
         "acorn": {
@@ -3237,7 +3239,7 @@
           "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
           "dev": true,
           "requires": {
-            "acorn": "3.3.0"
+            "acorn": "^3.0.4"
           },
           "dependencies": {
             "acorn": {
@@ -3254,10 +3256,10 @@
           "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "json-schema-traverse": "^0.3.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ajv-keywords": {
@@ -3290,7 +3292,7 @@
           "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
           "dev": true,
           "requires": {
-            "sprintf-js": "1.0.3"
+            "sprintf-js": "~1.0.2"
           }
         },
         "array-union": {
@@ -3299,7 +3301,7 @@
           "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
           "dev": true,
           "requires": {
-            "array-uniq": "1.0.3"
+            "array-uniq": "^1.0.1"
           }
         },
         "array-uniq": {
@@ -3320,9 +3322,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           },
           "dependencies": {
             "chalk": {
@@ -3331,11 +3333,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             },
             "strip-ansi": {
@@ -3344,7 +3346,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             }
           }
@@ -3361,7 +3363,7 @@
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -3371,7 +3373,7 @@
           "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
           "dev": true,
           "requires": {
-            "callsites": "0.2.0"
+            "callsites": "^0.2.0"
           }
         },
         "callsites": {
@@ -3386,9 +3388,9 @@
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -3397,7 +3399,7 @@
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
               "dev": true,
               "requires": {
-                "color-convert": "1.9.0"
+                "color-convert": "^1.9.0"
               }
             },
             "supports-color": {
@@ -3406,7 +3408,7 @@
               "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
               "dev": true,
               "requires": {
-                "has-flag": "2.0.0"
+                "has-flag": "^2.0.0"
               }
             }
           }
@@ -3423,7 +3425,7 @@
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "cli-width": {
@@ -3444,7 +3446,7 @@
           "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
           "dev": true,
           "requires": {
-            "color-name": "1.1.3"
+            "color-name": "^1.1.1"
           }
         },
         "color-name": {
@@ -3465,9 +3467,9 @@
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "core-util-is": {
@@ -3482,9 +3484,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "debug": {
@@ -3508,13 +3510,13 @@
           "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
           "dev": true,
           "requires": {
-            "globby": "5.0.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.0",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "rimraf": "2.6.2"
+            "globby": "^5.0.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "doctrine": {
@@ -3523,8 +3525,8 @@
           "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         },
         "escape-string-regexp": {
@@ -3539,8 +3541,8 @@
           "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
           "dev": true,
           "requires": {
-            "esrecurse": "4.2.0",
-            "estraverse": "4.2.0"
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
           }
         },
         "espree": {
@@ -3549,8 +3551,8 @@
           "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
           "dev": true,
           "requires": {
-            "acorn": "5.1.2",
-            "acorn-jsx": "3.0.1"
+            "acorn": "^5.1.1",
+            "acorn-jsx": "^3.0.0"
           }
         },
         "esquery": {
@@ -3559,7 +3561,7 @@
           "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
           "dev": true,
           "requires": {
-            "estraverse": "4.2.0"
+            "estraverse": "^4.0.0"
           }
         },
         "esrecurse": {
@@ -3568,8 +3570,8 @@
           "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
           "dev": true,
           "requires": {
-            "estraverse": "4.2.0",
-            "object-assign": "4.1.1"
+            "estraverse": "^4.1.0",
+            "object-assign": "^4.0.1"
           }
         },
         "esutils": {
@@ -3584,9 +3586,9 @@
           "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
           "dev": true,
           "requires": {
-            "iconv-lite": "0.4.19",
-            "jschardet": "1.5.1",
-            "tmp": "0.0.33"
+            "iconv-lite": "^0.4.17",
+            "jschardet": "^1.4.2",
+            "tmp": "^0.0.33"
           }
         },
         "fast-deep-equal": {
@@ -3607,7 +3609,7 @@
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "file-entry-cache": {
@@ -3616,8 +3618,8 @@
           "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
           "dev": true,
           "requires": {
-            "flat-cache": "1.2.2",
-            "object-assign": "4.1.1"
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
           }
         },
         "flat-cache": {
@@ -3626,10 +3628,10 @@
           "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
           "dev": true,
           "requires": {
-            "circular-json": "0.3.3",
-            "del": "2.2.2",
-            "graceful-fs": "4.1.11",
-            "write": "0.2.1"
+            "circular-json": "^0.3.1",
+            "del": "^2.0.2",
+            "graceful-fs": "^4.1.2",
+            "write": "^0.2.1"
           }
         },
         "fs.realpath": {
@@ -3650,12 +3652,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globals": {
@@ -3670,12 +3672,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "graceful-fs": {
@@ -3690,7 +3692,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "iconv-lite": {
@@ -3717,8 +3719,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -3733,20 +3735,20 @@
           "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.0.0",
-            "chalk": "2.1.0",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.0.5",
-            "figures": "2.0.0",
-            "lodash": "4.17.4",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx-lite": "4.0.8",
-            "rx-lite-aggregates": "4.0.8",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           }
         },
         "is-fullwidth-code-point": {
@@ -3767,7 +3769,7 @@
           "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
           "dev": true,
           "requires": {
-            "is-path-inside": "1.0.0"
+            "is-path-inside": "^1.0.0"
           }
         },
         "is-path-inside": {
@@ -3776,7 +3778,7 @@
           "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
           "dev": true,
           "requires": {
-            "path-is-inside": "1.0.2"
+            "path-is-inside": "^1.0.1"
           }
         },
         "is-resolvable": {
@@ -3785,7 +3787,7 @@
           "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
           "dev": true,
           "requires": {
-            "tryit": "1.0.3"
+            "tryit": "^1.0.1"
           }
         },
         "isarray": {
@@ -3812,8 +3814,8 @@
           "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "jschardet": {
@@ -3834,7 +3836,7 @@
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "jsonify": {
@@ -3849,8 +3851,8 @@
           "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
           "dev": true,
           "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
           }
         },
         "lodash": {
@@ -3865,8 +3867,8 @@
           "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "mimic-fn": {
@@ -3881,7 +3883,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "ms": {
@@ -3914,7 +3916,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "onetime": {
@@ -3923,7 +3925,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "optionator": {
@@ -3932,12 +3934,12 @@
           "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
           "dev": true,
           "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
           }
         },
         "os-tmpdir": {
@@ -3976,7 +3978,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "pluralize": {
@@ -4015,13 +4017,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "require-uncached": {
@@ -4030,8 +4032,8 @@
           "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
           "dev": true,
           "requires": {
-            "caller-path": "0.1.0",
-            "resolve-from": "1.0.1"
+            "caller-path": "^0.1.0",
+            "resolve-from": "^1.0.0"
           }
         },
         "resolve-from": {
@@ -4046,8 +4048,8 @@
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "rimraf": {
@@ -4056,7 +4058,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "run-async": {
@@ -4065,7 +4067,7 @@
           "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
           "dev": true,
           "requires": {
-            "is-promise": "2.1.0"
+            "is-promise": "^2.1.0"
           }
         },
         "rx-lite": {
@@ -4080,7 +4082,7 @@
           "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
           "dev": true,
           "requires": {
-            "rx-lite": "4.0.8"
+            "rx-lite": "*"
           }
         },
         "safe-buffer": {
@@ -4101,7 +4103,7 @@
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
-            "shebang-regex": "1.0.0"
+            "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
@@ -4128,8 +4130,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "string_decoder": {
@@ -4138,7 +4140,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -4147,7 +4149,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -4176,12 +4178,12 @@
           "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
           "dev": true,
           "requires": {
-            "ajv": "4.11.8",
-            "ajv-keywords": "1.5.1",
-            "chalk": "1.1.3",
-            "lodash": "4.17.4",
+            "ajv": "^4.7.0",
+            "ajv-keywords": "^1.0.0",
+            "chalk": "^1.1.1",
+            "lodash": "^4.0.0",
             "slice-ansi": "0.0.4",
-            "string-width": "2.1.1"
+            "string-width": "^2.0.0"
           },
           "dependencies": {
             "ajv": {
@@ -4190,8 +4192,8 @@
               "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
               "dev": true,
               "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
+                "co": "^4.6.0",
+                "json-stable-stringify": "^1.0.1"
               }
             },
             "chalk": {
@@ -4200,11 +4202,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             },
             "strip-ansi": {
@@ -4213,7 +4215,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             }
           }
@@ -4236,7 +4238,7 @@
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2"
+            "os-tmpdir": "~1.0.2"
           }
         },
         "tryit": {
@@ -4251,7 +4253,7 @@
           "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
           "dev": true,
           "requires": {
-            "prelude-ls": "1.1.2"
+            "prelude-ls": "~1.1.2"
           }
         },
         "typedarray": {
@@ -4272,7 +4274,7 @@
           "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "wordwrap": {
@@ -4293,7 +4295,7 @@
           "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
           "dev": true,
           "requires": {
-            "mkdirp": "0.5.1"
+            "mkdirp": "^0.5.1"
           }
         },
         "yallist": {
@@ -4340,8 +4342,8 @@
       "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
       "dev": true,
       "requires": {
-        "idna-uts46-hx": "2.3.1",
-        "js-sha3": "0.5.7"
+        "idna-uts46-hx": "^2.3.1",
+        "js-sha3": "^0.5.7"
       },
       "dependencies": {
         "js-sha3": {
@@ -4358,13 +4360,13 @@
       "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0",
-        "keccakjs": "0.2.1",
-        "nano-json-stream-parser": "0.1.2",
-        "servify": "0.1.12",
-        "ws": "3.3.3",
-        "xhr-request-promise": "0.1.2"
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "keccakjs": "^0.2.1",
+        "nano-json-stream-parser": "^0.1.2",
+        "servify": "^0.1.12",
+        "ws": "^3.0.0",
+        "xhr-request-promise": "^0.1.2"
       }
     },
     "ethereum-common": {
@@ -4375,10 +4377,11 @@
     },
     "ethereumjs-abi": {
       "version": "github:ethereumjs/ethereumjs-abi#09c3c48fd3bed143df7fa8f36f6f164205e23796",
+      "from": "ethereumjs-abi@github:ethereumjs/ethereumjs-abi#09c3c48fd3bed143df7fa8f36f6f164205e23796",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "ethereumjs-util": "5.1.2"
+        "bn.js": "^4.10.0",
+        "ethereumjs-util": "^5.0.0"
       }
     },
     "ethereumjs-account": {
@@ -4387,8 +4390,8 @@
       "integrity": "sha1-+MMCMby3B/RRTYoFLB+doQNiTUc=",
       "dev": true,
       "requires": {
-        "ethereumjs-util": "4.5.0",
-        "rlp": "2.0.0"
+        "ethereumjs-util": "^4.0.1",
+        "rlp": "^2.0.0"
       },
       "dependencies": {
         "ethereumjs-util": {
@@ -4397,11 +4400,11 @@
           "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "create-hash": "1.1.3",
-            "keccakjs": "0.2.1",
-            "rlp": "2.0.0",
-            "secp256k1": "3.5.0"
+            "bn.js": "^4.8.0",
+            "create-hash": "^1.1.2",
+            "keccakjs": "^0.2.0",
+            "rlp": "^2.0.0",
+            "secp256k1": "^3.0.1"
           }
         }
       }
@@ -4412,11 +4415,11 @@
       "integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
+        "async": "^2.0.1",
         "ethereum-common": "0.2.0",
-        "ethereumjs-tx": "1.3.3",
-        "ethereumjs-util": "5.1.2",
-        "merkle-patricia-tree": "2.3.0"
+        "ethereumjs-tx": "^1.2.2",
+        "ethereumjs-util": "^5.0.0",
+        "merkle-patricia-tree": "^2.1.2"
       },
       "dependencies": {
         "ethereum-common": {
@@ -4433,7 +4436,7 @@
       "integrity": "sha512-iv2qiGBFgk9mn5Nq2enX8dG5WQ7Lk+FCqpnxfPfH4Ns8KLPwttmNOy264nh3SXDJJvcQwz/XnlLteDQVILotbg==",
       "dev": true,
       "requires": {
-        "source-map-support": "0.5.3"
+        "source-map-support": "^0.5.3"
       }
     },
     "ethereumjs-tx": {
@@ -4442,8 +4445,8 @@
       "integrity": "sha1-7OBR0+/b53GtKlGNYWMsoqt17Ls=",
       "dev": true,
       "requires": {
-        "ethereum-common": "0.0.18",
-        "ethereumjs-util": "5.1.2"
+        "ethereum-common": "^0.0.18",
+        "ethereumjs-util": "^5.0.0"
       }
     },
     "ethereumjs-util": {
@@ -4452,14 +4455,14 @@
       "integrity": "sha1-JboCFcu0wvCxCKb5avKi5i5Fkh8=",
       "dev": true,
       "requires": {
-        "babel-preset-es2015": "6.24.1",
-        "babelify": "7.3.0",
-        "bn.js": "4.11.8",
-        "create-hash": "1.1.3",
-        "ethjs-util": "0.1.4",
-        "keccak": "1.3.0",
-        "rlp": "2.0.0",
-        "secp256k1": "3.3.0"
+        "babel-preset-es2015": "^6.24.0",
+        "babelify": "^7.3.0",
+        "bn.js": "^4.8.0",
+        "create-hash": "^1.1.2",
+        "ethjs-util": "^0.1.3",
+        "keccak": "^1.0.2",
+        "rlp": "^2.0.0",
+        "secp256k1": "^3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4486,8 +4489,8 @@
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.3"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "babel-code-frame": {
@@ -4496,9 +4499,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-core": {
@@ -4507,25 +4510,25 @@
           "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.0",
-            "babel-helpers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "convert-source-map": "1.5.0",
-            "debug": "2.6.9",
-            "json5": "0.5.1",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.7",
-            "slash": "1.0.0",
-            "source-map": "0.5.7"
+            "babel-code-frame": "^6.26.0",
+            "babel-generator": "^6.26.0",
+            "babel-helpers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "convert-source-map": "^1.5.0",
+            "debug": "^2.6.8",
+            "json5": "^0.5.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4",
+            "path-is-absolute": "^1.0.1",
+            "private": "^0.1.7",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.6"
           }
         },
         "babel-generator": {
@@ -4534,14 +4537,14 @@
           "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
           "dev": true,
           "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.6",
+            "trim-right": "^1.0.1"
           }
         },
         "babel-helpers": {
@@ -4550,8 +4553,8 @@
           "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-messages": {
@@ -4560,7 +4563,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-runtime": {
@@ -4569,8 +4572,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.1",
-            "regenerator-runtime": "0.11.0"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           }
         },
         "babel-template": {
@@ -4579,11 +4582,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -4592,15 +4595,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -4609,10 +4612,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babelify": {
@@ -4621,8 +4624,8 @@
           "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
           "dev": true,
           "requires": {
-            "babel-core": "6.26.0",
-            "object-assign": "4.1.1"
+            "babel-core": "^6.0.14",
+            "object-assign": "^4.0.0"
           }
         },
         "babylon": {
@@ -4649,7 +4652,7 @@
           "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "bl": {
@@ -4658,7 +4661,7 @@
           "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3"
+            "readable-stream": "^2.0.5"
           }
         },
         "bn.js": {
@@ -4673,7 +4676,7 @@
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -4689,12 +4692,12 @@
           "integrity": "sha512-WYCMOT/PtGTlpOKFht0YJFYcPy6pLCR98CtWfzK13zoynLlBMvAdEMSRGmgnJCw2M2j/5qxBkinZQFobieM8dQ==",
           "dev": true,
           "requires": {
-            "buffer-xor": "1.0.3",
-            "cipher-base": "1.0.4",
-            "create-hash": "1.1.3",
-            "evp_bytestokey": "1.0.3",
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "buffer-xor": {
@@ -4709,11 +4712,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "chownr": {
@@ -4728,8 +4731,8 @@
           "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "code-point-at": {
@@ -4774,10 +4777,10 @@
           "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
           "dev": true,
           "requires": {
-            "cipher-base": "1.0.4",
-            "inherits": "2.0.3",
-            "ripemd160": "2.0.1",
-            "sha.js": "2.4.8"
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "sha.js": "^2.4.0"
           }
         },
         "create-hmac": {
@@ -4786,12 +4789,12 @@
           "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
           "dev": true,
           "requires": {
-            "cipher-base": "1.0.4",
-            "create-hash": "1.1.3",
-            "inherits": "2.0.3",
-            "ripemd160": "2.0.1",
-            "safe-buffer": "5.1.1",
-            "sha.js": "2.4.8"
+            "cipher-base": "^1.0.3",
+            "create-hash": "^1.1.0",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
           }
         },
         "debug": {
@@ -4821,7 +4824,7 @@
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "drbg.js": {
@@ -4830,9 +4833,9 @@
           "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
           "dev": true,
           "requires": {
-            "browserify-aes": "1.0.8",
-            "create-hash": "1.1.3",
-            "create-hmac": "1.1.6"
+            "browserify-aes": "^1.0.6",
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4"
           }
         },
         "elliptic": {
@@ -4841,13 +4844,13 @@
           "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "brorand": "1.1.0",
-            "hash.js": "1.1.3",
-            "hmac-drbg": "1.0.1",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0",
-            "minimalistic-crypto-utils": "1.0.1"
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
           }
         },
         "end-of-stream": {
@@ -4856,7 +4859,7 @@
           "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
           "dev": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           }
         },
         "escape-string-regexp": {
@@ -4887,8 +4890,8 @@
           "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
           "dev": true,
           "requires": {
-            "md5.js": "1.3.4",
-            "safe-buffer": "5.1.1"
+            "md5.js": "^1.3.4",
+            "safe-buffer": "^5.1.1"
           }
         },
         "expand-template": {
@@ -4903,14 +4906,14 @@
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "github-from-package": {
@@ -4931,7 +4934,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-unicode": {
@@ -4946,7 +4949,7 @@
           "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "^2.0.1"
           }
         },
         "hash.js": {
@@ -4955,8 +4958,8 @@
           "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0"
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "hmac-drbg": {
@@ -4965,9 +4968,9 @@
           "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "dev": true,
           "requires": {
-            "hash.js": "1.1.3",
-            "minimalistic-assert": "1.0.0",
-            "minimalistic-crypto-utils": "1.0.1"
+            "hash.js": "^1.0.3",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.1"
           }
         },
         "inherits": {
@@ -4988,7 +4991,7 @@
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "is-finite": {
@@ -4997,7 +5000,7 @@
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -5006,7 +5009,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-hex-prefixed": {
@@ -5045,11 +5048,11 @@
           "integrity": "sha512-JgsKPxYhcJxKrV+TrCyg/GwZbOjhpRPrz2kG8xbAsUaIDelUlKjm08YcwBO9Fm8sqf/Kg8ZWkk6nWujhLykfvw==",
           "dev": true,
           "requires": {
-            "bindings": "1.3.0",
-            "inherits": "2.0.3",
-            "nan": "2.7.0",
-            "prebuild-install": "2.2.2",
-            "safe-buffer": "5.1.1"
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "prebuild-install": "^2.0.0",
+            "safe-buffer": "^5.1.0"
           }
         },
         "lodash": {
@@ -5064,7 +5067,7 @@
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "minimalistic-assert": {
@@ -5085,7 +5088,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -5124,10 +5127,10 @@
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -5148,7 +5151,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -5169,19 +5172,19 @@
           "integrity": "sha512-F46pcvDxtQhbV3B+dm+exHuKxIyJK26fVNiJRmbTW/5D7o0Z2yzc8CKeu7UWbo9XxQZoVOC88aKgySAsza+cWw==",
           "dev": true,
           "requires": {
-            "expand-template": "1.1.0",
+            "expand-template": "^1.0.2",
             "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "node-abi": "2.1.1",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "1.0.2",
-            "rc": "1.2.1",
-            "simple-get": "1.4.3",
-            "tar-fs": "1.15.3",
-            "tunnel-agent": "0.6.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "node-abi": "^2.0.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "os-homedir": "^1.0.1",
+            "pump": "^1.0.1",
+            "rc": "^1.1.6",
+            "simple-get": "^1.4.2",
+            "tar-fs": "^1.13.0",
+            "tunnel-agent": "^0.6.0",
             "xtend": "4.0.1"
           }
         },
@@ -5203,8 +5206,8 @@
           "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "rc": {
@@ -5213,10 +5216,10 @@
           "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           }
         },
         "readable-stream": {
@@ -5225,13 +5228,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "regenerator-runtime": {
@@ -5246,7 +5249,7 @@
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "ripemd160": {
@@ -5255,8 +5258,8 @@
           "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
           "dev": true,
           "requires": {
-            "hash-base": "2.0.2",
-            "inherits": "2.0.3"
+            "hash-base": "^2.0.0",
+            "inherits": "^2.0.1"
           }
         },
         "rlp": {
@@ -5277,15 +5280,15 @@
           "integrity": "sha512-CbrQoeGG5V0kQ1ohEMGI+J7oKerapLTpivLICBaXR0R4HyQcN3kM9itLsV5fdpV1UR1bD14tOkJ1xughmlDIiQ==",
           "dev": true,
           "requires": {
-            "bindings": "1.3.0",
-            "bip66": "1.1.5",
-            "bn.js": "4.11.8",
-            "create-hash": "1.1.3",
-            "drbg.js": "1.0.1",
-            "elliptic": "6.4.0",
-            "nan": "2.7.0",
-            "prebuild-install": "2.2.2",
-            "safe-buffer": "5.1.1"
+            "bindings": "^1.2.1",
+            "bip66": "^1.1.3",
+            "bn.js": "^4.11.3",
+            "create-hash": "^1.1.2",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.2.3",
+            "nan": "^2.2.1",
+            "prebuild-install": "^2.0.0",
+            "safe-buffer": "^5.1.0"
           }
         },
         "set-blocking": {
@@ -5300,7 +5303,7 @@
           "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "^2.0.1"
           }
         },
         "signal-exit": {
@@ -5315,9 +5318,9 @@
           "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "unzip-response": "1.0.2",
-            "xtend": "4.0.1"
+            "once": "^1.3.1",
+            "unzip-response": "^1.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "slash": {
@@ -5338,9 +5341,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -5349,7 +5352,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -5358,7 +5361,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-hex-prefix": {
@@ -5388,10 +5391,10 @@
           "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
           "dev": true,
           "requires": {
-            "chownr": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pump": "1.0.2",
-            "tar-stream": "1.5.4"
+            "chownr": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pump": "^1.0.0",
+            "tar-stream": "^1.1.2"
           }
         },
         "tar-stream": {
@@ -5400,10 +5403,10 @@
           "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
           "dev": true,
           "requires": {
-            "bl": "1.2.1",
-            "end-of-stream": "1.4.0",
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "bl": "^1.0.0",
+            "end-of-stream": "^1.0.0",
+            "readable-stream": "^2.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "to-fast-properties": {
@@ -5424,7 +5427,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "unzip-response": {
@@ -5445,7 +5448,7 @@
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -5468,17 +5471,17 @@
       "integrity": "sha512-yIWJqTEcrF9vJTCvNMxacRkAx6zIZTOW0SmSA+hSFiU1x8JyVZDi9o5udwsRVECT5RkPgQzm62kpL6Pf4qemsw==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+        "async": "^2.1.2",
+        "async-eventemitter": "^0.2.2",
         "ethereum-common": "0.2.0",
-        "ethereumjs-account": "2.0.4",
-        "ethereumjs-block": "1.7.0",
-        "ethereumjs-util": "5.1.4",
-        "fake-merkle-patricia-tree": "1.0.1",
-        "functional-red-black-tree": "1.0.1",
-        "merkle-patricia-tree": "2.3.0",
-        "rustbn.js": "0.1.2",
-        "safe-buffer": "5.1.1"
+        "ethereumjs-account": "^2.0.3",
+        "ethereumjs-block": "~1.7.0",
+        "ethereumjs-util": "^5.1.3",
+        "fake-merkle-patricia-tree": "^1.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "merkle-patricia-tree": "^2.1.2",
+        "rustbn.js": "~0.1.1",
+        "safe-buffer": "^5.1.1"
       },
       "dependencies": {
         "ethereum-common": {
@@ -5493,13 +5496,13 @@
           "integrity": "sha512-wbeTc5prEzIWFSQUcEsCAZbqubtJKy6yS+oZMY1cGG6GLYzLjm4YhC2RNrWIg8hRYnclWpnZmx2zkiufQkmd3w==",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "create-hash": "1.1.3",
-            "ethjs-util": "0.1.4",
-            "keccak": "1.4.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "secp256k1": "3.5.0"
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
           }
         }
       }
@@ -5510,13 +5513,13 @@
       "integrity": "sha1-gnY7Fpfuenlr5xVdqd+0my+Yz9s=",
       "dev": true,
       "requires": {
-        "aes-js": "0.2.4",
-        "bs58check": "1.3.4",
-        "ethereumjs-util": "4.5.0",
-        "hdkey": "0.7.1",
-        "scrypt.js": "0.2.0",
-        "utf8": "2.1.2",
-        "uuid": "2.0.3"
+        "aes-js": "^0.2.3",
+        "bs58check": "^1.0.8",
+        "ethereumjs-util": "^4.4.0",
+        "hdkey": "^0.7.0",
+        "scrypt.js": "^0.2.0",
+        "utf8": "^2.1.1",
+        "uuid": "^2.0.1"
       },
       "dependencies": {
         "ethereumjs-util": {
@@ -5525,11 +5528,11 @@
           "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "create-hash": "1.1.3",
-            "keccakjs": "0.2.1",
-            "rlp": "2.0.0",
-            "secp256k1": "3.5.0"
+            "bn.js": "^4.8.0",
+            "create-hash": "^1.1.2",
+            "keccakjs": "^0.2.0",
+            "rlp": "^2.0.0",
+            "secp256k1": "^3.0.1"
           }
         }
       }
@@ -5540,9 +5543,9 @@
       "integrity": "sha512-SoYhktEbLxf+fiux5SfCEwdzWENMvgIbMZD90I62s4GZD9nEjgEWy8ZboI3hck193Vs0bDoTohDISx84f2H2tw==",
       "dev": true,
       "requires": {
-        "@types/node": "10.12.9",
+        "@types/node": "^10.3.2",
         "aes-js": "3.0.0",
-        "bn.js": "4.11.8",
+        "bn.js": "^4.4.0",
         "elliptic": "6.3.3",
         "hash.js": "1.1.3",
         "js-sha3": "0.5.7",
@@ -5630,8 +5633,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "execa": {
@@ -5640,13 +5643,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-        "get-stream": "3.0.0",
-        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "expand-brackets": {
@@ -5655,7 +5658,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -5664,7 +5667,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "expand-template": {
@@ -5679,36 +5682,36 @@
       "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
       "dev": true,
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.3",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.4",
+        "proxy-addr": "~2.0.4",
         "qs": "6.5.2",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.2",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0",
-        "type-is": "1.6.16",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "qs": {
@@ -5743,7 +5746,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extsprintf": {
@@ -5758,7 +5761,7 @@
       "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
       "dev": true,
       "requires": {
-        "checkpoint-store": "1.1.0"
+        "checkpoint-store": "^1.1.0"
       }
     },
     "fast-deep-equal": {
@@ -5785,7 +5788,7 @@
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "file-type": {
@@ -5806,11 +5809,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "finalhandler": {
@@ -5820,12 +5823,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.4.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "statuses": {
@@ -5842,7 +5845,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "for-each": {
@@ -5851,7 +5854,7 @@
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
       "dev": true,
       "requires": {
-        "is-function": "1.0.1"
+        "is-function": "~1.0.0"
       }
     },
     "for-in": {
@@ -5866,7 +5869,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -5887,9 +5890,9 @@
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -5910,11 +5913,11 @@
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "fs-promise": {
@@ -5923,10 +5926,10 @@
       "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
       "dev": true,
       "requires": {
-        "any-promise": "1.3.0",
-        "fs-extra": "2.1.2",
-        "mz": "2.7.0",
-        "thenify-all": "1.6.0"
+        "any-promise": "^1.3.0",
+        "fs-extra": "^2.0.0",
+        "mz": "^2.6.0",
+        "thenify-all": "^1.6.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -5935,8 +5938,8 @@
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0"
           }
         }
       }
@@ -5954,8 +5957,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -5970,8 +5973,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
@@ -5991,8 +5994,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "asn1": {
@@ -6036,7 +6039,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "block-stream": {
@@ -6044,7 +6047,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "~2.0.0"
           }
         },
         "boom": {
@@ -6052,7 +6055,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "brace-expansion": {
@@ -6060,7 +6063,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
@@ -6091,7 +6094,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
@@ -6114,7 +6117,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "dashdash": {
@@ -6123,7 +6126,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -6172,7 +6175,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "extend": {
@@ -6198,9 +6201,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
@@ -6213,10 +6216,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "fstream-ignore": {
@@ -6225,9 +6228,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
           }
         },
         "gauge": {
@@ -6236,14 +6239,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "getpass": {
@@ -6252,7 +6255,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -6268,12 +6271,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -6293,8 +6296,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "has-unicode": {
@@ -6308,10 +6311,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -6325,9 +6328,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "inflight": {
@@ -6335,8 +6338,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -6355,7 +6358,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -6381,7 +6384,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "jsbn": {
@@ -6402,7 +6405,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -6447,7 +6450,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
@@ -6455,7 +6458,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -6483,17 +6486,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.2",
+            "detect-libc": "^1.0.2",
             "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
             "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^2.2.1",
+            "tar-pack": "^3.4.0"
           }
         },
         "nopt": {
@@ -6502,8 +6505,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npmlog": {
@@ -6512,10 +6515,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -6540,7 +6543,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -6561,8 +6564,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -6599,10 +6602,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -6618,13 +6621,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "request": {
@@ -6633,28 +6636,28 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "rimraf": {
@@ -6662,7 +6665,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -6693,7 +6696,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "sshpk": {
@@ -6702,15 +6705,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -6726,9 +6729,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -6736,7 +6739,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "stringstream": {
@@ -6750,7 +6753,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -6764,9 +6767,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "tar-pack": {
@@ -6775,14 +6778,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "debug": "^2.2.0",
+            "fstream": "^1.0.10",
+            "fstream-ignore": "^1.0.5",
+            "once": "^1.3.3",
+            "readable-stream": "^2.1.4",
+            "rimraf": "^2.5.1",
+            "tar": "^2.2.1",
+            "uid-number": "^0.0.6"
           }
         },
         "tough-cookie": {
@@ -6791,7 +6794,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -6800,7 +6803,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -6841,7 +6844,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -6857,10 +6860,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "function-bind": {
@@ -6881,7 +6884,7 @@
       "integrity": "sha512-yXzteu4SIgUL31mnpm9j+x6dpHUw0p/nsRVkcySKq0w+1vDxH9jMErP1QhZAJuTVE6ni4nfvGSNkaQx5cD3jfg==",
       "dev": true,
       "requires": {
-        "source-map-support": "0.5.3"
+        "source-map-support": "^0.5.3"
       }
     },
     "gauge": {
@@ -6890,14 +6893,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       },
       "dependencies": {
         "signal-exit": {
@@ -6912,9 +6915,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -6943,7 +6946,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "github-from-package": {
@@ -6958,12 +6961,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       },
       "dependencies": {
         "balanced-match": {
@@ -6978,7 +6981,7 @@
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -7000,7 +7003,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "path-is-absolute": {
@@ -7017,8 +7020,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -7027,7 +7030,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "global": {
@@ -7036,8 +7039,8 @@
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "dev": true,
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       },
       "dependencies": {
         "process": {
@@ -7054,20 +7057,20 @@
       "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
       "dev": true,
       "requires": {
-        "decompress-response": "3.3.0",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-plain-obj": "1.1.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "isurl": "1.0.0",
-        "lowercase-keys": "1.0.1",
-        "p-cancelable": "0.3.0",
-        "p-timeout": "1.2.1",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "url-parse-lax": "1.0.0",
-        "url-to-options": "1.0.1"
+        "decompress-response": "^3.2.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "p-cancelable": "^0.3.0",
+        "p-timeout": "^1.1.1",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "url-parse-lax": "^1.0.0",
+        "url-to-options": "^1.0.1"
       },
       "dependencies": {
         "is-stream": {
@@ -7096,10 +7099,10 @@
       "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "optimist": "0.6.1",
-        "source-map": "0.6.1",
-        "uglify-js": "3.4.9"
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
       },
       "dependencies": {
         "commander": {
@@ -7122,8 +7125,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "commander": "2.17.1",
-            "source-map": "0.6.1"
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1"
           }
         }
       }
@@ -7140,8 +7143,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -7150,7 +7153,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-flag": {
@@ -7171,7 +7174,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "1.4.2"
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "has-unicode": {
@@ -7186,7 +7189,7 @@
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "hash.js": {
@@ -7195,8 +7198,8 @@
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hawk": {
@@ -7205,10 +7208,10 @@
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "hdkey": {
@@ -7217,8 +7220,8 @@
       "integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
       "dev": true,
       "requires": {
-        "coinstring": "2.3.0",
-        "secp256k1": "3.5.0"
+        "coinstring": "^2.0.0",
+        "secp256k1": "^3.0.1"
       }
     },
     "he": {
@@ -7233,9 +7236,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoek": {
@@ -7256,10 +7259,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-https": {
@@ -7274,9 +7277,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -7320,8 +7323,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -7366,7 +7369,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -7381,7 +7384,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -7408,7 +7411,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -7429,7 +7432,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-function": {
@@ -7444,7 +7447,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-hex-prefixed": {
@@ -7465,7 +7468,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-object": {
@@ -7504,7 +7507,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-retry-allowed": {
@@ -7514,7 +7517,8 @@
       "dev": true
     },
     "is-stream": {
-      "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
@@ -7543,7 +7547,8 @@
       "dev": true
     },
     "isexe": {
-      "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
@@ -7562,8 +7567,8 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "dev": true,
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -7578,20 +7583,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.12",
-        "js-yaml": "3.12.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.1",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "async": {
@@ -7612,11 +7617,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -7643,7 +7648,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "which": {
@@ -7652,7 +7657,7 @@
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "wordwrap": {
@@ -7669,8 +7674,8 @@
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "requires": {
-        "has-to-string-tag-x": "1.4.1",
-        "is-object": "1.0.1"
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
       }
     },
     "js-sha3": {
@@ -7691,8 +7696,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -7726,7 +7731,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsprim": {
@@ -7747,10 +7752,10 @@
       "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
       "dev": true,
       "requires": {
-        "bindings": "1.3.0",
-        "inherits": "2.0.3",
-        "nan": "2.8.0",
-        "safe-buffer": "5.1.1"
+        "bindings": "^1.2.1",
+        "inherits": "^2.0.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
       }
     },
     "keccakjs": {
@@ -7759,8 +7764,8 @@
       "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
       "dev": true,
       "requires": {
-        "browserify-sha3": "0.0.1",
-        "sha3": "1.2.0"
+        "browserify-sha3": "^0.0.1",
+        "sha3": "^1.1.0"
       }
     },
     "keythereum": {
@@ -7781,10 +7786,10 @@
           "integrity": "sha1-tTYY/HlhtkL25z8VRu7DMp9+/+A=",
           "dev": true,
           "requires": {
-            "bindings": "1.3.0",
-            "inherits": "2.0.3",
-            "nan": "2.8.0",
-            "prebuild-install": "2.5.1"
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "prebuild-install": "^2.0.0"
           }
         },
         "secp256k1": {
@@ -7793,14 +7798,14 @@
           "integrity": "sha1-Dd5bJ+UCFmX23/ynssPgEMbBPJM=",
           "dev": true,
           "requires": {
-            "bindings": "1.3.0",
-            "bip66": "1.1.5",
-            "bn.js": "4.11.8",
-            "create-hash": "1.1.3",
-            "drbg.js": "1.0.1",
-            "elliptic": "6.4.0",
-            "nan": "2.8.0",
-            "prebuild-install": "2.5.1"
+            "bindings": "^1.2.1",
+            "bip66": "^1.1.3",
+            "bn.js": "^4.11.3",
+            "create-hash": "^1.1.2",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.2.3",
+            "nan": "^2.2.1",
+            "prebuild-install": "^2.0.0"
           }
         },
         "uuid": {
@@ -7817,7 +7822,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "klaw": {
@@ -7826,7 +7831,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "lcid": {
@@ -7835,7 +7840,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "lcov-parse": {
@@ -7856,7 +7861,7 @@
       "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "dev": true,
       "requires": {
-        "errno": "0.1.6"
+        "errno": "~0.1.1"
       }
     },
     "level-iterator-stream": {
@@ -7865,10 +7870,10 @@
       "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "level-errors": "1.0.5",
-        "readable-stream": "1.1.14",
-        "xtend": "4.0.1"
+        "inherits": "^2.0.1",
+        "level-errors": "^1.0.3",
+        "readable-stream": "^1.0.33",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -7883,10 +7888,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -7903,8 +7908,8 @@
       "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34",
-        "xtend": "2.1.2"
+        "readable-stream": "~1.0.15",
+        "xtend": "~2.1.1"
       },
       "dependencies": {
         "isarray": {
@@ -7925,10 +7930,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -7943,7 +7948,7 @@
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "dev": true,
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -7954,13 +7959,13 @@
       "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "dev": true,
       "requires": {
-        "deferred-leveldown": "1.2.2",
-        "level-codec": "7.0.1",
-        "level-errors": "1.0.5",
-        "level-iterator-stream": "1.3.1",
-        "prr": "1.0.1",
-        "semver": "5.4.1",
-        "xtend": "4.0.1"
+        "deferred-leveldown": "~1.2.1",
+        "level-codec": "~7.0.0",
+        "level-errors": "~1.0.3",
+        "level-iterator-stream": "~1.3.0",
+        "prr": "~1.0.1",
+        "semver": "~5.4.1",
+        "xtend": "~4.0.0"
       },
       "dependencies": {
         "semver": {
@@ -7977,8 +7982,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "locate-path": {
@@ -7987,8 +7992,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -8018,12 +8023,13 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
       "dev": true,
       "requires": {
-        "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-        "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "ltgt": {
@@ -8038,7 +8044,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -8055,8 +8061,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       },
       "dependencies": {
         "hash-base": {
@@ -8065,8 +8071,8 @@
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "inherits": {
@@ -8095,7 +8101,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz"
+        "mimic-fn": "^1.0.0"
       }
     },
     "memdown": {
@@ -8104,12 +8110,12 @@
       "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
       "dev": true,
       "requires": {
-        "abstract-leveldown": "2.7.2",
-        "functional-red-black-tree": "1.0.1",
-        "immediate": "3.2.3",
-        "inherits": "2.0.3",
-        "ltgt": "2.2.0",
-        "safe-buffer": "5.1.1"
+        "abstract-leveldown": "~2.7.1",
+        "functional-red-black-tree": "^1.0.1",
+        "immediate": "^3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.2.0",
+        "safe-buffer": "~5.1.1"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -8118,7 +8124,7 @@
           "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
           "dev": true,
           "requires": {
-            "xtend": "4.0.1"
+            "xtend": "~4.0.0"
           }
         }
       }
@@ -8141,14 +8147,14 @@
       "integrity": "sha512-LKd2OoIT9Re/OG38zXbd5pyHIk2IfcOUczCwkYXl5iJIbufg9nqpweh66VfPwMkUlrEvc7YVvtQdmSrB9V9TkQ==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "ethereumjs-util": "5.1.2",
+        "async": "^1.4.2",
+        "ethereumjs-util": "^5.0.0",
         "level-ws": "0.0.0",
-        "levelup": "1.3.9",
-        "memdown": "1.4.1",
-        "readable-stream": "2.3.3",
-        "rlp": "2.0.0",
-        "semaphore": "1.1.0"
+        "levelup": "^1.2.1",
+        "memdown": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "rlp": "^2.0.0",
+        "semaphore": ">=1.0.1"
       },
       "dependencies": {
         "async": {
@@ -8171,19 +8177,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "miller-rabin": {
@@ -8192,8 +8198,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -8214,11 +8220,12 @@
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
     },
     "mimic-fn": {
-      "version": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
       "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
       "dev": true
     },
@@ -8234,7 +8241,7 @@
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "dev": true,
       "requires": {
-        "dom-walk": "0.1.1"
+        "dom-walk": "^0.1.0"
       }
     },
     "minimalistic-assert": {
@@ -8255,7 +8262,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -8287,7 +8294,7 @@
       "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "*"
       }
     },
     "mocha": {
@@ -8361,9 +8368,9 @@
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "requires": {
-        "any-promise": "1.3.0",
-        "object-assign": "4.1.1",
-        "thenify-all": "1.6.0"
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
       }
     },
     "nan": {
@@ -8390,7 +8397,7 @@
       "integrity": "sha512-zwm6vU3SsVgw3e9fu48JBaRBCJGIvAgysDsqtf5+vEexFE71bEOtaMWb5zr/zODZNzTPtQlqUUpC79k68Hspow==",
       "dev": true,
       "requires": {
-        "semver": "5.5.0"
+        "semver": "^5.4.1"
       }
     },
     "node-fetch": {
@@ -8399,8 +8406,8 @@
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "dev": true,
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       },
       "dependencies": {
         "is-stream": {
@@ -8423,7 +8430,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -8432,10 +8439,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -8444,7 +8451,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm-run-path": {
@@ -8453,7 +8460,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
@@ -8462,10 +8469,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -8522,8 +8529,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "oboe": {
@@ -8532,7 +8539,7 @@
       "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
       "dev": true,
       "requires": {
-        "http-https": "1.0.0"
+        "http-https": "^1.0.0"
       }
     },
     "on-finished": {
@@ -8550,7 +8557,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "openzeppelin-solidity": {
@@ -8565,8 +8572,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.2"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -8583,12 +8590,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -8617,9 +8624,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       },
       "dependencies": {
         "invert-kv": {
@@ -8634,7 +8641,7 @@
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         }
       }
@@ -8669,7 +8676,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-timeout": {
@@ -8678,7 +8685,7 @@
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "dev": true,
       "requires": {
-        "p-finally": "1.0.0"
+        "p-finally": "^1.0.0"
       }
     },
     "parse-asn1": {
@@ -8687,11 +8694,11 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.9.2",
-        "browserify-aes": "1.1.1",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.14"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-glob": {
@@ -8700,10 +8707,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-headers": {
@@ -8712,7 +8719,7 @@
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
       "dev": true,
       "requires": {
-        "for-each": "0.3.2",
+        "for-each": "^0.3.2",
         "trim": "0.0.1"
       }
     },
@@ -8722,7 +8729,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parseurl": {
@@ -8737,7 +8744,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -8776,11 +8783,11 @@
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.9"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "pegjs": {
@@ -8819,7 +8826,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "prebuild-install": {
@@ -8828,21 +8835,21 @@
       "integrity": "sha512-3DX9L6pzwc1m1ksMkW3Ky2WLgPQUBiySOfXVl3WZyAeJSyJb4wtoH9OmeRGcubAWsMlLiL8BTHbwfm/jPQE9Ag==",
       "dev": true,
       "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "1.1.0",
+        "detect-libc": "^1.0.3",
+        "expand-template": "^1.0.2",
         "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.3.0",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "2.0.1",
-        "rc": "1.2.6",
-        "simple-get": "2.7.0",
-        "tar-fs": "1.16.0",
-        "tunnel-agent": "0.6.0",
-        "which-pm-runs": "1.0.0"
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-abi": "^2.2.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^2.0.1",
+        "rc": "^1.1.6",
+        "simple-get": "^2.7.0",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
       }
     },
     "prelude-ls": {
@@ -8881,7 +8888,7 @@
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
     },
@@ -8892,7 +8899,8 @@
       "dev": true
     },
     "pseudomap": {
-      "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
@@ -8908,11 +8916,11 @@
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "parse-asn1": "5.1.0",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "pump": {
@@ -8921,8 +8929,8 @@
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "punycode": {
@@ -8943,9 +8951,9 @@
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
       "requires": {
-        "decode-uri-component": "0.2.0",
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "randomatic": {
@@ -8954,8 +8962,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -8964,7 +8972,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -8973,7 +8981,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -8984,7 +8992,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -8995,7 +9003,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -9004,8 +9012,8 @@
       "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomhex": {
@@ -9038,7 +9046,7 @@
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         }
       }
@@ -9049,10 +9057,10 @@
       "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "dev": true,
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
     },
     "readable-stream": {
@@ -9061,13 +9069,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -9076,10 +9084,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "rechoir": {
@@ -9088,7 +9096,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.4.0"
+        "resolve": "^1.1.6"
       }
     },
     "regex-cache": {
@@ -9097,7 +9105,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "remove-trailing-separator": {
@@ -9124,7 +9132,7 @@
       "integrity": "sha1-DXOurpJm5penj3l2AZZ352rPD/8=",
       "dev": true,
       "requires": {
-        "req-from": "1.0.1"
+        "req-from": "^1.0.1"
       }
     },
     "req-from": {
@@ -9133,7 +9141,7 @@
       "integrity": "sha1-v4HaUUeUfTLRO5R9wSpYrUWHNQ4=",
       "dev": true,
       "requires": {
-        "resolve-from": "2.0.0"
+        "resolve-from": "^2.0.0"
       }
     },
     "request": {
@@ -9142,28 +9150,28 @@
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       },
       "dependencies": {
         "uuid": {
@@ -9198,7 +9206,7 @@
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -9213,7 +9221,7 @@
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3.4"
       }
     },
     "rimraf": {
@@ -9222,7 +9230,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "ripemd160": {
@@ -9231,8 +9239,8 @@
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "dev": true,
       "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.3"
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rlp": {
@@ -9265,7 +9273,7 @@
       "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
       "dev": true,
       "requires": {
-        "nan": "2.8.0"
+        "nan": "^2.0.8"
       }
     },
     "scrypt-js": {
@@ -9280,8 +9288,8 @@
       "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
       "dev": true,
       "requires": {
-        "scrypt": "6.0.3",
-        "scryptsy": "1.2.1"
+        "scrypt": "^6.0.2",
+        "scryptsy": "^1.2.1"
       }
     },
     "scryptsy": {
@@ -9290,7 +9298,7 @@
       "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
       "dev": true,
       "requires": {
-        "pbkdf2": "3.0.14"
+        "pbkdf2": "^3.0.3"
       }
     },
     "secp256k1": {
@@ -9299,14 +9307,14 @@
       "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
       "dev": true,
       "requires": {
-        "bindings": "1.3.0",
-        "bip66": "1.1.5",
-        "bn.js": "4.11.8",
-        "create-hash": "1.1.3",
-        "drbg.js": "1.0.1",
-        "elliptic": "6.4.0",
-        "nan": "2.8.0",
-        "safe-buffer": "5.1.1"
+        "bindings": "^1.2.1",
+        "bip66": "^1.1.3",
+        "bn.js": "^4.11.3",
+        "create-hash": "^1.1.2",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.2.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
       }
     },
     "seek-bzip": {
@@ -9315,7 +9323,7 @@
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "dev": true,
       "requires": {
-        "commander": "2.8.1"
+        "commander": "~2.8.1"
       },
       "dependencies": {
         "commander": {
@@ -9324,7 +9332,7 @@
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         }
       }
@@ -9348,18 +9356,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       },
       "dependencies": {
         "statuses": {
@@ -9376,9 +9384,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -9388,11 +9396,11 @@
       "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
       "dev": true,
       "requires": {
-        "body-parser": "1.18.3",
-        "cors": "2.8.5",
-        "express": "4.16.4",
-        "request": "2.83.0",
-        "xhr": "2.4.1"
+        "body-parser": "^1.16.0",
+        "cors": "^2.8.1",
+        "express": "^4.14.0",
+        "request": "^2.79.0",
+        "xhr": "^2.3.3"
       }
     },
     "set-blocking": {
@@ -9425,8 +9433,8 @@
       "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "sha3": {
@@ -9435,19 +9443,21 @@
       "integrity": "sha1-aYnxtwpJhwWHajc+LGKs6WqpOZo=",
       "dev": true,
       "requires": {
-        "nan": "2.8.0"
+        "nan": "^2.0.5"
       }
     },
     "shebang-command": {
-      "version": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
-      "version": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
@@ -9457,13 +9467,14 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "signal-exit": {
-      "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
@@ -9479,9 +9490,9 @@
       "integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
       "dev": true,
       "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "sjcl": {
@@ -9496,7 +9507,7 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "sol-digger": {
@@ -9517,11 +9528,11 @@
       "integrity": "sha512-Kq+O3PNF9Pfq7fB+lDYAuoqRdghLmZyfngsg0h1Hj38NKAeVHeGPOGeZasn5KqdPeCzbMFvaGyTySxzGv6aXCg==",
       "dev": true,
       "requires": {
-        "fs-extra": "0.30.0",
-        "memorystream": "0.3.1",
-        "require-from-string": "1.2.1",
-        "semver": "5.4.1",
-        "yargs": "4.8.1"
+        "fs-extra": "^0.30.0",
+        "memorystream": "^0.3.1",
+        "require-from-string": "^1.1.0",
+        "semver": "^5.3.0",
+        "yargs": "^4.7.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9542,7 +9553,7 @@
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -9564,9 +9575,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "code-point-at": {
@@ -9593,7 +9604,7 @@
           "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "dev": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "find-up": {
@@ -9602,8 +9613,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "fs-extra": {
@@ -9612,11 +9623,11 @@
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "fs.realpath": {
@@ -9637,12 +9648,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -9663,8 +9674,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -9691,7 +9702,7 @@
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -9700,7 +9711,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-utf8": {
@@ -9715,7 +9726,7 @@
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         },
         "klaw": {
@@ -9724,7 +9735,7 @@
           "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.9"
           }
         },
         "lcid": {
@@ -9733,7 +9744,7 @@
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "load-json-file": {
@@ -9742,11 +9753,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "lodash.assign": {
@@ -9767,7 +9778,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "normalize-package-data": {
@@ -9776,10 +9787,10 @@
           "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "number-is-nan": {
@@ -9794,7 +9805,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-locale": {
@@ -9803,7 +9814,7 @@
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "parse-json": {
@@ -9812,7 +9823,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -9821,7 +9832,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
@@ -9836,9 +9847,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -9859,7 +9870,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -9868,9 +9879,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -9879,8 +9890,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "require-directory": {
@@ -9907,7 +9918,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "semver": {
@@ -9928,7 +9939,7 @@
           "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
           "dev": true,
           "requires": {
-            "spdx-license-ids": "1.2.2"
+            "spdx-license-ids": "^1.0.2"
           }
         },
         "spdx-expression-parse": {
@@ -9949,9 +9960,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -9960,7 +9971,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -9969,7 +9980,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "validate-npm-package-license": {
@@ -9978,8 +9989,8 @@
           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
           "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
           }
         },
         "which-module": {
@@ -10000,8 +10011,8 @@
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           }
         },
         "wrappy": {
@@ -10022,20 +10033,20 @@
           "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
           "dev": true,
           "requires": {
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "lodash.assign": "4.2.0",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "window-size": "0.2.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "2.4.1"
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "lodash.assign": "^4.0.3",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.1",
+            "which-module": "^1.0.0",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^2.4.1"
           }
         },
         "yargs-parser": {
@@ -10044,8 +10055,8 @@
           "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "lodash.assign": "4.2.0"
+            "camelcase": "^3.0.0",
+            "lodash.assign": "^4.0.6"
           }
         }
       }
@@ -10056,20 +10067,21 @@
       "integrity": "sha512-qikdsSi6+9XbfvwA0aI7HUVpF9fIFNqRWTw23M89GMDY+b6Gj0wWU9IngJS0fimoZIAdEp3bfChxvpfVcrUesg==",
       "dev": true,
       "requires": {
-        "death": "1.1.0",
+        "death": "^1.1.0",
         "ethereumjs-testrpc-sc": "6.1.6",
-        "istanbul": "0.4.5",
-        "keccakjs": "0.2.1",
-        "req-cwd": "1.0.1",
-        "shelljs": "0.7.8",
-        "sol-explore": "1.6.2",
+        "istanbul": "^0.4.5",
+        "keccakjs": "^0.2.1",
+        "req-cwd": "^1.0.1",
+        "shelljs": "^0.7.4",
+        "sol-explore": "^1.6.2",
         "solidity-parser-sc": "0.4.11",
-        "tree-kill": "1.2.1",
-        "web3": "0.18.4"
+        "tree-kill": "^1.2.0",
+        "web3": "^0.18.4"
       },
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+          "from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
           "dev": true
         },
         "sol-explore": {
@@ -10085,10 +10097,10 @@
           "dev": true,
           "requires": {
             "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-            "crypto-js": "3.1.8",
-            "utf8": "2.1.2",
-            "xhr2": "0.1.4",
-            "xmlhttprequest": "1.8.0"
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xhr2": "*",
+            "xmlhttprequest": "*"
           }
         }
       }
@@ -10099,9 +10111,9 @@
       "integrity": "sha512-1kV5iC7m3CtMDfmHaVNwz2saSGQVIuF16rIxU417Al38MVCWHMQQ5vT6cmLsNwDe60S74auobWij9vNawSeOyw==",
       "dev": true,
       "requires": {
-        "mocha": "4.1.0",
-        "pegjs": "0.10.0",
-        "yargs": "4.8.1"
+        "mocha": "^4.1.0",
+        "pegjs": "^0.10.0",
+        "yargs": "^4.6.0"
       },
       "dependencies": {
         "camelcase": {
@@ -10116,9 +10128,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "find-up": {
@@ -10127,8 +10139,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -10137,11 +10149,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "os-locale": {
@@ -10150,7 +10162,7 @@
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "path-type": {
@@ -10159,9 +10171,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -10170,9 +10182,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -10181,8 +10193,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "string-width": {
@@ -10191,9 +10203,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-bom": {
@@ -10202,7 +10214,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "which-module": {
@@ -10223,20 +10235,20 @@
           "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
           "dev": true,
           "requires": {
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "lodash.assign": "4.2.0",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "window-size": "0.2.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "2.4.1"
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "lodash.assign": "^4.0.3",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.1",
+            "which-module": "^1.0.0",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^2.4.1"
           }
         },
         "yargs-parser": {
@@ -10245,8 +10257,8 @@
           "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "lodash.assign": "4.2.0"
+            "camelcase": "^3.0.0",
+            "lodash.assign": "^4.0.6"
           }
         }
       }
@@ -10257,18 +10269,18 @@
       "integrity": "sha512-fn0lusM6of14CytIDDHK73SGjn6NsVTaCVJjaKCKJyqKhT00rH/hDtvnIeZ2ZTD9z/xaXd4Js2brW3az6AV9RA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "chokidar": "1.7.0",
-        "colors": "1.1.2",
-        "commander": "2.13.0",
-        "eol": "0.9.1",
-        "js-string-escape": "1.0.1",
-        "lodash": "4.17.4",
+        "ajv": "^5.2.2",
+        "chokidar": "^1.6.0",
+        "colors": "^1.1.2",
+        "commander": "^2.9.0",
+        "eol": "^0.9.1",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.14.2",
         "sol-digger": "0.0.2",
         "sol-explore": "1.6.1",
         "solium-plugin-security": "0.1.1",
         "solparse": "2.2.5",
-        "text-table": "0.2.0"
+        "text-table": "^0.2.0"
       },
       "dependencies": {
         "solparse": {
@@ -10277,9 +10289,9 @@
           "integrity": "sha512-t7tvtR6KU6QfPYLMv1nlCh9DA8HYIu5tbjHpKu0fhGFZ1NuSp0KKDHfFHv07g6v1xgcuUY3rVqNFjZt5b9+5qA==",
           "dev": true,
           "requires": {
-            "mocha": "4.1.0",
-            "pegjs": "0.10.0",
-            "yargs": "10.1.1"
+            "mocha": "^4.0.1",
+            "pegjs": "^0.10.0",
+            "yargs": "^10.0.3"
           }
         }
       }
@@ -10296,7 +10308,7 @@
       "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
       "dev": true,
       "requires": {
-        "source-map": "0.6.1"
+        "source-map": "^0.6.0"
       },
       "dependencies": {
         "source-map": {
@@ -10313,7 +10325,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -10340,14 +10352,14 @@
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "statuses": {
@@ -10368,8 +10380,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -10390,7 +10402,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -10401,9 +10413,9 @@
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {
@@ -10412,7 +10424,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -10427,7 +10439,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-dirs": {
@@ -10436,7 +10448,7 @@
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "dev": true,
       "requires": {
-        "is-natural-number": "4.0.1"
+        "is-natural-number": "^4.0.1"
       }
     },
     "strip-eof": {
@@ -10466,7 +10478,7 @@
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "swarm-js": {
@@ -10475,19 +10487,19 @@
       "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.3",
-        "buffer": "5.2.1",
-        "decompress": "4.2.0",
-        "eth-lib": "0.1.27",
-        "fs-extra": "2.1.2",
-        "fs-promise": "2.0.3",
-        "got": "7.1.0",
-        "mime-types": "2.1.17",
-        "mkdirp-promise": "5.0.1",
-        "mock-fs": "4.7.0",
-        "setimmediate": "1.0.5",
-        "tar.gz": "1.0.7",
-        "xhr-request-promise": "0.1.2"
+        "bluebird": "^3.5.0",
+        "buffer": "^5.0.5",
+        "decompress": "^4.0.0",
+        "eth-lib": "^0.1.26",
+        "fs-extra": "^2.1.2",
+        "fs-promise": "^2.0.0",
+        "got": "^7.1.0",
+        "mime-types": "^2.1.16",
+        "mkdirp-promise": "^5.0.1",
+        "mock-fs": "^4.1.0",
+        "setimmediate": "^1.0.5",
+        "tar.gz": "^1.0.5",
+        "xhr-request-promise": "^0.1.2"
       },
       "dependencies": {
         "buffer": {
@@ -10496,8 +10508,8 @@
           "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
           "dev": true,
           "requires": {
-            "base64-js": "1.2.1",
-            "ieee754": "1.1.8"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
           }
         },
         "fs-extra": {
@@ -10506,8 +10518,8 @@
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0"
           }
         }
       }
@@ -10518,19 +10530,19 @@
       "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
       "dev": true,
       "requires": {
-        "deep-equal": "1.0.1",
-        "defined": "1.0.0",
-        "for-each": "0.3.2",
-        "function-bind": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.1",
-        "inherits": "2.0.3",
-        "minimist": "1.2.0",
-        "object-inspect": "1.3.0",
-        "resolve": "1.4.0",
-        "resumer": "0.0.0",
-        "string.prototype.trim": "1.1.2",
-        "through": "2.3.8"
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.2",
+        "function-bind": "~1.1.0",
+        "glob": "~7.1.2",
+        "has": "~1.0.1",
+        "inherits": "~2.0.3",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.3.0",
+        "resolve": "~1.4.0",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
       }
     },
     "tar": {
@@ -10539,9 +10551,9 @@
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "tar-fs": {
@@ -10550,10 +10562,10 @@
       "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
       "dev": true,
       "requires": {
-        "chownr": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.3",
-        "tar-stream": "1.5.5"
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
       },
       "dependencies": {
         "pump": {
@@ -10562,8 +10574,8 @@
           "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -10574,10 +10586,10 @@
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "dev": true,
       "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.1",
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "end-of-stream": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "bl": {
@@ -10586,7 +10598,7 @@
           "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3"
+            "readable-stream": "^2.0.5"
           }
         }
       }
@@ -10597,11 +10609,11 @@
       "integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
       "dev": true,
       "requires": {
-        "bluebird": "2.11.0",
-        "commander": "2.13.0",
-        "fstream": "1.0.11",
-        "mout": "0.11.1",
-        "tar": "2.2.1"
+        "bluebird": "^2.9.34",
+        "commander": "^2.8.1",
+        "fstream": "^1.0.8",
+        "mout": "^0.11.0",
+        "tar": "^2.1.1"
       },
       "dependencies": {
         "bluebird": {
@@ -10624,7 +10636,7 @@
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "dev": true,
       "requires": {
-        "any-promise": "1.3.0"
+        "any-promise": "^1.0.0"
       }
     },
     "thenify-all": {
@@ -10633,7 +10645,7 @@
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
-        "thenify": "3.3.0"
+        "thenify": ">= 3.1.0 < 4"
       }
     },
     "through": {
@@ -10654,7 +10666,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tough-cookie": {
@@ -10663,7 +10675,7 @@
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tree-kill": {
@@ -10684,9 +10696,9 @@
       "integrity": "sha512-ieCxk3WnOgFgXkyzC7GAa53igIwJBAaj1d2uB9M0XyWLQTyLndZtDK632GZNZDW+wY3SeI2baAq6ihC8Cl0uxw==",
       "dev": true,
       "requires": {
-        "mocha": "4.1.0",
+        "mocha": "^4.1.0",
         "original-require": "1.0.1",
-        "solc": "0.5.7"
+        "solc": "^0.5.0"
       },
       "dependencies": {
         "solc": {
@@ -10695,14 +10707,14 @@
           "integrity": "sha512-DaYFzB3AAYjzPtgUl9LenPY2xjI3wG9k8U8T8YE/sXHVIoCirCY5MB6mhcFPgk/VyUtaWZPUCWiYS1E6RSiiqw==",
           "dev": true,
           "requires": {
-            "command-exists": "1.2.8",
-            "fs-extra": "0.30.0",
-            "keccak": "1.4.0",
-            "memorystream": "0.3.1",
-            "require-from-string": "2.0.2",
-            "semver": "5.5.0",
+            "command-exists": "^1.2.8",
+            "fs-extra": "^0.30.0",
+            "keccak": "^1.0.2",
+            "memorystream": "^0.3.1",
+            "require-from-string": "^2.0.0",
+            "semver": "^5.5.0",
             "tmp": "0.0.33",
-            "yargs": "11.1.0"
+            "yargs": "^11.0.0"
           }
         },
         "yargs": {
@@ -10711,18 +10723,18 @@
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           }
         },
         "yargs-parser": {
@@ -10731,7 +10743,7 @@
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -10742,8 +10754,8 @@
       "integrity": "sha512-0j8WU7tc4tDhQauiGqgRFOQtH0QLlc/T/jd2KjSrw3kvJxu4IZU0KAdosohN2nFAnrGHF/O4K1da/yEQjwgH7g==",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "web3": "1.0.0-beta.36"
+        "assertion-error": "^1.1.0",
+        "web3": "^1.0.0-beta.35"
       },
       "dependencies": {
         "web3": {
@@ -10769,11 +10781,11 @@
       "integrity": "sha512-AyUBJsjdZkRgvsctGeZvnU507YUWAoePIi/e/ZEEU2FOuodded47SypYr63J7DhSVP15DtdYcSa9Ot/GqjBX3Q==",
       "dev": true,
       "requires": {
-        "ethereumjs-wallet": "0.6.0",
-        "keythereum": "1.0.2",
-        "prompt-sync": "4.1.5",
-        "web3": "0.20.5",
-        "web3-provider-engine": "8.6.1"
+        "ethereumjs-wallet": "^0.6.0",
+        "keythereum": "^1.0.2",
+        "prompt-sync": "^4.1.5",
+        "web3": "^0.20.1",
+        "web3-provider-engine": "^8.4.0"
       }
     },
     "tunnel-agent": {
@@ -10782,7 +10794,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -10798,7 +10810,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -10814,7 +10826,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.21"
+        "mime-types": "~2.1.18"
       },
       "dependencies": {
         "mime-db": {
@@ -10829,7 +10841,7 @@
           "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
           "dev": true,
           "requires": {
-            "mime-db": "1.37.0"
+            "mime-db": "~1.37.0"
           }
         }
       }
@@ -10840,7 +10852,7 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
       "requires": {
-        "is-typedarray": "1.0.0"
+        "is-typedarray": "^1.0.0"
       }
     },
     "ultron": {
@@ -10855,8 +10867,8 @@
       "integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
       "dev": true,
       "requires": {
-        "buffer": "3.6.0",
-        "through": "2.3.8"
+        "buffer": "^3.0.1",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "base64-js": {
@@ -10872,8 +10884,8 @@
           "dev": true,
           "requires": {
             "base64-js": "0.0.8",
-            "ieee754": "1.1.8",
-            "isarray": "1.0.0"
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
           }
         }
       }
@@ -10896,7 +10908,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "url-set-query": {
@@ -10941,8 +10953,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "vary": {
@@ -10957,9 +10969,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "web3": {
@@ -10969,14 +10981,15 @@
       "dev": true,
       "requires": {
         "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-        "crypto-js": "3.1.8",
-        "utf8": "2.1.2",
-        "xhr2": "0.1.4",
-        "xmlhttprequest": "1.8.0"
+        "crypto-js": "^3.1.4",
+        "utf8": "^2.1.1",
+        "xhr2": "*",
+        "xmlhttprequest": "*"
       },
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
           "dev": true
         }
       }
@@ -11118,9 +11131,9 @@
           "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "elliptic": "6.4.0",
-            "xhr-request-promise": "0.1.2"
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
           }
         },
         "uuid": {
@@ -11211,24 +11224,25 @@
       "integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "clone": "2.1.1",
-        "ethereumjs-block": "1.7.0",
-        "ethereumjs-tx": "1.3.3",
-        "ethereumjs-util": "5.1.2",
-        "ethereumjs-vm": "2.3.3",
-        "isomorphic-fetch": "2.2.1",
-        "request": "2.83.0",
-        "semaphore": "1.1.0",
-        "solc": "0.4.18",
-        "tape": "4.8.0",
-        "web3": "0.16.0",
-        "xhr": "2.4.1",
-        "xtend": "4.0.1"
+        "async": "^2.1.2",
+        "clone": "^2.0.0",
+        "ethereumjs-block": "^1.2.2",
+        "ethereumjs-tx": "^1.2.0",
+        "ethereumjs-util": "^5.0.1",
+        "ethereumjs-vm": "^2.0.2",
+        "isomorphic-fetch": "^2.2.0",
+        "request": "^2.67.0",
+        "semaphore": "^1.0.3",
+        "solc": "^0.4.2",
+        "tape": "^4.4.0",
+        "web3": "^0.16.0",
+        "xhr": "^2.2.0",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+          "from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
           "dev": true
         },
         "web3": {
@@ -11238,9 +11252,9 @@
           "dev": true,
           "requires": {
             "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-            "crypto-js": "3.1.8",
-            "utf8": "2.1.2",
-            "xmlhttprequest": "1.8.0"
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xmlhttprequest": "*"
           }
         }
       }
@@ -11320,12 +11334,13 @@
     },
     "websocket": {
       "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+      "from": "websocket@git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "nan": "2.8.0",
-        "typedarray-to-buffer": "3.1.5",
-        "yaeti": "0.0.6"
+        "debug": "^2.2.0",
+        "nan": "^2.3.3",
+        "typedarray-to-buffer": "^3.1.2",
+        "yaeti": "^0.0.6"
       }
     },
     "whatwg-fetch": {
@@ -11335,11 +11350,12 @@
       "dev": true
     },
     "which": {
-      "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "dev": true,
       "requires": {
-        "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -11360,7 +11376,7 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       },
       "dependencies": {
         "string-width": {
@@ -11369,9 +11385,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -11388,8 +11404,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "string-width": {
@@ -11398,9 +11414,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -11417,9 +11433,9 @@
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "dev": true,
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
       }
     },
     "xhr": {
@@ -11428,10 +11444,10 @@
       "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
       "dev": true,
       "requires": {
-        "global": "4.3.2",
-        "is-function": "1.0.1",
-        "parse-headers": "2.0.1",
-        "xtend": "4.0.1"
+        "global": "~4.3.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "xhr-request": {
@@ -11440,13 +11456,13 @@
       "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
       "dev": true,
       "requires": {
-        "buffer-to-arraybuffer": "0.0.5",
-        "object-assign": "4.1.1",
-        "query-string": "5.1.1",
-        "simple-get": "2.7.0",
-        "timed-out": "4.0.1",
-        "url-set-query": "1.0.0",
-        "xhr": "2.4.1"
+        "buffer-to-arraybuffer": "^0.0.5",
+        "object-assign": "^4.1.1",
+        "query-string": "^5.0.1",
+        "simple-get": "^2.7.0",
+        "timed-out": "^4.0.1",
+        "url-set-query": "^1.0.0",
+        "xhr": "^2.0.4"
       }
     },
     "xhr-request-promise": {
@@ -11455,7 +11471,7 @@
       "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
       "dev": true,
       "requires": {
-        "xhr-request": "1.1.0"
+        "xhr-request": "^1.0.1"
       }
     },
     "xhr2": {
@@ -11470,7 +11486,7 @@
       "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
       "dev": true,
       "requires": {
-        "cookiejar": "2.1.2"
+        "cookiejar": "^2.1.1"
       }
     },
     "xmlhttprequest": {
@@ -11498,7 +11514,8 @@
       "dev": true
     },
     "yallist": {
-      "version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
@@ -11508,18 +11525,18 @@
       "integrity": "sha512-7uRL1HZdCbc1QTP+X8mehOPuCYKC/XTaqAPj7gABLfTt6pgLyVRn3QVte4qhtilZouWCvqd1kipgMKl5tKsFiw==",
       "dev": true,
       "requires": {
-        "cliui": "4.0.0",
-        "decamelize": "1.2.0",
-        "find-up": "2.1.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "8.1.0"
+        "cliui": "^4.0.0",
+        "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^8.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -11534,9 +11551,9 @@
           "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "code-point-at": {
@@ -11593,8 +11610,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -11603,7 +11620,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "wrap-ansi": {
@@ -11612,8 +11629,8 @@
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "ansi-regex": {
@@ -11628,7 +11645,7 @@
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "string-width": {
@@ -11637,9 +11654,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             },
             "strip-ansi": {
@@ -11648,7 +11665,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             }
           }
@@ -11667,7 +11684,7 @@
       "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       }
     },
     "yauzl": {
@@ -11676,8 +11693,8 @@
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "fd-slicer": "1.1.0"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "lint": "npm run eslint && npm run solium",
+    "lint:fix": "./node_modules/.bin/eslint util/** test/** --fix",
     "eslint": "./node_modules/.bin/eslint util/** test/**",
     "solium": "./node_modules/.bin/solium --dir ./contracts",
     "ganache": "bash scripts/run_ganache.sh",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "npm run ganache && truffle test test/unit/*",
     "test:integration": "npm run ganache && truffle test test/integration/*",
+    "test:describe": "func() { npm run ganache && truffle test -g \"$1\"; }; func",
     "validateDeploymentAndGenesis": "READ_ONLY=true truffle exec scripts/validateDeploymentAndGenesis.js",
     "migrate": "truffle migrate",
     "docker:build": "docker build --cache-from livepeer/protocol:latest --tag livepeer/protocol:latest -f Dockerfile .",

--- a/test/helpers/expectFail.js
+++ b/test/helpers/expectFail.js
@@ -1,4 +1,4 @@
-module.exports.expectRevertWithReason = async (promise, reason) => {
+export default async (promise, reason) => {
     try {
         await promise
     } catch (error) {

--- a/test/integration/Delegation.js
+++ b/test/integration/Delegation.js
@@ -71,8 +71,9 @@ contract("Delegation", accounts => {
         assert.equal(await bondingManager.getTotalBonded(), 0, "wrong total bonded")
 
         await bondingManager.transcoder(0, 5, {from: transcoder1})
-
-        assert.equal(await bondingManager.transcoderStatus(transcoder1), 1, "wrong transcoder status")
+        await roundsManager.mineBlocks(roundLength.toNumber() * 1)
+        await roundsManager.initializeRound()
+        assert.isTrue(await bondingManager.isRegisteredTranscoder(transcoder1), "wrong transcoder status")
         // Stake counted (+1000) after user joins transcoder pool
         assert.equal(await bondingManager.getTotalBonded(), 1000, "wrong total bonded")
     })
@@ -83,10 +84,10 @@ contract("Delegation", accounts => {
 
         // Stake doesn't count until user joins transcoder pool
         assert.equal(await bondingManager.getTotalBonded(), 1000, "wrong total bonded")
-
         await bondingManager.transcoder(0, 5, {from: transcoder2})
-
-        assert.equal(await bondingManager.transcoderStatus(transcoder2), 1, "wrong transcoder status")
+        await roundsManager.mineBlocks(roundLength.toNumber() * 1)
+        await roundsManager.initializeRound()
+        assert.isTrue(await bondingManager.isRegisteredTranscoder(transcoder1), "wrong transcoder status")
         // Stake counted (+1000) after user joins transcoder pool
         assert.equal(await bondingManager.getTotalBonded(), 2000, "wrong total bonded")
     })

--- a/test/integration/Delegation.js
+++ b/test/integration/Delegation.js
@@ -70,7 +70,7 @@ contract("Delegation", accounts => {
         // Stake doesn't count until user joins transcoder pool
         assert.equal(await bondingManager.getTotalBonded(), 0, "wrong total bonded")
 
-        await bondingManager.transcoder(0, 5, 100, {from: transcoder1})
+        await bondingManager.transcoder(0, 5, {from: transcoder1})
 
         assert.equal(await bondingManager.transcoderStatus(transcoder1), 1, "wrong transcoder status")
         // Stake counted (+1000) after user joins transcoder pool
@@ -84,7 +84,7 @@ contract("Delegation", accounts => {
         // Stake doesn't count until user joins transcoder pool
         assert.equal(await bondingManager.getTotalBonded(), 1000, "wrong total bonded")
 
-        await bondingManager.transcoder(0, 5, 100, {from: transcoder2})
+        await bondingManager.transcoder(0, 5, {from: transcoder2})
 
         assert.equal(await bondingManager.transcoderStatus(transcoder2), 1, "wrong transcoder status")
         // Stake counted (+1000) after user joins transcoder pool

--- a/test/integration/Delegation.js
+++ b/test/integration/Delegation.js
@@ -66,29 +66,20 @@ contract("Delegation", accounts => {
     it("registers transcoder 1 that self bonds", async () => {
         await token.approve(bondingManager.address, 1000, {from: transcoder1})
         await bondingManager.bond(1000, transcoder1, {from: transcoder1})
-
-        // Stake doesn't count until user joins transcoder pool
-        assert.equal(await bondingManager.getTotalBonded(), 0, "wrong total bonded")
-
         await bondingManager.transcoder(0, 5, {from: transcoder1})
         await roundsManager.mineBlocks(roundLength.toNumber() * 1)
         await roundsManager.initializeRound()
         assert.isTrue(await bondingManager.isRegisteredTranscoder(transcoder1), "wrong transcoder status")
-        // Stake counted (+1000) after user joins transcoder pool
         assert.equal(await bondingManager.getTotalBonded(), 1000, "wrong total bonded")
     })
 
     it("registers transcoder 2 that self bonds", async () => {
         await token.approve(bondingManager.address, 1000, {from: transcoder2})
         await bondingManager.bond(1000, transcoder2, {from: transcoder2})
-
-        // Stake doesn't count until user joins transcoder pool
-        assert.equal(await bondingManager.getTotalBonded(), 1000, "wrong total bonded")
         await bondingManager.transcoder(0, 5, {from: transcoder2})
         await roundsManager.mineBlocks(roundLength.toNumber() * 1)
         await roundsManager.initializeRound()
-        assert.isTrue(await bondingManager.isRegisteredTranscoder(transcoder1), "wrong transcoder status")
-        // Stake counted (+1000) after user joins transcoder pool
+        assert.isTrue(await bondingManager.isRegisteredTranscoder(transcoder2), "wrong transcoder status")
         assert.equal(await bondingManager.getTotalBonded(), 2000, "wrong total bonded")
     })
 

--- a/test/integration/Rewards.js
+++ b/test/integration/Rewards.js
@@ -65,7 +65,7 @@ contract("Rewards", accounts => {
         // Register transcoder 1
         await token.approve(bondingManager.address, transcoder1StartStake, {from: transcoder1})
         await bondingManager.bond(transcoder1StartStake, transcoder1, {from: transcoder1})
-        await bondingManager.transcoder(rewardCut * constants.PERC_MULTIPLIER, feeShare * constants.PERC_MULTIPLIER, 200000000000, {from: transcoder1})
+        await bondingManager.transcoder(rewardCut * constants.PERC_MULTIPLIER, feeShare * constants.PERC_MULTIPLIER, {from: transcoder1})
 
         // Delegator 1 delegates to transcoder 1
         await token.approve(bondingManager.address, delegator1StartStake, {from: delegator1})

--- a/test/integration/RoundInitialization.js
+++ b/test/integration/RoundInitialization.js
@@ -27,7 +27,7 @@ contract("RoundInitialization", accounts => {
             await token.transfer(tr, amount)
             await token.approve(bondingManager.address, amount, {from: tr})
             await bondingManager.bond(amount, tr, {from: tr})
-            await bondingManager.transcoder(0, 100, 15, {from: tr})
+            await bondingManager.transcoder(0, 100, {from: tr})
         }
 
         await mineAndInitializeRound(roundsManager)
@@ -62,7 +62,6 @@ contract("RoundInitialization", accounts => {
     it("initializes a round with numActiveTranscoders = 15 and numTranscoders = 20", async () => {
         await bondingManager.setNumActiveTranscoders(15)
         assert.equal(await bondingManager.numActiveTranscoders.call(), 15, "wrong max # of active transcoders")
-
         await mineAndInitializeRound(roundsManager)
 
         const currentRound = await roundsManager.currentRound()

--- a/test/integration/RoundInitialization.js
+++ b/test/integration/RoundInitialization.js
@@ -51,54 +51,52 @@ contract("RoundInitialization", accounts => {
         await mineAndInitializeRound(roundsManager)
     })
 
-    it("initializes a round with numActiveTranscoders = 10 and numTranscoders = 20", async () => {
-        const newTranscoders = accounts.slice(1, 21)
+    it("initializes a round with numActiveTranscoders = 10", async () => {
+        const newTranscoders = accounts.slice(1, 11)
         await registerTranscodersAndInitializeRound(bondAmount, newTranscoders, bondingManager, token, roundsManager)
 
-        const currentRound = await roundsManager.currentRound()
-        assert.equal(await bondingManager.getTotalActiveStake(currentRound), bondAmount.times(10).toNumber(), "wrong total active stake")
+        assert.equal(await bondingManager.currentRoundTotalActiveStake(), bondAmount.times(10).toNumber(), "wrong total active stake")
     })
 
-    it("initializes a round with numActiveTranscoders = 15 and numTranscoders = 20", async () => {
+    it("initializes a round with numActiveTranscoders = 15", async () => {
+        const newTranscoders = accounts.slice(11, 26)
         await bondingManager.setNumActiveTranscoders(15)
-        assert.equal(await bondingManager.numActiveTranscoders.call(), 15, "wrong max # of active transcoders")
-        await mineAndInitializeRound(roundsManager)
+        assert.equal(await bondingManager.getTranscoderPoolMaxSize(), 15, "wrong max # of active transcoders")
+        await registerTranscodersAndInitializeRound(bondAmount, newTranscoders, bondingManager, token, roundsManager)
 
-        const currentRound = await roundsManager.currentRound()
-        assert.equal(await bondingManager.getTotalActiveStake(currentRound), bondAmount.times(15).toNumber(), "wrong total active stake")
+        assert.equal(await bondingManager.currentRoundTotalActiveStake(), bondAmount.times(15).toNumber(), "wrong total active stake")
     })
 
-    it("initializes a round with numActiveTranscoders = 20 and numTranscoders = 50", async () => {
-        const newTranscoders = accounts.slice(21, 51)
+    it("initializes a round with numActiveTranscoders = 20", async () => {
+        const newTranscoders = accounts.slice(26, 46)
 
-        await bondingManager.setNumTranscoders(50)
-        assert.equal(await bondingManager.getTranscoderPoolMaxSize(), 50, "wrong transcoder pool max size")
         await bondingManager.setNumActiveTranscoders(20)
-        assert.equal(await bondingManager.numActiveTranscoders.call(), 20, "wrong max # of active transcoders")
+        assert.equal(await bondingManager.getTranscoderPoolMaxSize(), 20, "wrong max # of active transcoders")
 
         await registerTranscodersAndInitializeRound(bondAmount, newTranscoders, bondingManager, token, roundsManager)
 
-        const currentRound = await roundsManager.currentRound()
-        assert.equal(await bondingManager.getTotalActiveStake(currentRound), bondAmount.times(20).toNumber(), "wrong total active stake")
+        assert.equal(await bondingManager.currentRoundTotalActiveStake(), bondAmount.times(20).toNumber(), "wrong total active stake")
     })
 
-    it("initializes a round with numActiveTranscoders = 30 and numTranscoders = 50", async () => {
+    it("initializes a round with numActiveTranscoders = 30", async () => {
+        const newTranscoders = accounts.slice(46, 76)
+
         await bondingManager.setNumActiveTranscoders(30)
-        assert.equal(await bondingManager.numActiveTranscoders.call(), 30, "wrong max # of active transcoders")
+        assert.equal(await bondingManager.getTranscoderPoolMaxSize(), 30, "wrong max # of active transcoders")
+        await registerTranscodersAndInitializeRound(bondAmount, newTranscoders, bondingManager, token, roundsManager)
 
         await mineAndInitializeRound(roundsManager)
 
-        const currentRound = await roundsManager.currentRound()
-        assert.equal(await bondingManager.getTotalActiveStake(currentRound), bondAmount.times(30).toNumber(), "wrong total active stake")
+        assert.equal(await bondingManager.currentRoundTotalActiveStake(), bondAmount.times(30).toNumber(), "wrong total active stake")
     })
 
-    it("initializes a round with numActiveTranscoders = 40 and numTranscoders = 50", async () => {
+    it("initializes a round with numActiveTranscoders = 40", async () => {
+        const newTranscoders = accounts.slice(76, 100)
         await bondingManager.setNumActiveTranscoders(40)
-        assert.equal(await bondingManager.numActiveTranscoders.call(), 40, "wrong max # of active transcoders")
+        assert.equal(await bondingManager.getTranscoderPoolMaxSize(), 40, "wrong max # of active transcoders")
 
-        await mineAndInitializeRound(roundsManager)
+        await registerTranscodersAndInitializeRound(bondAmount, newTranscoders, bondingManager, token, roundsManager)
 
-        const currentRound = await roundsManager.currentRound()
-        assert.equal(await bondingManager.getTotalActiveStake(currentRound), bondAmount.times(40).toNumber(), "wrong total active stake")
+        assert.equal(await bondingManager.currentRoundTotalActiveStake(), bondAmount.times(40).toNumber(), "wrong total active stake")
     })
 })

--- a/test/integration/SystemPause.js
+++ b/test/integration/SystemPause.js
@@ -50,8 +50,9 @@ contract("System Pause", accounts => {
         await token.approve(bondingManager.address, 1000, {from: transcoder1})
         await bondingManager.bond(1000, transcoder1, {from: transcoder1})
         await bondingManager.transcoder(0, 5, {from: transcoder1})
-
-        assert.equal(await bondingManager.transcoderStatus(transcoder1), 1, "wrong transcoder status")
+        await roundsManager.mineBlocks(roundLength.toNumber() * 1)
+        await roundsManager.initializeRound()
+        assert.isTrue(await bondingManager.isRegisteredTranscoder(transcoder1), "wrong transcoder status")
     })
 
     it("delegator 1 bonds to transcoder 1", async () => {

--- a/test/integration/SystemPause.js
+++ b/test/integration/SystemPause.js
@@ -49,7 +49,7 @@ contract("System Pause", accounts => {
     it("registers transcoder 1 that self bonds", async () => {
         await token.approve(bondingManager.address, 1000, {from: transcoder1})
         await bondingManager.bond(1000, transcoder1, {from: transcoder1})
-        await bondingManager.transcoder(0, 5, 100, {from: transcoder1})
+        await bondingManager.transcoder(0, 5, {from: transcoder1})
 
         assert.equal(await bondingManager.transcoderStatus(transcoder1), 1, "wrong transcoder status")
     })

--- a/test/integration/TicketFlow.js
+++ b/test/integration/TicketFlow.js
@@ -48,7 +48,7 @@ contract("TicketFlow", accounts => {
         // Register transcoder
         await token.approve(bondingManager.address, amount, {from: transcoder})
         await bondingManager.bond(amount, transcoder, {from: transcoder})
-        await bondingManager.transcoder(0, 0, 0, {from: transcoder})
+        await bondingManager.transcoder(0, 0, {from: transcoder})
 
         roundLength = await roundsManager.roundLength.call()
         await roundsManager.mineBlocks(roundLength.toNumber() * 1000)

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -422,7 +422,7 @@ contract("BondingManager", accounts => {
                     const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
                     assert.equal(endTotalStake.sub(startTotalStake), 3000)
                 })
-          
+
                 it("should update transcoder's lastActiveStakeUpdateRound", async () => {
                     await bondingManager.bond(3000, transcoder0, {from: delegator})
                     assert.equal(await bondingManager.lastActiveStakeUpdateRound(transcoder0), currentRound+1)

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -186,16 +186,17 @@ contract("BondingManager", accounts => {
                         // Caller bonds 6000 which is more than transcoder with least delegated stake
                         await bondingManager.bond(6000, newTranscoder, {from: newTranscoder})
                         await bondingManager.transcoder(5, 10, {from: newTranscoder})
+                        await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
 
                         // Subtract evicted transcoder's delegated stake and add new transcoder's delegated stake
                         const expTotalBonded = totalBonded - 1000 + 6000
-                        assert.equal((await bondingManager.getTotalBonded()).toString(), expTotalBonded, "wrong total bonded")
+                        assert.equal((await bondingManager.getTotalBonded()), expTotalBonded, "wrong total bonded")
 
-                        assert.isTrue(await bondingManager.isActiveTranscoder(newTranscoder, currentRound+1), "caller should be registered as transocder")
+                        assert.isTrue(await bondingManager.isActiveTranscoder(newTranscoder), "caller should be registered as transocder")
                         assert.equal(await bondingManager.getTranscoderPoolSize(), 2, "wrong transcoder pool size")
                         assert.equal(await bondingManager.getTranscoderPoolMaxSize(), 2, "wrong transcoder pool max size")
                         assert.equal(await bondingManager.transcoderTotalStake(newTranscoder), 6000, "wrong transcoder total stake")
-                        assert.isFalse(await bondingManager.isActiveTranscoder(accounts[0], currentRound+1), "transcoder with least delegated stake should be evicted")
+                        assert.isFalse(await bondingManager.isActiveTranscoder(accounts[0]), "transcoder with least delegated stake should be evicted")
                     })
                 })
 
@@ -219,8 +220,9 @@ contract("BondingManager", accounts => {
                         // Caller bonds 600 - less than transcoder with least delegated stake
                         await bondingManager.bond(600, newTranscoder, {from: newTranscoder})
                         await bondingManager.transcoder(5, 10, {from: newTranscoder})
+                        await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
 
-                        assert.isFalse(await bondingManager.isActiveTranscoder(newTranscoder, currentRound+1), "should not register caller as a transcoder in the pool")
+                        assert.isFalse(await bondingManager.isActiveTranscoder(newTranscoder), "should not register caller as a transcoder in the pool")
                     })
 
                     it("should not add caller with equal delegated stake to transcoder with least delegated stake in pool", async () => {
@@ -242,8 +244,8 @@ contract("BondingManager", accounts => {
                         // Caller bonds 2000 - same as transcoder with least delegated stake
                         await bondingManager.bond(2000, newTranscoder, {from: newTranscoder})
                         await bondingManager.transcoder(5, 10, {from: newTranscoder})
-
-                        assert.isFalse(await bondingManager.isActiveTranscoder(newTranscoder, currentRound+1), "should not register caller as a transcoder in the pool")
+                        await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
+                        assert.isFalse(await bondingManager.isActiveTranscoder(newTranscoder), "should not register caller as a transcoder in the pool")
                     })
                 })
             })
@@ -325,24 +327,27 @@ contract("BondingManager", accounts => {
                     assert.equal(e.returnValues.transcoder, transcoder0)
                 })
                 await bondingManager.bond(2000, transcoder2, {from: delegator})
-                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder2, currentRound+2))
-                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder1, currentRound))
-                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder0, currentRound+2))
+                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+2)
+                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder2))
+                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder1))
+                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder0))
                 assert.equal((await bondingManager.transcoderTotalStake(transcoder2)).toString(), "2500")
             })
 
             it("inserts into pool without evicting if pool is not full", async () => {
                 await bondingManager.unbond(2000, {from: transcoder1})
                 await bondingManager.bond(2500, transcoder2, {from: delegator})
-                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder2, currentRound+2))
-                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder0, currentRound))
+                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+2)
+                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder2))
+                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder0))
                 // transcoder 2 should be first
                 assert.equal(await bondingManager.getFirstTranscoderInPool(), transcoder2)
             })
 
             it("doesn't insert into pool when stake is too low", async () => {
                 await bondingManager.bond(10, transcoder2, {from: delegator})
-                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder2, currentRound+2))
+                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+2)
+                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder2))
             })
 
             it("activates and deactivates transcoders on the earningspool", async () => {
@@ -350,10 +355,8 @@ contract("BondingManager", accounts => {
                 await bondingManager.bond(2000, transcoder2, {from: delegator})
                 const poolT2 = await bondingManager.getTranscoderEarningsPoolForRound(transcoder2, currentRound+2)
                 const poolT0 = await bondingManager.getTranscoderEarningsPoolForRound(transcoder0, currentRound+2)
-                assert.isTrue(poolT2.active)
-                assert.equal(poolT2.totalStake.toString(), "2500")
-                assert.isFalse(poolT0.active)
-                assert.equal(poolT0.totalStake.toString(), "0")
+                assert.equal(poolT2.totalStake, 2500)
+                assert.equal(poolT0.totalStake, 0)
             })
         })
 
@@ -419,6 +422,11 @@ contract("BondingManager", accounts => {
                     const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
                     assert.equal(endTotalStake.sub(startTotalStake), 3000)
                 })
+          
+                it("should update transcoder's lastActiveStakeUpdateRound", async () => {
+                    await bondingManager.bond(3000, transcoder0, {from: delegator})
+                    assert.equal(await bondingManager.lastActiveStakeUpdateRound(transcoder0), currentRound+1)
+                })
             })
 
             describe("delegate is not a registered transcoder", () => {
@@ -435,6 +443,11 @@ contract("BondingManager", accounts => {
                     await bondingManager.bond(1000, nonTranscoder, {from: delegator})
                     const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
                     assert.equal(startTotalStake.sub(endTotalStake), 0, "wrong change in total active stake for next round")
+                })
+
+                it("should not update transcoder's lastActiveStakeUpdateRound", async () => {
+                    await bondingManager.bond(3000, nonTranscoder, {from: delegator})
+                    assert.equal(await bondingManager.lastActiveStakeUpdateRound(nonTranscoder), 0)
                 })
             })
         })
@@ -485,6 +498,12 @@ contract("BondingManager", accounts => {
                             const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
                             assert.equal(startTotalStake.sub(endTotalStake), 0, "wrong change in total active stake for next round")
                         })
+
+                        it("should update old delegate and new delegate's lastActiveStakeUpdateRound", async () => {
+                            await bondingManager.bond(0, transcoder1, {from: delegator})
+                            assert.equal(await bondingManager.lastActiveStakeUpdateRound(transcoder0), currentRound+1)
+                            assert.equal(await bondingManager.lastActiveStakeUpdateRound(transcoder1), currentRound+1)
+                        })
                     })
 
                     describe("new delegate is not a registered transcoder", () => {
@@ -492,7 +511,7 @@ contract("BondingManager", accounts => {
                             await bondingManager.bond(0, nonTranscoder, {from: delegator})
                             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
                             // New delegate was not previously first transcoder in pool and now is
-                            assert.isFalse(await bondingManager.isActiveTranscoder(nonTranscoder, currentRound +1 ))
+                            assert.isFalse(await bondingManager.isActiveTranscoder(nonTranscoder))
                         })
 
                         it("should decrease the total active stake for the next round", async () => {
@@ -500,6 +519,12 @@ contract("BondingManager", accounts => {
                             await bondingManager.bond(0, nonTranscoder, {from: delegator})
                             const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
                             assert.equal(startTotalStake.sub(endTotalStake), 2000, "wrong change in total active stake for next round")
+                        })
+
+                        it("should only update old delegate's lastActiveStakeUpdateRound", async () => {
+                            await bondingManager.bond(0, nonTranscoder, {from: delegator})
+                            assert.equal(await bondingManager.lastActiveStakeUpdateRound(transcoder0), currentRound +1)
+                            assert.equal(await bondingManager.lastActiveStakeUpdateRound(nonTranscoder), 0)
                         })
                     })
                 })
@@ -523,12 +548,23 @@ contract("BondingManager", accounts => {
                             assert.equal(endTotalStake.sub(startTotalStake), 2000, "wrong change in total active stake for next round")
                         })
 
-                        describe("new delegate is not a registered transcoder()", () => {
-                            it("should not update the new delegate's position in transcoder pool", async () => {
-                                await bondingManager.bond(0, nonTranscoder, {from: delegator})
-                                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
-                                assert.isFalse(await bondingManager.isActiveTranscoder(nonTranscoder, currentRound +1 ), "did not correctly update position in pool")
-                            })
+                        it("should only update new delegate lastActiveStakeUpdateRound", async () => {
+                            await bondingManager.bond(0, transcoder0, {from: delegator})
+                            assert.equal(await bondingManager.lastActiveStakeUpdateRound(transcoder0), currentRound+1)
+                            assert.equal(await bondingManager.lastActiveStakeUpdateRound(delegator2), 0)
+                        })
+                    })
+
+                    describe("new delegate is not a registered transcoder()", () => {
+                        it("should not update the new delegate's position in transcoder pool", async () => {
+                            await bondingManager.bond(0, nonTranscoder, {from: delegator})
+                            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
+                            assert.isFalse(await bondingManager.isActiveTranscoder(nonTranscoder), "did not correctly update position in pool")
+                        })
+
+                        it("should not update new delegate's lastActiveStakeUpdateRound", async () => {
+                            await bondingManager.bond(0, nonTranscoder, {from: delegator})
+                            assert.equal(await bondingManager.lastActiveStakeUpdateRound(nonTranscoder), 0)
                         })
                     })
                 })
@@ -923,6 +959,11 @@ contract("BondingManager", accounts => {
                     const endTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
                     assert.equal(endTotalActiveStake.sub(startTotalActiveStake), 0, "wrong change in nextRoundTotalActiveStake")
                 })
+
+                it("should not change delegate's lastActiveStakeUpdateRound", async () => {
+                    await bondingManager.unbond(500, {from: delegator2})
+                    assert.equal(await bondingManager.lastActiveStakeUpdateRound(delegator), 0)
+                })
             })
 
             describe("not delegated to self and delegate is registered transcoder", () => {
@@ -947,6 +988,11 @@ contract("BondingManager", accounts => {
                     const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
                     assert.equal(startTotalStake.sub(endTotalStake), 500, "wrong change in total next round stake")
                 })
+
+                it("should update delegate's lastActiveStakeUpdateRound", async () => {
+                    await bondingManager.unbond(500, {from: delegator})
+                    assert.equal(await bondingManager.lastActiveStakeUpdateRound(transcoder), currentRound+2)
+                })
             })
 
             describe("delegated to self with non-zero bonded amount and is registered transcoder", () => {
@@ -970,6 +1016,11 @@ contract("BondingManager", accounts => {
                     await bondingManager.unbond(500, {from: transcoder})
                     const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
                     assert.equal(startTotalStake.sub(endTotalStake), 500, "wrong change in total next round stake")
+                })
+
+                it("should update delegate's lastActiveStakeUpdateRound", async () => {
+                    await bondingManager.unbond(500, {from: delegator})
+                    assert.equal(await bondingManager.lastActiveStakeUpdateRound(transcoder), currentRound+2)
                 })
             })
         })
@@ -1029,6 +1080,11 @@ contract("BondingManager", accounts => {
                     const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
                     // Decrease by 2000 (delegated stake) instead of just 1000 (own bonded stake)
                     assert.equal(startTotalStake.sub(endTotalStake), 2000, "wrong change in total next round stake")
+                })
+
+                it("should set transcoder's lastActiveStakeUpdateRound to 0", async () => {
+                    await bondingManager.unbond(1000, {from: transcoder})
+                    assert.equal(await bondingManager.lastActiveStakeUpdateRound(transcoder), 0)
                 })
             })
 
@@ -1125,20 +1181,26 @@ contract("BondingManager", accounts => {
                 assert.equal(endTotalActiveStake.sub(startTotalActiveStake), 500, "wrong change in nextRoundTotalActiveStake")
             })
 
+            it("should update delegate's lastActiveStakeUpdateRound", async () => {
+                await bondingManager.rebond(unbondingLockID, {from: delegator})
+                assert.equal(await bondingManager.lastActiveStakeUpdateRound(transcoder), currentRound+2)
+            })
+
             it("should evict when rebonding and pool is full", async () => {
                 await bondingManager.bond(1900, transcoder1, {from: transcoder1})
                 await bondingManager.transcoder(5, 10, {from: transcoder1})
                 await bondingManager.bond(1800, transcoder2, {from: transcoder2})
                 await bondingManager.transcoder(5, 10, {from: transcoder2})
-                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder, currentRound))
+                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder))
                 bondingManager.TranscoderEvicted({}).on("data", e => {
                     assert.equal(e.returnValues.transcoder, transcoder2)
                 })
                 await bondingManager.rebond(unbondingLockID, {from: delegator})
-                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder, currentRound+1))
-                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder2, currentRound+1))
-                const pool = await bondingManager.getTranscoderEarningsPoolForRound(transcoder, currentRound+1)
-                assert.equal(pool.totalStake.toNumber(), 1000)
+                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+2)
+                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder))
+                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder2))
+                const pool = await bondingManager.getTranscoderEarningsPoolForRound(transcoder, currentRound+2)
+                assert.equal(pool.totalStake.toNumber(), 2500)
             })
         })
 
@@ -1160,6 +1222,11 @@ contract("BondingManager", accounts => {
                 await bondingManager.rebond(unbondingLockID, {from: delegator})
                 const endTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
                 assert.equal(endTotalActiveStake.sub(startTotalActiveStake), 0, "wrong change in nextRoundTotalActiveStake")
+            })
+
+            it("should not update delegate's lastActiveStakeUpdateRound", async () => {
+                await bondingManager.rebond(unbondingLockID, {from: delegator})
+                assert.equal(await bondingManager.lastActiveStakeUpdateRound(nonTranscoder), 0)
             })
         })
 
@@ -1274,6 +1341,11 @@ contract("BondingManager", accounts => {
                 const endTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
                 assert.equal(endTotalActiveStake.sub(startTotalActiveStake), 500, "wrong change in nextRoundTotalActiveStake")
             })
+
+            it("should update delegate's lastActiveStakeUpdateRound", async () => {
+                await bondingManager.rebondFromUnbonded(transcoder, unbondingLockID, {from: delegator})
+                assert.equal(await bondingManager.lastActiveStakeUpdateRound(transcoder), currentRound+2)
+            })
         })
 
         describe("new delegate is not a registered transcoder", () => {
@@ -1295,6 +1367,11 @@ contract("BondingManager", accounts => {
                 await bondingManager.rebondFromUnbonded(nonTranscoder, unbondingLockID, {from: delegator})
                 const endTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
                 assert.equal(endTotalActiveStake.sub(startTotalActiveStake), 0, "wrong change in nextRoundTotalActiveStake")
+            })
+
+            it("should not update delegate's lastActiveStakeUpdateRound", async () => {
+                await bondingManager.rebondFromUnbonded(nonTranscoder, unbondingLockID, {from: delegator})
+                assert.equal(await bondingManager.lastActiveStakeUpdateRound(nonTranscoder), 0)
             })
         })
 
@@ -1477,7 +1554,8 @@ contract("BondingManager", accounts => {
             assert.equal(earningsPool0[6], 0, "should set transcoder reward pool to 0")
             assert.equal(earningsPool0[7], 0, "should set transcoder fee pool to 0")
             assert.equal(earningsPool0[8], true, "should set hasTranscoderRewardFeePool flag to true")
-            assert.isOk(await bondingManager.isActiveTranscoder(transcoder0, currentRound + 1), "should set transcoder as active for current round")
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
+            assert.isOk(await bondingManager.isActiveTranscoder(transcoder0), "should set transcoder as active for current round")
 
             const tInfo1 = await bondingManager.getTranscoder(transcoder1)
             assert.equal(tInfo1[1], tInfo1[3].toNumber(), "should set rewardCut to pendingRewardCut")
@@ -1493,7 +1571,7 @@ contract("BondingManager", accounts => {
             assert.equal(earningsPool1[7], 0, "should set transcoder fee pool to 0")
             assert.equal(earningsPool1[8], true, "should set hasTranscoderRewardFeePool flag to true")
 
-            assert.isOk(await bondingManager.isActiveTranscoder(transcoder1, currentRound + 1), "should set transcoder as active for current round")
+            assert.isOk(await bondingManager.isActiveTranscoder(transcoder1), "should set transcoder as active for current round")
 
             assert.equal(await bondingManager.nextRoundTotalActiveStake(), 2000, "should set total active stake to sum of total stake of all active transcoders")
         })
@@ -1723,7 +1801,8 @@ contract("BondingManager", accounts => {
                         [transcoder, constants.NULL_ADDRESS, PERC_DIVISOR / 2, 0]
                     )
                 )
-                assert.isNotOk(await bondingManager.isActiveTranscoder(transcoder, currentRound + 2), "should set active transcoder as inactive for the round")
+                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+2)
+                assert.isNotOk(await bondingManager.isActiveTranscoder(transcoder), "should set active transcoder as inactive for the round")
             })
 
             it("deducts the transcoder's stake from the total for the current round", async () => {
@@ -1736,8 +1815,9 @@ contract("BondingManager", accounts => {
                         [transcoder, constants.NULL_ADDRESS, PERC_DIVISOR / 2, 0]
                     )
                 )
+                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+2)
                 const endTotalActiveStake = await bondingManager.currentRoundTotalActiveStake()
-                assert.isNotOk(await bondingManager.isActiveTranscoder(transcoder, currentRound + 2), "should set active transcoder as inactive for the round")
+                assert.isNotOk(await bondingManager.isActiveTranscoder(transcoder), "should set active transcoder as inactive for the round")
                 assert.equal(startTotalActiveStake.sub(endTotalActiveStake).toNumber(), 1000, "should decrease total active stake by total stake of transcoder")
             })
 
@@ -1753,6 +1833,18 @@ contract("BondingManager", accounts => {
                 )
                 const endTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
                 assert.equal(startTotalActiveStake.sub(endTotalActiveStake).toNumber(), 1000, "should decrease total active stake by total stake of transcoder")
+            })
+
+            it("sets the transcoder lastActiveStakeUpdateRound to 0", async () => {
+                await fixture.ticketBroker.execute(
+                    bondingManager.address,
+                    functionEncodedABI(
+                        "slashTranscoder(address,address,uint256,uint256)",
+                        ["address", "uint256", "uint256", "uint256"],
+                        [transcoder, constants.NULL_ADDRESS, PERC_DIVISOR / 2, 0]
+                    )
+                )
+                assert.equal(await bondingManager.lastActiveStakeUpdateRound(transcoder), 0)
             })
         })
 
@@ -1784,8 +1876,9 @@ contract("BondingManager", accounts => {
                         [nonTranscoder, constants.NULL_ADDRESS, PERC_DIVISOR / 2, 0]
                     )
                 )
+                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+2)
                 const endTotalActiveStake = await bondingManager.currentRoundTotalActiveStake()
-                assert.isNotOk(await bondingManager.isActiveTranscoder(nonTranscoder, currentRound + 2), "should remain inactive for the round")
+                assert.isNotOk(await bondingManager.isActiveTranscoder(nonTranscoder), "should remain inactive for the round")
                 assert.equal(startTotalActiveStake.sub(endTotalActiveStake).toNumber(), 0, "should decrease total active stake by total stake of transcoder")
             })
 
@@ -2373,14 +2466,14 @@ contract("BondingManager", accounts => {
         describe("caller is not in transcoder pool", () => {
             it("returns NotRegistered", async () => {
                 await bondingManager.unbond(1000, {from: transcoder})
-
-                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder, currentRound + 1), "should return NotRegistered for caller not in transcoder pool")
+                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
+                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder), "should return NotRegistered for caller not in transcoder pool")
             })
         })
 
         describe("caller is in transcoder pool", () => {
             it("returns Registered", async () => {
-                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder, currentRound), "should return Registered for caller in transcoder pool")
+                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder), "should return Registered for caller in transcoder pool")
             })
         })
     })

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -1,5 +1,6 @@
 import Fixture from "./helpers/Fixture"
 import expectThrow from "../helpers/expectThrow"
+import expectRevertWithReason from "../helpers/expectFail"
 import {contractId, functionSig, functionEncodedABI} from "../../utils/helpers"
 import {constants} from "../../utils/constants"
 import BN from "bn.js"
@@ -123,33 +124,37 @@ contract("BondingManager", accounts => {
         it("should fail if current round is not initialized", async () => {
             await fixture.roundsManager.setMockBool(functionSig("currentRoundInitialized()"), false)
 
-            await expectThrow(bondingManager.transcoder(5, 10, 1))
+            await expectThrow(bondingManager.transcoder(5, 10))
+        })
+
+        it("should fail if the current round is locked", async () => {
+            await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), true)
+
+            await expectRevertWithReason(bondingManager.transcoder(5, 10), "can't update transcoder params, current round is locked")
         })
 
         it("should fail if rewardCut is not a valid percentage <= 100%", async () => {
-            await expectThrow(bondingManager.transcoder(PERC_DIVISOR + 1, 10, 1))
+            await expectThrow(bondingManager.transcoder(PERC_DIVISOR + 1, 10))
         })
 
         it("should fail if feeShare is not a valid percentage <= 100%", async () => {
-            await expectThrow(bondingManager.transcoder(5, PERC_DIVISOR + 1, 1))
+            await expectThrow(bondingManager.transcoder(5, PERC_DIVISOR + 1))
         })
 
         describe("transcoder is not already registered", () => {
             it("should fail if caller is not delegated to self with a non-zero bonded amount", async () => {
-                await expectThrow(bondingManager.transcoder(5, 10, 1))
+                await expectThrow(bondingManager.transcoder(5, 10))
             })
 
-            it("should set transcoder's pending rewardCut, feeShare, and pricePerSegment", async () => {
+            it("should set transcoder's pending rewardCut and feeShare", async () => {
                 await bondingManager.bond(1000, accounts[0])
-                await bondingManager.transcoder(5, 10, 1)
+                await bondingManager.transcoder(5, 10)
 
                 let tInfo = await bondingManager.getTranscoder(accounts[0])
                 assert.equal(tInfo[1], 0, "wrong rewardCut")
                 assert.equal(tInfo[2], 0, "wrong feeShare")
-                assert.equal(tInfo[3], 0, "wrong pricePerSegment")
-                assert.equal(tInfo[4], 5, "wrong pendingRewardCut")
-                assert.equal(tInfo[5], 10, "wrong pendingFeeShare")
-                assert.equal(tInfo[6], 1, "wrong pendingPricePerSegment")
+                assert.equal(tInfo[3], 5, "wrong pendingRewardCut")
+                assert.equal(tInfo[4], 10, "wrong pendingFeeShare")
             })
 
             describe("transcoder pool is not full", () => {
@@ -157,12 +162,11 @@ contract("BondingManager", accounts => {
                     bondingManager.TranscoderUpdate({transcoder: accounts[0]}).on("data", e => {
                         assert.equal(e.returnValues.pendingRewardCut, 5, "should fire TranscoderUpdate event with provided rewardCut")
                         assert.equal(e.returnValues.pendingFeeShare, 10, "should fire TranscoderUpdate event with provided feeShare")
-                        assert.equal(e.returnValues.pendingPricePerSegment, 1, "should fire TranscoderUpdate event with provided pricePerSegment")
                         assert.equal(e.returnValues.args.registered, true, "should fire TranscoderUpdate event with registered set to true")
                     })
 
                     await bondingManager.bond(1000, accounts[0])
-                    await bondingManager.transcoder(5, 10, 1)
+                    await bondingManager.transcoder(5, 10)
 
                     assert.equal(await bondingManager.getTotalBonded(), 1000, "wrong total bonded")
                     assert.equal(await bondingManager.getTranscoderPoolSize(), 1, "wrong transcoder pool size")
@@ -172,9 +176,9 @@ contract("BondingManager", accounts => {
 
                 it("should add multiple additional transcoders to the pool", async () => {
                     await bondingManager.bond(2000, accounts[0])
-                    await bondingManager.transcoder(5, 10, 1)
+                    await bondingManager.transcoder(5, 10)
                     await bondingManager.bond(1000, accounts[1], {from: accounts[1]})
-                    await bondingManager.transcoder(5, 10, 1, {from: accounts[1]})
+                    await bondingManager.transcoder(5, 10, {from: accounts[1]})
 
                     assert.equal(await bondingManager.getTotalBonded(), 3000, "wrong total bonded")
                     assert.equal(await bondingManager.getTranscoderPoolSize(), 2, "wrong transcoder pool size")
@@ -193,14 +197,13 @@ contract("BondingManager", accounts => {
 
                         await Promise.all(transcoders.map((account, idx) => {
                             return bondingManager.bond(1000 * (idx + 1), account, {from: account}).then(() => {
-                                return bondingManager.transcoder(5, 10, 1, {from: account})
+                                return bondingManager.transcoder(5, 10, {from: account})
                             })
                         }))
 
                         bondingManager.TranscoderUpdate({transcoder: newTranscoder}).on("data", e => {
                             assert.equal(e.returnValues.pendingRewardCut, 5, "should fire TranscoderUpdate event with provided rewardCut")
                             assert.equal(e.returnValues.pendingFeeShare, 10, "should fire TranscoderUpdate event with provided feeShare")
-                            assert.equal(e.returnValues.pendingPricePerSegment, 1, "should fire TranscoderUpdate event with provided pricePerSegment")
                             assert.equal(e.returnValues.registered, true, "should fire TranscoderUpdate event with registered set to true")
                         })
 
@@ -208,7 +211,7 @@ contract("BondingManager", accounts => {
 
                         // Caller bonds 6000 which is more than transcoder with least delegated stake
                         await bondingManager.bond(6000, newTranscoder, {from: newTranscoder})
-                        await bondingManager.transcoder(5, 10, 1, {from: newTranscoder})
+                        await bondingManager.transcoder(5, 10, {from: newTranscoder})
 
                         // Subtract evicted transcoder's delegated stake and add new transcoder's delegated stake
                         const expTotalBonded = totalBonded - 1000 + 6000
@@ -228,20 +231,19 @@ contract("BondingManager", accounts => {
 
                         await Promise.all(transcoders.map(account => {
                             return bondingManager.bond(2000, account, {from: account}).then(() => {
-                                return bondingManager.transcoder(5, 10, 1, {from: account})
+                                return bondingManager.transcoder(5, 10, {from: account})
                             })
                         }))
 
                         bondingManager.TranscoderUpdate({transcoder: newTranscoder}).on("data", e => {
                             assert.equal(e.returnValues.pendingRewardCut, 5, "should fire TranscoderUpdate event with provided rewardCut")
                             assert.equal(e.returnValues.pendingFeeShare, 10, "should fire TranscoderUpdate event with provided feeShare")
-                            assert.equal(e.returnValues.pendingPricePerSegment, 1, "should fire TranscoderUpdate event with provided pricePerSegment")
                             assert.equal(e.returnValues.registered, false, "should fire TranscoderUpdate event with registered set to true")
                         })
 
                         // Caller bonds 600 - less than transcoder with least delegated stake
                         await bondingManager.bond(600, newTranscoder, {from: newTranscoder})
-                        await bondingManager.transcoder(5, 10, 1, {from: newTranscoder})
+                        await bondingManager.transcoder(5, 10, {from: newTranscoder})
 
                         assert.equal(await bondingManager.transcoderStatus(newTranscoder), TranscoderStatus.NotRegistered, "should not register caller as a transcoder in the pool")
                     })
@@ -252,20 +254,19 @@ contract("BondingManager", accounts => {
 
                         await Promise.all(transcoders.map(account => {
                             return bondingManager.bond(2000, account, {from: account}).then(() => {
-                                return bondingManager.transcoder(5, 10, 1, {from: account})
+                                return bondingManager.transcoder(5, 10, {from: account})
                             })
                         }))
 
                         bondingManager.TranscoderUpdate({transcoder: newTranscoder}).on("data", e => {
                             assert.equal(e.returnValues.pendingRewardCut, 5, "should fire TranscoderUpdate event with provided rewardCut")
                             assert.equal(e.returnValues.pendingFeeShare, 10, "should fire TranscoderUpdate event with provided feeShare")
-                            assert.equal(e.returnValues.pendingPricePerSegment, 1, "should fire TranscoderUpdate event with provided pricePerSegment")
                             assert.equal(e.returnValues.registered, false, "should fire TranscoderUpdate event with registered set to true")
                         })
 
                         // Caller bonds 2000 - same as transcoder with least delegated stake
                         await bondingManager.bond(2000, newTranscoder, {from: newTranscoder})
-                        await bondingManager.transcoder(5, 10, 1, {from: newTranscoder})
+                        await bondingManager.transcoder(5, 10, {from: newTranscoder})
 
                         assert.equal(await bondingManager.transcoderStatus(newTranscoder), TranscoderStatus.NotRegistered, "should not register caller as a transcoder in the pool")
                     })
@@ -274,110 +275,23 @@ contract("BondingManager", accounts => {
         })
 
         describe("transcoder is already registered", () => {
-            it("should update transcoder's pending rewardCut, feeShare, and pricePerSegment", async () => {
+            it("should update transcoder's pending rewardCut and feeShare", async () => {
                 await bondingManager.bond(1000, accounts[0])
-                await bondingManager.transcoder(5, 10, 1)
+                await bondingManager.transcoder(5, 10)
 
                 let tInfo = await bondingManager.getTranscoder(accounts[0])
                 assert.equal(tInfo[1], 0, "wrong rewardCut")
                 assert.equal(tInfo[2], 0, "wrong feeShare")
-                assert.equal(tInfo[3], 0, "wrong pricePerSegment")
-                assert.equal(tInfo[4], 5, "wrong pendingRewardCut")
-                assert.equal(tInfo[5], 10, "wrong pendingFeeShare")
-                assert.equal(tInfo[6], 1, "wrong pendingPricePerSegment")
+                assert.equal(tInfo[3], 5, "wrong pendingRewardCut")
+                assert.equal(tInfo[4], 10, "wrong pendingFeeShare")
 
-                await bondingManager.transcoder(10, 15, 4)
+                await bondingManager.transcoder(10, 15)
 
                 tInfo = await bondingManager.getTranscoder(accounts[0])
                 assert.equal(tInfo[1], 0, "wrong rewardCut")
                 assert.equal(tInfo[2], 0, "wrong feeShare")
-                assert.equal(tInfo[3], 0, "wrong pricePerSegment")
-                assert.equal(tInfo[4], 10, "wrong pendingRewardCut")
-                assert.equal(tInfo[5], 15, "wrong pendingFeeShare")
-                assert.equal(tInfo[6], 4, "wrong pendingPricePerSegment")
-            })
-
-            describe("current round is in lock period", () => {
-                beforeEach(async () => {
-                    await bondingManager.bond(1000, accounts[0], {from: accounts[0]})
-                    await bondingManager.transcoder(5, 10, 5, {from: accounts[0]})
-
-                    await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), true)
-                })
-
-                it("should fail if caller is not a registered transcoder", async () => {
-                    await expectThrow(bondingManager.transcoder(5, 10, 6, {from: accounts[2]}))
-                })
-
-                it("should fail if provided rewardCut != previously set pendingRewardCut", async () => {
-                    await expectThrow(bondingManager.transcoder(6, 10, 5, {from: accounts[0]}))
-                })
-
-                it("should fail if provided feeShare != previously set pendingFeeShare", async () => {
-                    await expectThrow(bondingManager.transcoder(5, 11, 5, {from: accounts[0]}))
-                })
-
-                describe("1 transcoder in the pool", () => {
-                    it("should fail if provided pricePerSegment is > previously set pendingPricePerSegment", async () => {
-                        await expectThrow(bondingManager.transcoder(5, 10, 6, {from: accounts[0]}))
-                    })
-
-                    it("should fail if provided pricePerSegment is < current price floor (transcoder's own price)", async () => {
-                        await expectThrow(bondingManager.transcoder(5, 10, 4, {from: accounts[0]}))
-                    })
-
-                    it("should set new pricePerSegment that is >= current price floor and <= previously set pendingPricePerSegment", async () => {
-                        // The only thing the caller can do is to set the price to its previously set pendingPricePerSegment
-                        await bondingManager.transcoder(5, 10, 5, {from: accounts[0]})
-
-                        const tInfo = await bondingManager.getTranscoder(accounts[0])
-                        assert.equal(tInfo[4], 5, "should not change pendingRewardCut")
-                        assert.equal(tInfo[5], 10, "should not change pendingFeeShare")
-                        assert.equal(tInfo[6], 5, "should not change pendingPricePerSegment")
-                    })
-                })
-
-                describe("2 transcoders in the pool", () => {
-                    describe("lowest price transcoder is first in pool", () => {
-                        beforeEach(async () => {
-                            await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), false)
-
-                            await bondingManager.bond(2000, accounts[1], {from: accounts[1]})
-                            await bondingManager.transcoder(5, 10, 2, {from: accounts[1]})
-
-                            await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), true)
-                        })
-
-                        it("should set new pricePerSegment that is >= current price floor and <= previously set pendingPricePerSegment", async () => {
-                            await bondingManager.transcoder(5, 10, 2, {from: accounts[0]})
-
-                            const tInfo = await bondingManager.getTranscoder(accounts[0])
-                            assert.equal(tInfo[4], 5, "should not change pendingRewardCut")
-                            assert.equal(tInfo[5], 10, "should not change pendingFeeShare")
-                            assert.equal(tInfo[6], 2, "should change pendingPricePerSegment to provided value")
-                        })
-                    })
-
-                    describe("lowest price transcoder is not first in pool", () => {
-                        beforeEach(async () => {
-                            await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), false)
-
-                            await bondingManager.bond(500, accounts[1], {from: accounts[1]})
-                            await bondingManager.transcoder(5, 10, 2, {from: accounts[1]})
-
-                            await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), true)
-                        })
-
-                        it("should set new pricePerSegment that is >= current price floor and <= previously set pendingPricePerSegment", async () => {
-                            await bondingManager.transcoder(5, 10, 2, {from: accounts[0]})
-
-                            const tInfo = await bondingManager.getTranscoder(accounts[0])
-                            assert.equal(tInfo[4], 5, "should not change pendingRewardCut")
-                            assert.equal(tInfo[5], 10, "should not change pendingFeeShare")
-                            assert.equal(tInfo[6], 2, "should change pendingPricePerSegment to provided value")
-                        })
-                    })
-                })
+                assert.equal(tInfo[3], 10, "wrong pendingRewardCut")
+                assert.equal(tInfo[4], 15, "wrong pendingFeeShare")
             })
         })
     })
@@ -396,9 +310,9 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder0, {from: transcoder0})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder0})
+            await bondingManager.transcoder(5, 10, {from: transcoder0})
             await bondingManager.bond(2000, transcoder1, {from: transcoder1})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder1})
+            await bondingManager.transcoder(5, 10, {from: transcoder1})
             await bondingManager.bond(1000, nonTranscoder, {from: nonTranscoder})
         })
 
@@ -796,7 +710,7 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder})
+            await bondingManager.transcoder(5, 10, {from: transcoder})
             await bondingManager.bond(1000, transcoder, {from: delegator})
             await bondingManager.bond(1000, delegator, {from: delegator2})
 
@@ -971,7 +885,7 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder})
+            await bondingManager.transcoder(5, 10, {from: transcoder})
             await bondingManager.bond(1000, transcoder, {from: delegator})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
@@ -1069,7 +983,7 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder})
+            await bondingManager.transcoder(5, 10, {from: transcoder})
             await bondingManager.bond(1000, transcoder, {from: delegator})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
@@ -1194,7 +1108,7 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder})
+            await bondingManager.transcoder(5, 10, {from: transcoder})
             await bondingManager.bond(1000, transcoder, {from: delegator})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
@@ -1258,9 +1172,9 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder0, {from: transcoder0})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder0})
+            await bondingManager.transcoder(5, 10, {from: transcoder0})
             await bondingManager.bond(1000, transcoder1, {from: transcoder1})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder1})
+            await bondingManager.transcoder(5, 10, {from: transcoder1})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
             await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
@@ -1313,9 +1227,9 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder0, {from: transcoder0})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder0})
+            await bondingManager.transcoder(5, 10, {from: transcoder0})
             await bondingManager.bond(1000, transcoder1, {from: transcoder1})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder1})
+            await bondingManager.transcoder(5, 10, {from: transcoder1})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
         })
@@ -1334,9 +1248,8 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
 
             const tInfo0 = await bondingManager.getTranscoder(transcoder0)
-            assert.equal(tInfo0[1], tInfo0[4].toNumber(), "should set rewardCut to pendingRewardCut")
-            assert.equal(tInfo0[2], tInfo0[5].toNumber(), "should set feeShare to pendingFeeShare")
-            assert.equal(tInfo0[3], tInfo0[6].toNumber(), "should set pricePerSegment to pendingPricePerSegment")
+            assert.equal(tInfo0[1], tInfo0[3].toNumber(), "should set rewardCut to pendingRewardCut")
+            assert.equal(tInfo0[2], tInfo0[4].toNumber(), "should set feeShare to pendingFeeShare")
             const earningsPool0 = await bondingManager.getTranscoderEarningsPoolForRound(transcoder0, currentRound + 1)
             assert.equal(earningsPool0[0], 0, "should set delegator reward pool to 0")
             assert.equal(earningsPool0[1], 0, "should set delegator fee pool to 0")
@@ -1350,9 +1263,8 @@ contract("BondingManager", accounts => {
             assert.isOk(await bondingManager.isActiveTranscoder(transcoder0, currentRound + 1), "should set transcoder as active for current round")
 
             const tInfo1 = await bondingManager.getTranscoder(transcoder1)
-            assert.equal(tInfo1[1], tInfo1[4].toNumber(), "should set rewardCut to pendingRewardCut")
-            assert.equal(tInfo1[2], tInfo1[5].toNumber(), "should set feeShare to pendingFeeShare")
-            assert.equal(tInfo1[3], tInfo1[6].toNumber(), "should set pricePerSegment to pendingPricePerSegment")
+            assert.equal(tInfo1[1], tInfo1[3].toNumber(), "should set rewardCut to pendingRewardCut")
+            assert.equal(tInfo1[2], tInfo1[4].toNumber(), "should set feeShare to pendingFeeShare")
             const earningsPool1 = await bondingManager.getTranscoderEarningsPoolForRound(transcoder1, currentRound + 1)
             assert.equal(earningsPool1[0], 0, "should set delegator reward pool to 0")
             assert.equal(earningsPool1[1], 0, "should set delegator fee pool to 0")
@@ -1381,7 +1293,7 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder})
+            await bondingManager.transcoder(5, 10, {from: transcoder})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
             await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
@@ -1440,7 +1352,7 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder})
+            await bondingManager.transcoder(5, 10, {from: transcoder})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
         })
@@ -1503,7 +1415,7 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder})
+            await bondingManager.transcoder(5, 10, {from: transcoder})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
             await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
@@ -1699,80 +1611,6 @@ contract("BondingManager", accounts => {
         })
     })
 
-    describe("electActiveTranscoder", () => {
-        const transcoder0 = accounts[0]
-        const transcoder1 = accounts[1]
-        const currentRound = 100
-
-        beforeEach(async () => {
-            await fixture.roundsManager.setMockBool(functionSig("currentRoundInitialized()"), true)
-            await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), false)
-            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
-
-            await bondingManager.bond(2000, transcoder0, {from: transcoder0})
-            await bondingManager.transcoder(5, 10, 5, {from: transcoder0})
-            await bondingManager.bond(1000, transcoder1, {from: transcoder1})
-            await bondingManager.transcoder(5, 10, 10, {from: transcoder1})
-
-            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
-            await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
-        })
-
-        it("should exclude transcoders with a price > provided maxPricePerSegment", async () => {
-            assert.equal(
-                await bondingManager.electActiveTranscoder(6, web3.utils.sha3("foo"), currentRound + 1),
-                transcoder0,
-                "should exclude transcoder with price > provided maxPricePerSegment"
-            )
-        })
-
-        it("should not exclude transcoders with a price = provided maxPricePerSegment", async () => {
-            assert.equal(
-                await bondingManager.electActiveTranscoder(5, web3.utils.sha3("foo"), currentRound + 1),
-                transcoder0,
-                "should not exclude transcoder with price = provided maxPricePerSegment"
-            )
-        })
-
-        it("should return null address if there are no transcoders with a price <= provided maxPricePerSegment", async () => {
-            assert.equal(
-                await bondingManager.electActiveTranscoder(2, web3.utils.sha3("foo"), currentRound + 1),
-                constants.NULL_ADDRESS,
-                "should return null address if there are no transcoders with a price <= provided maxPricePerSegment"
-            )
-        })
-
-        it("should return null address if there are no active transcoders", async () => {
-            await bondingManager.unbond(2000, {from: transcoder0})
-            await bondingManager.unbond(1000, {from: transcoder1})
-
-            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 2)
-            await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
-
-            assert.equal(
-                await bondingManager.electActiveTranscoder(6, web3.utils.sha3("foo"), currentRound + 2),
-                constants.NULL_ADDRESS,
-                "should return null address if there are no active transcoders"
-            )
-        })
-
-        it("should return a transcoder if there is only one available active transcoder", async () => {
-            await bondingManager.unbond(2000, {from: transcoder0})
-
-            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 2)
-            await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
-
-            assert.equal(
-                await bondingManager.electActiveTranscoder(10, web3.utils.sha3("foo"), currentRound + 2),
-                transcoder1,
-                "should return a transcoder if there is only one available active transcoder"
-            )
-        })
-
-        // There is already an integration test for the random weighted selection based on stake
-        // TBD whether we should include a test for the weighted selection here as well...
-    })
-
     describe("claimEarnings", () => {
         const transcoder = accounts[0]
         const delegator1 = accounts[1]
@@ -1791,7 +1629,7 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
-            await bondingManager.transcoder(50 * PERC_MULTIPLIER, 25 * PERC_MULTIPLIER, 1, {from: transcoder})
+            await bondingManager.transcoder(50 * PERC_MULTIPLIER, 25 * PERC_MULTIPLIER, {from: transcoder})
             await bondingManager.bond(3000, transcoder, {from: delegator1})
             await bondingManager.bond(3000, transcoder, {from: delegator2})
             await bondingManager.bond(3000, transcoder, {from: delegator3})
@@ -2047,7 +1885,7 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
-            await bondingManager.transcoder(50 * PERC_MULTIPLIER, 25 * PERC_MULTIPLIER, 1, {from: transcoder})
+            await bondingManager.transcoder(50 * PERC_MULTIPLIER, 25 * PERC_MULTIPLIER, {from: transcoder})
             await bondingManager.bond(1000, transcoder, {from: delegator})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
@@ -2148,7 +1986,7 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
-            await bondingManager.transcoder(50 * PERC_MULTIPLIER, 25 * PERC_MULTIPLIER, 1, {from: transcoder})
+            await bondingManager.transcoder(50 * PERC_MULTIPLIER, 25 * PERC_MULTIPLIER, {from: transcoder})
             await bondingManager.bond(1000, transcoder, {from: delegator})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
@@ -2244,7 +2082,7 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder})
+            await bondingManager.transcoder(5, 10, {from: transcoder})
         })
 
         it("should fail if transcoder is not active", async () => {
@@ -2268,7 +2106,7 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder})
+            await bondingManager.transcoder(5, 10, {from: transcoder})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
         })
@@ -2356,7 +2194,7 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
-            await bondingManager.transcoder(5, 10, 1, {from: transcoder})
+            await bondingManager.transcoder(5, 10, {from: transcoder})
         })
 
         describe("address is registered transcoder", () => {

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -620,8 +620,8 @@ contract("BondingManager", accounts => {
 
                         describe("old delegate is not registered transcoder", () => {
                             it("should increase total bonded", async () => {
-                                // Delegate to non-transcoder i.e. self
-                                await bondingManager.bond(0, delegator, {from: delegator})
+                                // Delegate to non-transcoder
+                                await bondingManager.bond(0, nonTranscoder, {from: delegator})
 
                                 const startTotalBonded = await bondingManager.getTotalBonded()
                                 await bondingManager.bond(0, transcoder1, {from: delegator})
@@ -636,7 +636,7 @@ contract("BondingManager", accounts => {
                         describe("old delegate is registered transcoder", () => {
                             it("should decrease total bonded", async () => {
                                 const startTotalBonded = await bondingManager.getTotalBonded()
-                                await bondingManager.bond(0, delegator, {from: delegator})
+                                await bondingManager.bond(0, nonTranscoder, {from: delegator})
                                 const endTotalBonded = await bondingManager.getTotalBonded()
 
                                 assert.equal(startTotalBonded.sub(endTotalBonded), 2000, "wrong change in total bonded")
@@ -645,8 +645,8 @@ contract("BondingManager", accounts => {
 
                         describe("old delegate is not registered transcoder", () => {
                             it("should not change total bonded", async () => {
-                                // Delegate to non-transcoder i.e. self
-                                await bondingManager.bond(0, delegator, {from: delegator})
+                                // Delegate to non-transcoder
+                                await bondingManager.bond(0, nonTranscoder, {from: delegator})
 
                                 const startTotalBonded = await bondingManager.getTotalBonded()
                                 await bondingManager.bond(0, delegator2, {from: delegator})
@@ -733,8 +733,8 @@ contract("BondingManager", accounts => {
 
                         describe("old delegate is not registered transcoder", () => {
                             it("should increase total bonded by current bonded stake + additional bonded stake", async () => {
-                                // Delegate to non-transcoder i.e. self
-                                await bondingManager.bond(0, delegator, {from: delegator})
+                                // Delegate to non-transcoder
+                                await bondingManager.bond(0, nonTranscoder, {from: delegator})
 
                                 const bondedAmount = (await bondingManager.getDelegator(delegator))[0].toNumber()
                                 const startTotalBonded = await bondingManager.getTotalBonded()
@@ -751,7 +751,7 @@ contract("BondingManager", accounts => {
                             it("should decrease total bonded by current bonded stake (no additional bonded stake counted)", async () => {
                                 const bondedAmount = (await bondingManager.getDelegator(delegator))[0].toNumber()
                                 const startTotalBonded = await bondingManager.getTotalBonded()
-                                await bondingManager.bond(1000, delegator, {from: delegator})
+                                await bondingManager.bond(1000, nonTranscoder, {from: delegator})
                                 const endTotalBonded = await bondingManager.getTotalBonded()
 
                                 assert.equal(startTotalBonded.sub(endTotalBonded), bondedAmount, "wrong change in totalBonded")
@@ -759,7 +759,7 @@ contract("BondingManager", accounts => {
 
                             it("should decrease the total stake for the next round", async () => {
                                 const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
-                                await bondingManager.bond(1000, delegator, {from: delegator})
+                                await bondingManager.bond(1000, nonTranscoder, {from: delegator})
                                 const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
                                 assert.equal(startTotalStake.sub(endTotalStake).toString(), 2000, "wrong change in total next round stake")
                             })
@@ -1082,9 +1082,9 @@ contract("BondingManager", accounts => {
                     assert.equal(startTotalStake.sub(endTotalStake), 2000, "wrong change in total next round stake")
                 })
 
-                it("should set transcoder's lastActiveStakeUpdateRound to 0", async () => {
+                it("sets transcoder's activation round to 0", async () => {
                     await bondingManager.unbond(1000, {from: transcoder})
-                    assert.equal(await bondingManager.lastActiveStakeUpdateRound(transcoder), 0)
+                    assert.equal((await bondingManager.getTranscoder(transcoder)).activationRound, 0)
                 })
             })
 
@@ -1200,7 +1200,7 @@ contract("BondingManager", accounts => {
                 assert.isTrue(await bondingManager.isActiveTranscoder(transcoder))
                 assert.isFalse(await bondingManager.isActiveTranscoder(transcoder2))
                 const pool = await bondingManager.getTranscoderEarningsPoolForRound(transcoder, currentRound+2)
-                assert.equal(pool.totalStake.toNumber(), 2500)
+                assert.equal(pool.totalStake.toNumber(), 2000)
             })
         })
 
@@ -1835,7 +1835,7 @@ contract("BondingManager", accounts => {
                 assert.equal(startTotalActiveStake.sub(endTotalActiveStake).toNumber(), 1000, "should decrease total active stake by total stake of transcoder")
             })
 
-            it("sets the transcoder lastActiveStakeUpdateRound to 0", async () => {
+            it("sets the transcoder's activation round to 0", async () => {
                 await fixture.ticketBroker.execute(
                     bondingManager.address,
                     functionEncodedABI(
@@ -1844,7 +1844,7 @@ contract("BondingManager", accounts => {
                         [transcoder, constants.NULL_ADDRESS, PERC_DIVISOR / 2, 0]
                     )
                 )
-                assert.equal(await bondingManager.lastActiveStakeUpdateRound(transcoder), 0)
+                assert.equal((await bondingManager.getTranscoder(transcoder)).activationRound, 0)
             })
         })
 

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -7,13 +7,12 @@ import BN from "bn.js"
 
 const BondingManager = artifacts.require("BondingManager")
 
-const {DelegatorStatus, TranscoderStatus} = constants
+const {DelegatorStatus} = constants
 
 contract("BondingManager", accounts => {
     let fixture
     let bondingManager
 
-    const NUM_TRANSCODERS = 5
     const NUM_ACTIVE_TRANSCODERS = 2
     const UNBONDING_PERIOD = 2
     const MAX_EARNINGS_CLAIMS_ROUNDS = 20
@@ -28,7 +27,6 @@ contract("BondingManager", accounts => {
         bondingManager = await fixture.deployAndRegister(BondingManager, "BondingManager", fixture.controller.address)
 
         await bondingManager.setUnbondingPeriod(UNBONDING_PERIOD)
-        await bondingManager.setNumTranscoders(NUM_TRANSCODERS)
         await bondingManager.setNumActiveTranscoders(NUM_ACTIVE_TRANSCODERS)
         await bondingManager.setMaxEarningsClaimsRounds(MAX_EARNINGS_CLAIMS_ROUNDS)
     })
@@ -65,41 +63,15 @@ contract("BondingManager", accounts => {
         })
     })
 
-    describe("setNumTranscoders", () => {
-        it("should fail if caller is not Controller owner", async () => {
-            await expectThrow(bondingManager.setNumTranscoders(15, {from: accounts[2]}))
-        })
-
-        it("should fail if provided numTranscoders < current numActiveTranscoders", async () => {
-            await expectThrow(bondingManager.setNumTranscoders(1))
-        })
-
-        it("should fail if provided numTranscoders < current numTranscoders", async () => {
-            // This is a limitation of the sorted doubly linked list implementation used
-            // to track the transcoder pool
-            await expectThrow(bondingManager.setNumTranscoders(4))
-        })
-
-        it("should set the max size of the transcoder pool", async () => {
-            await bondingManager.setNumTranscoders(15)
-
-            assert.equal(await bondingManager.getTranscoderPoolMaxSize(), 15, "wrong transcoder pool max size")
-        })
-    })
-
     describe("setNumActiveTranscoders", () => {
         it("should fail if caller is not Controller owner", async () => {
             await expectThrow(bondingManager.setNumActiveTranscoders(7, {from: accounts[2]}))
         })
 
-        it("should fail if provided numActiveTranscoders > current max size of transcoder pool", async () => {
-            await expectThrow(bondingManager.setNumActiveTranscoders(11))
-        })
-
         it("should set numActiveTranscoders", async () => {
             await bondingManager.setNumActiveTranscoders(4)
 
-            assert.equal(await bondingManager.numActiveTranscoders.call(), 4, "wrong numActiveTranscoders")
+            assert.equal(await bondingManager.getTranscoderPoolMaxSize(), 4, "wrong numActiveTranscoders")
         })
     })
 
@@ -116,9 +88,11 @@ contract("BondingManager", accounts => {
     })
 
     describe("transcoder", () => {
+        const currentRound = 100
         beforeEach(async () => {
             await fixture.roundsManager.setMockBool(functionSig("currentRoundInitialized()"), true)
             await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), false)
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
         })
 
         it("should fail if current round is not initialized", async () => {
@@ -192,8 +166,8 @@ contract("BondingManager", accounts => {
             describe("transcoder pool is full", () => {
                 describe("caller has sufficient delegated stake to join pool", () => {
                     it("should evict the transcoder with the least delegated stake and add new transcoder to the pool", async () => {
-                        const transcoders = accounts.slice(0, 5)
-                        const newTranscoder = accounts[5]
+                        const transcoders = accounts.slice(0, 2)
+                        const newTranscoder = accounts[3]
 
                         await Promise.all(transcoders.map((account, idx) => {
                             return bondingManager.bond(1000 * (idx + 1), account, {from: account}).then(() => {
@@ -215,12 +189,13 @@ contract("BondingManager", accounts => {
 
                         // Subtract evicted transcoder's delegated stake and add new transcoder's delegated stake
                         const expTotalBonded = totalBonded - 1000 + 6000
-                        assert.equal(await bondingManager.getTotalBonded(), expTotalBonded, "wrong total bonded")
+                        assert.equal((await bondingManager.getTotalBonded()).toString(), expTotalBonded, "wrong total bonded")
 
-                        assert.equal(await bondingManager.transcoderStatus(newTranscoder), TranscoderStatus.Registered, "caller should be registered as transocder")
-                        assert.equal(await bondingManager.getTranscoderPoolSize(), 5, "wrong transcoder pool size")
+                        assert.isTrue(await bondingManager.isActiveTranscoder(newTranscoder, currentRound+1), "caller should be registered as transocder")
+                        assert.equal(await bondingManager.getTranscoderPoolSize(), 2, "wrong transcoder pool size")
+                        assert.equal(await bondingManager.getTranscoderPoolMaxSize(), 2, "wrong transcoder pool max size")
                         assert.equal(await bondingManager.transcoderTotalStake(newTranscoder), 6000, "wrong transcoder total stake")
-                        assert.equal(await bondingManager.transcoderStatus(accounts[0]), TranscoderStatus.NotRegistered, "transcoder with least delegated stake should be evicted")
+                        assert.isFalse(await bondingManager.isActiveTranscoder(accounts[0], currentRound+1), "transcoder with least delegated stake should be evicted")
                     })
                 })
 
@@ -245,7 +220,7 @@ contract("BondingManager", accounts => {
                         await bondingManager.bond(600, newTranscoder, {from: newTranscoder})
                         await bondingManager.transcoder(5, 10, {from: newTranscoder})
 
-                        assert.equal(await bondingManager.transcoderStatus(newTranscoder), TranscoderStatus.NotRegistered, "should not register caller as a transcoder in the pool")
+                        assert.isFalse(await bondingManager.isActiveTranscoder(newTranscoder, currentRound+1), "should not register caller as a transcoder in the pool")
                     })
 
                     it("should not add caller with equal delegated stake to transcoder with least delegated stake in pool", async () => {
@@ -268,7 +243,7 @@ contract("BondingManager", accounts => {
                         await bondingManager.bond(2000, newTranscoder, {from: newTranscoder})
                         await bondingManager.transcoder(5, 10, {from: newTranscoder})
 
-                        assert.equal(await bondingManager.transcoderStatus(newTranscoder), TranscoderStatus.NotRegistered, "should not register caller as a transcoder in the pool")
+                        assert.isFalse(await bondingManager.isActiveTranscoder(newTranscoder, currentRound+1), "should not register caller as a transcoder in the pool")
                     })
                 })
             })
@@ -299,7 +274,8 @@ contract("BondingManager", accounts => {
     describe("bond", () => {
         const transcoder0 = accounts[0]
         const transcoder1 = accounts[1]
-        const nonTranscoder = accounts[2]
+        const transcoder2 = accounts[2]
+        const nonTranscoder = accounts[9]
         const delegator = accounts[3]
         const delegator2 = accounts[4]
         const currentRound = 100
@@ -307,19 +283,78 @@ contract("BondingManager", accounts => {
         beforeEach(async () => {
             await fixture.roundsManager.setMockBool(functionSig("currentRoundInitialized()"), true)
             await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), false)
-            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound-1)
 
             await bondingManager.bond(1000, transcoder0, {from: transcoder0})
             await bondingManager.transcoder(5, 10, {from: transcoder0})
             await bondingManager.bond(2000, transcoder1, {from: transcoder1})
             await bondingManager.transcoder(5, 10, {from: transcoder1})
-            await bondingManager.bond(1000, nonTranscoder, {from: nonTranscoder})
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
         })
 
         it("should fail if current round is not initialized", async () => {
             await fixture.roundsManager.setMockBool(functionSig("currentRoundInitialized()"), false)
 
             await expectThrow(bondingManager.bond(1000, transcoder0, {from: delegator}))
+        })
+
+        describe("update transcoder pool", () => {
+            beforeEach(async () => {
+                await bondingManager.bond(500, transcoder2, {from: transcoder2})
+                await bondingManager.transcoder(5, 10, {from: transcoder2})
+                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
+                await fixture.roundsManager.execute(bondingManager.address, functionSig("setCurrentRoundTotalActiveStake()"))
+            })
+
+            it("adds a new transcoder to the pool", async () => {
+                await bondingManager.bond(1000, transcoder2, {from: delegator})
+                const firstTranscoder = await bondingManager.getFirstTranscoderInPool()
+                const firstStake = await bondingManager.transcoderTotalStake(firstTranscoder)
+                const secondTranscoder = await bondingManager.getNextTranscoderInPool(firstTranscoder)
+                const secondStake = await bondingManager.transcoderTotalStake(secondTranscoder)
+                const firstDel = await bondingManager.getDelegator(firstTranscoder)
+                const secondDel = await bondingManager.getDelegator(secondTranscoder)
+                assert.equal(firstTranscoder, transcoder1)
+                assert.equal(firstStake.toString(), firstDel.delegatedAmount.toString())
+                assert.equal(await bondingManager.getNextTranscoderInPool(firstTranscoder), transcoder2)
+                assert.equal(secondStake.toString(), secondDel.delegatedAmount.toString())
+            })
+
+            it("evicts a transcoder from the pool", async () => {
+                bondingManager.TranscoderEvicted({}).on("data", e => {
+                    assert.equal(e.returnValues.transcoder, transcoder0)
+                })
+                await bondingManager.bond(2000, transcoder2, {from: delegator})
+                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder2, currentRound+2))
+                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder1, currentRound))
+                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder0, currentRound+2))
+                assert.equal((await bondingManager.transcoderTotalStake(transcoder2)).toString(), "2500")
+            })
+
+            it("inserts into pool without evicting if pool is not full", async () => {
+                await bondingManager.unbond(2000, {from: transcoder1})
+                await bondingManager.bond(2500, transcoder2, {from: delegator})
+                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder2, currentRound+2))
+                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder0, currentRound))
+                // transcoder 2 should be first
+                assert.equal(await bondingManager.getFirstTranscoderInPool(), transcoder2)
+            })
+
+            it("doesn't insert into pool when stake is too low", async () => {
+                await bondingManager.bond(10, transcoder2, {from: delegator})
+                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder2, currentRound+2))
+            })
+
+            it("activates and deactivates transcoders on the earningspool", async () => {
+                // evict transcoder0 from the pool
+                await bondingManager.bond(2000, transcoder2, {from: delegator})
+                const poolT2 = await bondingManager.getTranscoderEarningsPoolForRound(transcoder2, currentRound+2)
+                const poolT0 = await bondingManager.getTranscoderEarningsPoolForRound(transcoder0, currentRound+2)
+                assert.isTrue(poolT2.active)
+                assert.equal(poolT2.totalStake.toString(), "2500")
+                assert.isFalse(poolT0.active)
+                assert.equal(poolT0.totalStake.toString(), "0")
+            })
         })
 
         describe("caller is unbonded", () => {
@@ -375,18 +410,31 @@ contract("BondingManager", accounts => {
 
                 it("should update delegate's position in transcoder pool", async () => {
                     await bondingManager.bond(3000, transcoder0, {from: delegator})
+                    assert.equal(await bondingManager.getFirstTranscoderInPool(), transcoder0, "did not correctly update position in transcoder pool")
+                })
 
-                    assert.equal((await bondingManager.getFirstTranscoderInPool()), transcoder0, "did not correctly update position in transcoder pool")
+                it("should increase the total stake for the next round", async () => {
+                    const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                    await bondingManager.bond(3000, transcoder0, {from: delegator})
+                    const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                    assert.equal(endTotalStake.sub(startTotalStake), 3000)
                 })
             })
 
             describe("delegate is not a registered transcoder", () => {
                 it("should not update total bonded", async () => {
                     const startTotalBonded = await bondingManager.getTotalBonded()
-                    await bondingManager.bond(1000, delegator, {from: delegator})
+                    await bondingManager.bond(1000, nonTranscoder, {from: delegator})
                     const endTotalBonded = await bondingManager.getTotalBonded()
 
                     assert.equal(endTotalBonded.sub(startTotalBonded), 0, "wrong change in total bonded")
+                })
+
+                it("should not update total active stake for the next round", async () => {
+                    const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                    await bondingManager.bond(1000, nonTranscoder, {from: delegator})
+                    const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                    assert.equal(startTotalStake.sub(endTotalStake), 0, "wrong change in total active stake for next round")
                 })
             })
         })
@@ -394,18 +442,18 @@ contract("BondingManager", accounts => {
         describe("caller is bonded", () => {
             beforeEach(async () => {
                 await bondingManager.bond(2000, transcoder0, {from: delegator})
-                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
             })
 
             describe("caller is changing delegate", () => {
                 it("should fail if caller is a registered transcoder", async () => {
-                    await expectThrow(bondingManager.bond(0, transcoder1, {from: transcoder0}))
+                    await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
+                    await expectRevertWithReason(bondingManager.bond(0, transcoder1, {from: transcoder0}), "registered transcoders can't delegate towards other addresses")
                 })
 
                 it("should set startRound to next round", async () => {
                     await bondingManager.bond(0, transcoder1, {from: delegator})
 
-                    assert.equal((await bondingManager.getDelegator(delegator))[4], currentRound + 2, "wrong startRound")
+                    assert.equal((await bondingManager.getDelegator(delegator))[4], currentRound + 1, "wrong startRound")
                 })
 
                 it("should decrease old delegate's delegated amount", async () => {
@@ -422,21 +470,66 @@ contract("BondingManager", accounts => {
                     assert.equal((await bondingManager.getDelegator(delegator))[2], transcoder1, "wrong delegateAddress")
                 })
 
-                describe("new delegate is registered transcoder", () => {
-                    it("should update new delegate's position in transcoder pool", async () => {
-                        await bondingManager.bond(0, transcoder1, {from: delegator})
+                describe("old delegate is registered transcoder", () => {
+                    describe("new delegate is a registered transcoder", () => {
+                        it("should update new delegate's position in transcoder pool", async () => {
+                            await bondingManager.bond(0, transcoder1, {from: delegator})
+                            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
+                            // New delegate was not previously first transcoder in pool and now is
+                            assert.equal(await bondingManager.getFirstTranscoderInPool(), transcoder1, "did not correctly update position in pool")
+                        })
 
-                        // New delegate was not previously first transcoder in pool and now is
-                        assert.equal(await bondingManager.getFirstTranscoderInPool(), transcoder1, "did not correctly update position in pool")
+                        it("should not increase/decrease the total active stake for the next round", async () => {
+                            const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                            await bondingManager.bond(0, transcoder1, {from: delegator})
+                            const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                            assert.equal(startTotalStake.sub(endTotalStake), 0, "wrong change in total active stake for next round")
+                        })
+                    })
+
+                    describe("new delegate is not a registered transcoder", () => {
+                        it("should not update new delegate's position in transcoder pool", async () => {
+                            await bondingManager.bond(0, nonTranscoder, {from: delegator})
+                            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
+                            // New delegate was not previously first transcoder in pool and now is
+                            assert.isFalse(await bondingManager.isActiveTranscoder(nonTranscoder, currentRound +1 ))
+                        })
+
+                        it("should decrease the total active stake for the next round", async () => {
+                            const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                            await bondingManager.bond(0, nonTranscoder, {from: delegator})
+                            const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                            assert.equal(startTotalStake.sub(endTotalStake), 2000, "wrong change in total active stake for next round")
+                        })
                     })
                 })
 
-                describe("old delegate is registered transcoder", () => {
-                    it("should update old delegate's position in the transcoder pool", async () => {
-                        await bondingManager.bond(0, transcoder1, {from: delegator})
+                describe("old delegate is not a registered transcoder", () => {
+                    beforeEach(async () => {
+                        await bondingManager.bond(0, delegator2, {from: delegator})
+                    })
+                    describe("new delegate is a registered transcoder", () => {
+                        it("should update new delegate's position in transcoder pool", async () => {
+                            await bondingManager.bond(0, transcoder0, {from: delegator})
+                            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
+                            // New delegate was not previously first transcoder in pool and now is
+                            assert.equal(await bondingManager.getFirstTranscoderInPool(), transcoder0, "did not correctly update position in pool")
+                        })
 
-                        // Old delegate was previously first transcoder in pool and now no longer is
-                        assert.isOk(await bondingManager.getFirstTranscoderInPool() != transcoder0, "did not correctly update position in pool")
+                        it("should increase the total active stake for the next round", async () => {
+                            const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                            await bondingManager.bond(0, transcoder1, {from: delegator})
+                            const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                            assert.equal(endTotalStake.sub(startTotalStake), 2000, "wrong change in total active stake for next round")
+                        })
+
+                        describe("new delegate is not a registered transcoder()", () => {
+                            it("should not update the new delegate's position in transcoder pool", async () => {
+                                await bondingManager.bond(0, nonTranscoder, {from: delegator})
+                                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
+                                assert.isFalse(await bondingManager.isActiveTranscoder(nonTranscoder, currentRound +1 ), "did not correctly update position in pool")
+                            })
+                        })
                     })
                 })
 
@@ -444,6 +537,7 @@ contract("BondingManager", accounts => {
                     it("should update new delegate's delegated amount with current bonded stake", async () => {
                         const startDelegatedAmount = (await bondingManager.getDelegator(transcoder1))[3]
                         await bondingManager.bond(0, transcoder1, {from: delegator})
+
                         const endDelegatedAmount = (await bondingManager.getDelegator(transcoder1))[3]
 
                         assert.equal(endDelegatedAmount.sub(startDelegatedAmount), 2000, "wrong change in delegatedAmount")
@@ -563,6 +657,13 @@ contract("BondingManager", accounts => {
                         assert.equal(endTotalBonded.sub(startTotalBonded), 1000, "wrong change in totalBonded")
                     })
 
+                    it("should increase the total stake for the next round", async () => {
+                        const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                        await bondingManager.bond(1000, transcoder1, {from: delegator})
+                        const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                        assert.equal(endTotalStake.sub(startTotalStake), 1000, "wrong change in total next round stake")
+                    })
+
                     it("should fire a Bond event when increasing bonded stake and changing delegates", async () => {
                         bondingManager.Bond({}).on("data", e => {
                             assert.equal(e.returnValues.newDelegate, transcoder1, "wrong newDelegate in Bond event")
@@ -619,18 +720,33 @@ contract("BondingManager", accounts => {
 
                                 assert.equal(startTotalBonded.sub(endTotalBonded), bondedAmount, "wrong change in totalBonded")
                             })
+
+                            it("should decrease the total stake for the next round", async () => {
+                                const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                                await bondingManager.bond(1000, delegator, {from: delegator})
+                                const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                                assert.equal(startTotalStake.sub(endTotalStake).toString(), 2000, "wrong change in total next round stake")
+                            })
                         })
 
                         describe("old delegate is not registered transcoder", () => {
+                            beforeEach(async () => {
+                                // Delegate to non-transcoder
+                                await bondingManager.bond(0, nonTranscoder, {from: delegator})
+                            })
                             it("should not change total bonded", async () => {
-                                // Delegate to non-transcoder i.e. self
-                                await bondingManager.bond(0, delegator, {from: delegator})
-
                                 const startTotalBonded = await bondingManager.getTotalBonded()
                                 await bondingManager.bond(1000, delegator2, {from: delegator})
                                 const endTotalBonded = await bondingManager.getTotalBonded()
 
                                 assert.equal(endTotalBonded.sub(startTotalBonded), 0, "wrong change in totalBonded")
+                            })
+
+                            it("should not decrease the total stake for the next round", async () => {
+                                const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                                await bondingManager.bond(1000, nonTranscoder, {from: delegator})
+                                const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                                assert.equal(endTotalStake.sub(startTotalStake).toString(), 0, "wrong change in total next round stake")
                             })
                         })
                     })
@@ -668,18 +784,33 @@ contract("BondingManager", accounts => {
 
                         assert.equal(endTotalBonded.sub(startTotalBonded), 1000, "wrong change in totalBonded")
                     })
+
+                    it("should increase the total stake for the next round", async () => {
+                        const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                        await bondingManager.bond(1000, transcoder0, {from: delegator})
+                        const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                        assert.equal(endTotalStake.sub(startTotalStake), 1000, "wrong change in nextRoundTotalActiveStake")
+                    })
                 })
 
                 describe("delegate is not registered transcoder", () => {
-                    it("should not change total bonded", async () => {
+                    beforeEach(async () => {
                         // Delegate to a non-transcoder i.e. self
-                        await bondingManager.bond(0, delegator, {from: delegator})
-
+                        await bondingManager.bond(0, nonTranscoder, {from: delegator})
+                    })
+                    it("should not change total bonded", async () => {
                         const startTotalBonded = await bondingManager.getTotalBonded()
-                        await bondingManager.bond(1000, delegator2, {from: delegator})
+                        await bondingManager.bond(1000, nonTranscoder, {from: delegator})
                         const endTotalBonded = await bondingManager.getTotalBonded()
 
                         assert.equal(endTotalBonded.sub(startTotalBonded), 0, "wrong change in totalBonded")
+                    })
+
+                    it("should not change the total active stake for next round", async () => {
+                        const startTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                        await bondingManager.bond(1000, nonTranscoder, {from: delegator})
+                        const endTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                        assert.equal(endTotalActiveStake.sub(startTotalActiveStake), 0, "wrong change in nextRoundTotalActiveStake")
                     })
                 })
 
@@ -707,15 +838,18 @@ contract("BondingManager", accounts => {
         beforeEach(async () => {
             await fixture.roundsManager.setMockBool(functionSig("currentRoundInitialized()"), true)
             await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), false)
-            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound-1)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
             await bondingManager.transcoder(5, 10, {from: transcoder})
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
+
             await bondingManager.bond(1000, transcoder, {from: delegator})
             await bondingManager.bond(1000, delegator, {from: delegator2})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
             await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
+            await fixture.roundsManager.execute(bondingManager.address, functionSig("setCurrentRoundTotalActiveStake()"))
         })
 
         it("should fail if current round is not initialized", async () => {
@@ -728,15 +862,15 @@ contract("BondingManager", accounts => {
             await bondingManager.unbond(1000, {from: delegator})
 
             // This should fail because caller is already unbonded and not bonded
-            await expectThrow(bondingManager.unbond(500, {from: delegator}))
+            await expectRevertWithReason(bondingManager.unbond(500, {from: delegator}), "caller must be bonded")
         })
 
         it("should fail if amount is 0", async () => {
-            await expectThrow(bondingManager.unbond(0, {from: delegator}))
+            await expectRevertWithReason(bondingManager.unbond(0, {from: delegator}), "unbonding amount must be greater than 0")
         })
 
         it("should fail if amount is greater than bonded amount", async () => {
-            await expectThrow(bondingManager.unbond(1001, {from: delegator}))
+            await expectRevertWithReason(bondingManager.unbond(1001, {from: delegator}), "amount is greater than bonded amount")
         })
 
         describe("partial unbonding", () => {
@@ -780,8 +914,14 @@ contract("BondingManager", accounts => {
                     // Caller is delegator delegated to non-transcoder
                     await bondingManager.unbond(500, {from: delegator2})
                     const endTotalBonded = await bondingManager.getTotalBonded()
-
                     assert.equal(endTotalBonded.sub(startTotalBonded), 0, "wrong change in total bonded")
+                })
+
+                it("should not change total active stake for the next round", async () => {
+                    const startTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                    await bondingManager.unbond(500, {from: delegator2})
+                    const endTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                    assert.equal(endTotalActiveStake.sub(startTotalActiveStake), 0, "wrong change in nextRoundTotalActiveStake")
                 })
             })
 
@@ -800,6 +940,13 @@ contract("BondingManager", accounts => {
 
                     assert.equal(startTotalBonded.sub(endTotalBonded), 500, "wrong change in total bonded")
                 })
+
+                it("should decrease the total stake for the next round", async () => {
+                    const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                    await bondingManager.unbond(500, {from: delegator})
+                    const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                    assert.equal(startTotalStake.sub(endTotalStake), 500, "wrong change in total next round stake")
+                })
             })
 
             describe("delegated to self with non-zero bonded amount and is registered transcoder", () => {
@@ -812,10 +959,17 @@ contract("BondingManager", accounts => {
 
                 it("should decrease total bonded", async () => {
                     const startTotalBonded = await bondingManager.getTotalBonded()
-                    await bondingManager.unbond(500, {from: delegator})
+                    await bondingManager.unbond(500, {from: transcoder})
                     const endTotalBonded = await bondingManager.getTotalBonded()
 
                     assert.equal(startTotalBonded.sub(endTotalBonded), 500, "wrong change in total bonded")
+                })
+
+                it("should decrease the total stake for the next round", async () => {
+                    const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                    await bondingManager.unbond(500, {from: transcoder})
+                    const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                    assert.equal(startTotalStake.sub(endTotalStake), 500, "wrong change in total next round stake")
                 })
             })
         })
@@ -858,16 +1012,32 @@ contract("BondingManager", accounts => {
                     // Caller is transcoder delegated to self
                     await bondingManager.unbond(1000, {from: transcoder})
 
-                    assert.equal(await bondingManager.transcoderStatus(transcoder), TranscoderStatus.NotRegistered, "wrong transcoder status")
+                    assert.isFalse(await bondingManager.isRegisteredTranscoder(transcoder), "wrong transcoder status")
                 })
 
                 it("should decrease total bonded by entire delegated stake (not just own bonded stake)", async () => {
                     const startTotalBonded = await bondingManager.getTotalBonded()
                     await bondingManager.unbond(1000, {from: transcoder})
                     const endTotalBonded = await bondingManager.getTotalBonded()
-
                     // Decrease by 2000 (delegated stake) instead of just 1000 (own bonded stake)
-                    assert.equal(startTotalBonded.sub(endTotalBonded), 2000, "wrong change in total bonded")
+                    assert.equal(startTotalBonded.sub(endTotalBonded).toString(), 2000, "wrong change in total bonded")
+                })
+
+                it("should decrease the total stake for the next round", async () => {
+                    const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                    await bondingManager.unbond(1000, {from: transcoder})
+                    const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                    // Decrease by 2000 (delegated stake) instead of just 1000 (own bonded stake)
+                    assert.equal(startTotalStake.sub(endTotalStake), 2000, "wrong change in total next round stake")
+                })
+            })
+
+            describe("is not a registered transcoder", () => {
+                it("should not update total active stake for the next round", async () => {
+                    const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                    await bondingManager.unbond(1000, {from: delegator2})
+                    const endTotalStake = await bondingManager.nextRoundTotalActiveStake()
+                    assert.equal(startTotalStake.sub(endTotalStake), 0, "wrong change in total next round stake")
                 })
             })
         })
@@ -875,7 +1045,10 @@ contract("BondingManager", accounts => {
 
     describe("rebond", () => {
         const transcoder = accounts[0]
-        const delegator = accounts[1]
+        const transcoder1 = accounts[1]
+        const transcoder2 = accounts[2]
+        const nonTranscoder = accounts[3]
+        const delegator = accounts[4]
         const currentRound = 100
         const unbondingLockID = 0
 
@@ -908,7 +1081,7 @@ contract("BondingManager", accounts => {
             // Unbond the rest of the delegator's tokens so it is no longer has any bonded tokens
             await bondingManager.unbond(500, {from: delegator})
 
-            await expectThrow(bondingManager.rebond(unbondingLockID), {from: delegator})
+            await expectRevertWithReason(bondingManager.rebond(unbondingLockID, {from: delegator}), "caller must be bonded")
         })
 
         it("should fail for invalid unbonding lock ID", async () => {
@@ -944,18 +1117,49 @@ contract("BondingManager", accounts => {
 
                 assert.equal(endTotalBonded.sub(startTotalBonded), 500, {from: delegator})
             })
+
+            it("should increase total active stake for the next round", async () => {
+                const startTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                await bondingManager.rebond(unbondingLockID, {from: delegator})
+                const endTotalActiveStake= await bondingManager.nextRoundTotalActiveStake()
+                assert.equal(endTotalActiveStake.sub(startTotalActiveStake), 500, "wrong change in nextRoundTotalActiveStake")
+            })
+
+            it("should evict when rebonding and pool is full", async () => {
+                await bondingManager.bond(1900, transcoder1, {from: transcoder1})
+                await bondingManager.transcoder(5, 10, {from: transcoder1})
+                await bondingManager.bond(1800, transcoder2, {from: transcoder2})
+                await bondingManager.transcoder(5, 10, {from: transcoder2})
+                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder, currentRound))
+                bondingManager.TranscoderEvicted({}).on("data", e => {
+                    assert.equal(e.returnValues.transcoder, transcoder2)
+                })
+                await bondingManager.rebond(unbondingLockID, {from: delegator})
+                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder, currentRound+1))
+                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder2, currentRound+1))
+                const pool = await bondingManager.getTranscoderEarningsPoolForRound(transcoder, currentRound+1)
+                assert.equal(pool.totalStake.toNumber(), 1000)
+            })
         })
 
         describe("current delegate is not a registered transcoder", () => {
-            it("should not change total bonded", async () => {
+            beforeEach(async () => {
                 // Delegate to a non-transcoder i.e. self
-                await bondingManager.bond(0, delegator, {from: delegator})
-
+                await bondingManager.bond(0, nonTranscoder, {from: delegator})
+            })
+            it("should not change total bonded", async () => {
                 const startTotalBonded = await bondingManager.getTotalBonded()
                 await bondingManager.rebond(unbondingLockID, {from: delegator})
                 const endTotalBonded = await bondingManager.getTotalBonded()
 
                 assert.equal(endTotalBonded.sub(startTotalBonded), 0, {from: delegator})
+            })
+
+            it("should not change total active stake for the next round", async () => {
+                const startTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                await bondingManager.rebond(unbondingLockID, {from: delegator})
+                const endTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                assert.equal(endTotalActiveStake.sub(startTotalActiveStake), 0, "wrong change in nextRoundTotalActiveStake")
             })
         })
 
@@ -974,6 +1178,7 @@ contract("BondingManager", accounts => {
     describe("rebondFromUnbonded", () => {
         const transcoder = accounts[0]
         const delegator = accounts[1]
+        const nonTranscoder = accounts[3]
         const currentRound = 100
         const unbondingLockID = 0
 
@@ -1047,37 +1252,49 @@ contract("BondingManager", accounts => {
         })
 
         describe("new delegate is a registered transcoder", () => {
-            it("should increase transcoder's delegated stake in pool", async () => {
+            beforeEach(async () => {
                 // Delegator unbonds rest of tokens transitioning to the Unbonded state
                 await bondingManager.unbond(500, {from: delegator})
-
+            })
+            it("should increase transcoder's delegated stake in pool", async () => {
                 await bondingManager.rebondFromUnbonded(transcoder, unbondingLockID, {from: delegator})
-
                 assert.equal(await bondingManager.transcoderTotalStake(transcoder), 1500, "wrong transcoder total stake")
             })
 
             it("should increase total bonded", async () => {
-                // Delegator unbonds rest of tokens transitioning to the Unbonded state
-                await bondingManager.unbond(500, {from: delegator})
-
                 const startTotalBonded = await bondingManager.getTotalBonded()
                 await bondingManager.rebondFromUnbonded(transcoder, unbondingLockID, {from: delegator})
                 const endTotalBonded = await bondingManager.getTotalBonded()
-
                 assert.equal(endTotalBonded.sub(startTotalBonded), 500, "wrong total bonded")
+            })
+
+            it("should increase the total active stake for the next round", async () => {
+                const startTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                await bondingManager.rebondFromUnbonded(transcoder, unbondingLockID, {from: delegator})
+                const endTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                assert.equal(endTotalActiveStake.sub(startTotalActiveStake), 500, "wrong change in nextRoundTotalActiveStake")
             })
         })
 
         describe("new delegate is not a registered transcoder", () => {
-            it("should not change total bonded", async () => {
+            beforeEach(async () => {
                 // Delegator unbonds rest of tokens transitioning to the Unbonded state
+                // 500 is unbonded from transcoder in the active pool
                 await bondingManager.unbond(500, {from: delegator})
-
+            })
+            it("should not change total bonded", async () => {
                 const startTotalBonded = await bondingManager.getTotalBonded()
-                await bondingManager.rebondFromUnbonded(delegator, unbondingLockID, {from: delegator})
+                // delegator is not in the active pool so endTotalBonded ends up being 500 less than startTotalBonded
+                await bondingManager.rebondFromUnbonded(nonTranscoder, unbondingLockID, {from: delegator})
                 const endTotalBonded = await bondingManager.getTotalBonded()
+                assert.strictEqual(endTotalBonded.sub(startTotalBonded).toNumber(), 0, "wrong total bonded")
+            })
 
-                assert.equal(endTotalBonded.sub(startTotalBonded), 0, "wrong total bonded")
+            it("should not change the total active stake for the next round", async () => {
+                const startTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                await bondingManager.rebondFromUnbonded(nonTranscoder, unbondingLockID, {from: delegator})
+                const endTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                assert.equal(endTotalActiveStake.sub(startTotalActiveStake), 0, "wrong change in nextRoundTotalActiveStake")
             })
         })
 
@@ -1278,7 +1495,7 @@ contract("BondingManager", accounts => {
 
             assert.isOk(await bondingManager.isActiveTranscoder(transcoder1, currentRound + 1), "should set transcoder as active for current round")
 
-            assert.equal(await bondingManager.getTotalActiveStake(currentRound + 1), 2000, "should set total active stake to sum of total stake of all active transcoders")
+            assert.equal(await bondingManager.nextRoundTotalActiveStake(), 2000, "should set total active stake to sum of total stake of all active transcoders")
         })
     })
 
@@ -1407,6 +1624,7 @@ contract("BondingManager", accounts => {
     describe("slashTranscoder", () => {
         const transcoder = accounts[0]
         const finder = accounts[1]
+        const nonTranscoder = accounts[2]
         const currentRound = 100
 
         beforeEach(async () => {
@@ -1419,6 +1637,7 @@ contract("BondingManager", accounts => {
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
             await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
+            await fixture.roundsManager.execute(bondingManager.address, functionSig("setCurrentRoundTotalActiveStake()"))
         })
 
         it("should fail if system is paused", async () => {
@@ -1495,7 +1714,7 @@ contract("BondingManager", accounts => {
         })
 
         describe("transcoder is registered", () => {
-            it("removes transcoder from the pool", async () => {
+            it("removes active transcoder from active set for the current round", async () => {
                 await fixture.ticketBroker.execute(
                     bondingManager.address,
                     functionEncodedABI(
@@ -1504,26 +1723,36 @@ contract("BondingManager", accounts => {
                         [transcoder, constants.NULL_ADDRESS, PERC_DIVISOR / 2, 0]
                     )
                 )
-
-                assert.equal(await bondingManager.transcoderStatus(transcoder), TranscoderStatus.NotRegistered, "should remove transcoder from the pool")
+                assert.isNotOk(await bondingManager.isActiveTranscoder(transcoder, currentRound + 2), "should set active transcoder as inactive for the round")
             })
 
-            describe("transcoder is active", () => {
-                it("removes transcoder from active set for the current round", async () => {
-                    const startTotalActiveStake = await bondingManager.getTotalActiveStake(currentRound + 1)
-                    await fixture.ticketBroker.execute(
-                        bondingManager.address,
-                        functionEncodedABI(
-                            "slashTranscoder(address,address,uint256,uint256)",
-                            ["address", "uint256", "uint256", "uint256"],
-                            [transcoder, constants.NULL_ADDRESS, PERC_DIVISOR / 2, 0]
-                        )
+            it("deducts the transcoder's stake from the total for the current round", async () => {
+                const startTotalActiveStake = await bondingManager.currentRoundTotalActiveStake()
+                await fixture.ticketBroker.execute(
+                    bondingManager.address,
+                    functionEncodedABI(
+                        "slashTranscoder(address,address,uint256,uint256)",
+                        ["address", "uint256", "uint256", "uint256"],
+                        [transcoder, constants.NULL_ADDRESS, PERC_DIVISOR / 2, 0]
                     )
-                    const endTotalActiveStake = await bondingManager.getTotalActiveStake(currentRound + 1)
+                )
+                const endTotalActiveStake = await bondingManager.currentRoundTotalActiveStake()
+                assert.isNotOk(await bondingManager.isActiveTranscoder(transcoder, currentRound + 2), "should set active transcoder as inactive for the round")
+                assert.equal(startTotalActiveStake.sub(endTotalActiveStake).toNumber(), 1000, "should decrease total active stake by total stake of transcoder")
+            })
 
-                    assert.isNotOk(await bondingManager.isActiveTranscoder(transcoder, currentRound + 1), "should set active transcoder as inactive for the round")
-                    assert.equal(startTotalActiveStake.sub(endTotalActiveStake).toNumber(), 1000, "should decrease total active stake by total stake of transcoder")
-                })
+            it("deducts the transcoder's stake from the total for the next round", async () => {
+                const startTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                await fixture.ticketBroker.execute(
+                    bondingManager.address,
+                    functionEncodedABI(
+                        "slashTranscoder(address,address,uint256,uint256)",
+                        ["address", "uint256", "uint256", "uint256"],
+                        [transcoder, constants.NULL_ADDRESS, PERC_DIVISOR / 2, 0]
+                    )
+                )
+                const endTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                assert.equal(startTotalActiveStake.sub(endTotalActiveStake).toNumber(), 1000, "should decrease total active stake by total stake of transcoder")
             })
         })
 
@@ -1543,6 +1772,35 @@ contract("BondingManager", accounts => {
 
                     assert.equal(endBondedAmount, startBondedAmount.div(2).toNumber(), "should decrease transcoder's bondedAmount by slashAmount")
                 })
+            })
+
+            it("doesn't change the total for the current round", async () => {
+                const startTotalActiveStake = await bondingManager.currentRoundTotalActiveStake()
+                await fixture.ticketBroker.execute(
+                    bondingManager.address,
+                    functionEncodedABI(
+                        "slashTranscoder(address,address,uint256,uint256)",
+                        ["address", "uint256", "uint256", "uint256"],
+                        [nonTranscoder, constants.NULL_ADDRESS, PERC_DIVISOR / 2, 0]
+                    )
+                )
+                const endTotalActiveStake = await bondingManager.currentRoundTotalActiveStake()
+                assert.isNotOk(await bondingManager.isActiveTranscoder(nonTranscoder, currentRound + 2), "should remain inactive for the round")
+                assert.equal(startTotalActiveStake.sub(endTotalActiveStake).toNumber(), 0, "should decrease total active stake by total stake of transcoder")
+            })
+
+            it("doesn't change the total for the next round", async () => {
+                const startTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                await fixture.ticketBroker.execute(
+                    bondingManager.address,
+                    functionEncodedABI(
+                        "slashTranscoder(address,address,uint256,uint256)",
+                        ["address", "uint256", "uint256", "uint256"],
+                        [nonTranscoder, constants.NULL_ADDRESS, PERC_DIVISOR / 2, 0]
+                    )
+                )
+                const endTotalActiveStake = await bondingManager.nextRoundTotalActiveStake()
+                assert.equal(startTotalActiveStake.sub(endTotalActiveStake).toNumber(), 0, "should decrease total active stake by total stake of transcoder")
             })
         })
 
@@ -2085,8 +2343,8 @@ contract("BondingManager", accounts => {
             await bondingManager.transcoder(5, 10, {from: transcoder})
         })
 
-        it("should fail if transcoder is not active", async () => {
-            await expectThrow(bondingManager.activeTranscoderTotalStake(transcoder, currentRound))
+        it("should return 0 transcoder is not active", async () => {
+            await assert.equal(await bondingManager.activeTranscoderTotalStake(transcoder, currentRound), 0)
         })
 
         it("should return active transcoder's total stake for round", async () => {
@@ -2096,32 +2354,33 @@ contract("BondingManager", accounts => {
         })
     })
 
-    describe("transcoderStatus", () => {
+    describe("isActiveTranscoder", () => {
         const transcoder = accounts[0]
         const currentRound = 100
 
         beforeEach(async () => {
             await fixture.roundsManager.setMockBool(functionSig("currentRoundInitialized()"), true)
             await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), false)
-            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound - 1)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
             await bondingManager.transcoder(5, 10, {from: transcoder})
 
-            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
+            await fixture.roundsManager.execute(bondingManager.address, functionSig("setCurrentRoundTotalActiveStake()"))
         })
 
         describe("caller is not in transcoder pool", () => {
             it("returns NotRegistered", async () => {
                 await bondingManager.unbond(1000, {from: transcoder})
 
-                assert.equal(await bondingManager.transcoderStatus(transcoder), TranscoderStatus.NotRegistered, "should return NotRegistered for caller not in transcoder pool")
+                assert.isFalse(await bondingManager.isActiveTranscoder(transcoder, currentRound + 1), "should return NotRegistered for caller not in transcoder pool")
             })
         })
 
         describe("caller is in transcoder pool", () => {
             it("returns Registered", async () => {
-                assert.equal(await bondingManager.transcoderStatus(transcoder), TranscoderStatus.Registered, "should return Registered for caller in transcoder pool")
+                assert.isTrue(await bondingManager.isActiveTranscoder(transcoder, currentRound), "should return Registered for caller in transcoder pool")
             })
         })
     })
@@ -2136,16 +2395,11 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), false)
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
-            await bondingManager.bond(1000, delegator0, {from: delegator0})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
         })
 
         describe("caller has zero bonded amount", () => {
-            beforeEach(async () => {
-                await bondingManager.unbond(1000, {from: delegator0})
-            })
-
             it("returns Unbonded", async () => {
                 assert.equal(await bondingManager.delegatorStatus(delegator0), DelegatorStatus.Unbonded, "should return Unbonded for delegator with zero bonded amount")
             })
@@ -2153,7 +2407,7 @@ contract("BondingManager", accounts => {
 
         describe("caller has a startRound", () => {
             beforeEach(async () => {
-                await bondingManager.bond(0, transcoder, {from: delegator0})
+                await bondingManager.bond(1000, transcoder, {from: delegator0})
             })
 
             describe("startRound is now", () => {
@@ -2191,10 +2445,11 @@ contract("BondingManager", accounts => {
         beforeEach(async () => {
             await fixture.roundsManager.setMockBool(functionSig("currentRoundInitialized()"), true)
             await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), false)
-            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound-1)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
             await bondingManager.transcoder(5, 10, {from: transcoder})
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
         })
 
         describe("address is registered transcoder", () => {

--- a/test/unit/TicketBroker.js
+++ b/test/unit/TicketBroker.js
@@ -1,7 +1,7 @@
 import BN from "bn.js"
 import truffleAssert from "truffle-assertions"
 import calcTxCost from "../helpers/calcTxCost"
-import {expectRevertWithReason} from "../helpers/expectFail"
+import expectRevertWithReason from "../helpers/expectFail"
 import {
     DUMMY_TICKET_CREATION_ROUND,
     DUMMY_TICKET_CREATION_ROUND_BLOCK_HASH,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
- Make the sorted doubly linked list a fluent representation of the active transcoder set as stake updates happen
- Repurpose transcoder `Registered` status to indicate self-bonding as a willingness to be a transcoder
- Keep track of total stake for the active transcoder set

**Specific updates (required)**
- Removed `setNumTranscoders()` function 
- Added helpers to increase/decrease stake for active transcoders as well as process total active set stake updates
- Added a helper to join the active set based on current transcoder stake
- Reworked resign method to do the necessary state updates for active transcoders
- Reworked `isRegisteredTranscoder` to indicate self-bonding
- Removed `transcoderStatus()` method, instead we now have `isActiveTranscoder()` and `isRegisteredTranscoder()` that return boolean values
- Deprecated `numActiveTranscoders` variable, instead we can get the size/maxSize of transcoderPool with the public helpers
- added a call to `bondingManager.setCurrentRoundTotalActiveStake()` upon round init to set `nextRoundTotalActiveStake` to the `currentRoundTotalActiveStake` 
- adjusted unit & integration tests
- added a npm run script `npm run test:describe` to run tests for describe blocks (uses mocha's grep feature with `-g` flag)
- added a map `lastActiveStakeUpdateRound` that keeps track of the round in which an active transcoder's stake was last updated

**How did you test each of these updates (required)**
Adjusted & ran unit and integation tests

**Does this pull request close any open issues?**
Fixes #300 
Fixes #302 
Fixes #304 

**Checklist:**
- [ ] README and other documentation updated
- [x] All unit & integration tests pass
