### PR TITLE
Remove freeze period

### DIFF
--- a/contracts/pm/TicketBroker.sol
+++ b/contracts/pm/TicketBroker.sol
@@ -18,7 +18,6 @@ contract TicketBroker is
 {
     constructor(
         address _controller,
-        uint256 _freezePeriod,
         uint256 _unlockPeriod,
         uint256 _ticketValidityPeriod
     )
@@ -28,17 +27,8 @@ contract TicketBroker is
         MixinTicketBrokerCore()
         MixinTicketProcessor()
     {
-        freezePeriod = _freezePeriod;
         unlockPeriod = _unlockPeriod;
         ticketValidityPeriod = _ticketValidityPeriod;
-    }
-
-    /**
-     * @dev Sets freezePeriod value. Only callable by the Controller owner
-     * @param _freezePeriod Value for freezePeriod
-     */
-    function setFreezePeriod(uint256 _freezePeriod) external onlyControllerOwner {
-        freezePeriod = _freezePeriod;
     }
 
     /**

--- a/contracts/pm/mixins/MixinReserve.sol
+++ b/contracts/pm/mixins/MixinReserve.sol
@@ -11,23 +11,13 @@ contract MixinReserve is MContractRegistry, MReserve {
     using SafeMath for uint256;
 
     struct Reserve {
-        uint256 fundsAdded;               // Amount of funds added to the reserve
-        uint256 fundsClaimed;             // Amount of funds claimed from the reserve
-        uint256 freezeRound;              // Round that the reserve was frozen
-        uint256 recipientsInFreezeRound;  // Number of recipients registered in BondingManager during freezeRound
+        uint256 funds;                                                        // Amount of funds in the reserve
+        mapping (uint256 => uint256) claimedForRound;                         // Mapping of round => total amount claimed
+        mapping (uint256 => mapping (address => uint256)) claimedByAddress;   // Mapping of round => claimant address => amount claimed
     }
 
-    struct ReserveManager {
-        uint256 reserveNonce;                                                 // Current reserve ID
-        Reserve reserve;                                                      // Storage pointer to a reserve
-        mapping (uint256 => mapping (address => uint256)) claimedPerReserve;  // Mapping of reserve ID => claimant address => amount claimed for reserve ID
-    }
-
-    // Mapping of address => managed reserve for an address
-    mapping (address => ReserveManager) internal reserveManagers;
-
-    // Number of rounds before a frozen reserve thaws
-    uint256 public freezePeriod;
+    // Mapping of address => reserve
+    mapping (address => Reserve) internal reserves;
 
     /**
      * @dev Returns info about a reserve
@@ -35,43 +25,47 @@ contract MixinReserve is MContractRegistry, MReserve {
      * @return Info about the reserve for `_reserveHolder`
      */
     function getReserveInfo(address _reserveHolder) public view returns (ReserveInfo memory info) {
-        Reserve storage reserve = reserveManagers[_reserveHolder].reserve;
-
         info.fundsRemaining = remainingReserve(_reserveHolder);
-        info.state = reserveState(_reserveHolder);
-        info.thawRound = reserve.freezeRound == 0 ? 0 : reserve.freezeRound.add(freezePeriod);
+        info.claimedInCurrentRound = reserves[_reserveHolder].claimedForRound[roundsManager().currentRound()];
     }
 
     /**
-     * @dev Returns the amount of funds claimable by a claimant from a reserve
+     * @dev Returns the amount of funds claimable by a claimant from a reserve in the current round
      * @param _reserveHolder Address of reserve holder
      * @param _claimant Address of claimant
-     * @return Amount of funds claimable by `_claimant` from the reserve for `_reserveHolder`
+     * @return Amount of funds claimable by `_claimant` from the reserve for `_reserveHolder` in the current round
      */
     function claimableReserve(address _reserveHolder, address _claimant) public view returns (uint256) {
-        ReserveManager storage manager = reserveManagers[_reserveHolder];
-        Reserve storage reserve = manager.reserve;
-        if (reserveState(_reserveHolder) == ReserveState.NotFrozen) {
-            // TODO: Check if claimant is registered in current round
-            uint256 poolSize = bondingManager().getTranscoderPoolSize();
-            return poolSize > 0 ? reserve.fundsAdded.div(poolSize) : 0;
-        } else {
-            // TODO: Check if claimant is registered during the freezeRound
-            return reserve.recipientsInFreezeRound > 0 ?
-                reserve.fundsAdded.div(reserve.recipientsInFreezeRound).sub(manager.claimedPerReserve[manager.reserveNonce][_claimant]) :
-                0;
+        Reserve storage reserve = reserves[_reserveHolder];
+
+        uint256 currentRound = roundsManager().currentRound();
+
+        // TODO: Check if claimant is active in the current round
+        // We are just checking if it is registered for now
+        if (!bondingManager().isRegisteredTranscoder(_claimant)) {
+            return 0;
         }
+
+        uint256 poolSize = bondingManager().getTranscoderPoolSize();
+        if (poolSize == 0) {
+            return 0;
+        }
+
+        // Total claimable funds = remaining funds + amount claimed for the round
+        uint256 totalClaimable = reserve.funds.add(reserve.claimedForRound[currentRound]);
+        return totalClaimable.div(poolSize).sub(reserve.claimedByAddress[currentRound][_claimant]);
     }
 
     /**
-     * @dev Returns the amount of funds claimed by a claimant from a reserve
+     * @dev Returns the amount of funds claimed by a claimant from a reserve in the current round
      * @param _reserveHolder Address of reserve holder
      * @param _claimant Address of claimant
-     * @return Amount of funds claimed by `_claimant` from the reserve for `_reserveHolder`
+     * @return Amount of funds claimed by `_claimant` from the reserve for `_reserveHolder` in the current round
      */
     function claimedReserve(address _reserveHolder, address _claimant) public view returns (uint256) {
-        ReserveManager storage manager = reserveManagers[_reserveHolder];
-        return manager.claimedPerReserve[manager.reserveNonce][_claimant];
+        Reserve storage reserve = reserves[_reserveHolder];
+        uint256 currentRound = roundsManager().currentRound();
+        return reserve.claimedByAddress[currentRound][_claimant];
     }
 
     /**
@@ -80,27 +74,7 @@ contract MixinReserve is MContractRegistry, MReserve {
      * @param _amount Amount of funds to add to reserve
      */
     function addReserve(address _reserveHolder, uint256 _amount) internal {
-        ReserveManager storage manager = reserveManagers[_reserveHolder];
-        Reserve storage reserve = manager.reserve;
-
-        reserve.fundsAdded = remainingReserve(_reserveHolder).add(_amount);
-
-        // If reserve is thawed then clear unneeded contract storage
-        // for the reserve and update the reserve while ensuring that
-        // any additional funds are added to the remaining funds in the reserve
-        if (reserveState(_reserveHolder) == ReserveState.Thawed) {
-            // We clear these individual fields of the reserve instead
-            // of using `clearReserve()` because we can directly update
-            // fundsAdded with its new value instead of clearing the old
-            // value and then setting its new value
-            reserve.fundsClaimed = 0;
-            reserve.freezeRound = 0;
-            reserve.recipientsInFreezeRound = 0;
-            // Increment reserveNonce so the manager can point to a new
-            // mapping for tracking funds claimed from a reserve by
-            // different claimants
-            manager.reserveNonce = manager.reserveNonce.add(1);
-        }
+        reserves[_reserveHolder].funds = reserves[_reserveHolder].funds.add(_amount);
 
         emit ReserveFunded(_reserveHolder, _amount);
     }
@@ -110,12 +84,7 @@ contract MixinReserve is MContractRegistry, MReserve {
      * @param _reserveHolder Address of reserve holder
      */
     function clearReserve(address _reserveHolder) internal {
-        ReserveManager storage manager = reserveManagers[_reserveHolder];
-        delete manager.reserve;
-        // Increment reserveNonce so the manager can point to a new
-        // mapping for tracking funds claimed from a reserve by
-        // different claimants
-        manager.reserveNonce = manager.reserveNonce.add(1);
+        delete reserves[_reserveHolder];
     }
 
     /**
@@ -133,56 +102,20 @@ contract MixinReserve is MContractRegistry, MReserve {
         internal
         returns (uint256)
     {
-        ReserveManager storage manager = reserveManagers[_reserveHolder];
-        Reserve storage reserve = manager.reserve;
-
-        // If reserve is not frozen then freeze it
-        if (reserveState(_reserveHolder) == ReserveState.NotFrozen) {
-            uint256 freezeRound = roundsManager().currentRound();
-            // TODO: make sure bondingManager.getTranscoderPoolSize()
-            // returns the locked in # registered for the freeze round
-            uint256 recipientsInFreezeRound = bondingManager().getTranscoderPoolSize();
-
-            reserve.freezeRound = freezeRound;
-            reserve.recipientsInFreezeRound = recipientsInFreezeRound;
-
-            emit ReserveFrozen(
-                _reserveHolder,
-                _claimant,
-                freezeRound,
-                recipientsInFreezeRound
-            );
-        }
-
-        // If the reserve is not frozen or if there are no recipients
-        // registered with BondingManager during the freezeRound then
-        // no funds can be claimed from the reserve
-        if (reserve.freezeRound == 0 || reserve.recipientsInFreezeRound == 0) {
-            return 0;
-        }
-
-        // If claimant is not registered it cannot claim any funds
-        // from the reserve
-        //
-        // TODO: consider just checking if recipient is registered
-        // in current round vs. keeping track of all rounds that recipient
-        // is registered in and checking if recipient was registered
-        // during the freeze round (could be in the past)
-        if (!bondingManager().isRegisteredTranscoder(_claimant)) {
-            return 0;
-        }
-
-        uint256 reserveID = manager.reserveNonce;
-        uint256 claimedFunds = manager.claimedPerReserve[reserveID][_claimant];
-        // Amount claimable from reserve by claimant = max allocation from reserve for claimant - amount already claimed by claimant
-        uint256 claimableFunds = reserve.fundsAdded.div(reserve.recipientsInFreezeRound).sub(claimedFunds);
+        uint256 claimableFunds = claimableReserve(_reserveHolder, _claimant);
         // If the given amount > claimableFunds then claim claimableFunds
         // If the given amount <= claimableFunds then claim the given amount
         uint256 claimAmount = _amount > claimableFunds ? claimableFunds : _amount;
 
         if (claimAmount > 0) {
-            manager.claimedPerReserve[reserveID][_claimant] = claimedFunds.add(claimAmount);
-            reserve.fundsClaimed = reserve.fundsClaimed.add(claimAmount);
+            uint256 currentRound = roundsManager().currentRound();
+            Reserve storage reserve = reserves[_reserveHolder];
+            // Increase total amount claimed for the round
+            reserve.claimedForRound[currentRound] = reserve.claimedForRound[currentRound].add(claimAmount);
+            // Increase amount claimed by claimant for the round
+            reserve.claimedByAddress[currentRound][_claimant] = reserve.claimedByAddress[currentRound][_claimant].add(claimAmount);
+            // Decrease remaining reserve
+            reserve.funds = reserve.funds.sub(claimAmount);
 
             emit ReserveClaimed(_reserveHolder, _claimant, claimAmount);
         }
@@ -191,34 +124,11 @@ contract MixinReserve is MContractRegistry, MReserve {
     }
 
     /**
-     * @dev Returns the state of a reserve
-     * @param _reserveHolder Address of reserve holder
-     * @return State of the reserve for `_reserveHolder`
-     */
-    function reserveState(address _reserveHolder) internal view returns (ReserveState) {
-        Reserve storage reserve = reserveManagers[_reserveHolder].reserve;
-
-        uint256 currentRound = roundsManager().currentRound();
-
-        if (reserve.freezeRound == 0) {
-            return ReserveState.NotFrozen;
-        } else if (
-            reserve.freezeRound > 0 &&
-            reserve.freezeRound.add(freezePeriod) > currentRound
-        ) {
-            return ReserveState.Frozen;
-        } else {
-            return ReserveState.Thawed;
-        }
-    }
-
-    /**
      * @dev Returns the amount of funds remaining in a reserve
      * @param _reserveHolder Address of reserve holder
      * @return Amount of funds remaining in the reserve for `_reserveHolder`
      */
     function remainingReserve(address _reserveHolder) internal view returns (uint256) {
-        Reserve storage reserve = reserveManagers[_reserveHolder].reserve;
-        return reserve.fundsAdded.sub(reserve.fundsClaimed);
+        return reserves[_reserveHolder].funds;
     }
 }

--- a/contracts/pm/mixins/interfaces/MReserve.sol
+++ b/contracts/pm/mixins/interfaces/MReserve.sol
@@ -4,30 +4,15 @@ pragma experimental ABIEncoderV2;
 
 
 contract MReserve {
-    // States for a reserve
-    enum ReserveState {
-        NotFrozen,
-        Frozen,
-        Thawed
-    }
-
     struct ReserveInfo {
-        uint256 fundsRemaining;  // Funds remaining in reserve
-        ReserveState state;      // State of reserve
-        uint256 thawRound;       // Round that the reserve can be withdrawn if it has been frozen
+        uint256 fundsRemaining;        // Funds remaining in reserve
+        uint256 claimedInCurrentRound; // Funds claimed from reserve in current round
     }
 
     // Emitted when funds are added to a reserve
     event ReserveFunded(address indexed reserveHolder, uint256 amount);
-    // Emitted when funds are claimed from a frozen reserve
+    // Emitted when funds are claimed from a reserve
     event ReserveClaimed(address indexed reserveHolder, address claimant, uint256 amount);
-    // Emitted when a reserve is frozen
-    event ReserveFrozen(
-        address indexed reserveHolder,
-        address indexed claimant,
-        uint256 freezeRound,
-        uint256 recipientsInFreezeRound
-    );
 
     /**
      * @dev Returns info about a reserve
@@ -71,13 +56,6 @@ contract MReserve {
     )
         internal
         returns (uint256);
-
-    /**
-     * @dev Returns the state of a reserve
-     * @param _reserveHolder Address of reserve holder
-     * @return State of the reserve for `_reserveHolder`
-     */
-    function reserveState(address _reserveHolder) internal view returns (ReserveState);
 
     /**
      * @dev Returns the amount of funds remaining in a reserve

--- a/contracts/pm/mixins/interfaces/MTicketBrokerCore.sol
+++ b/contracts/pm/mixins/interfaces/MTicketBrokerCore.sol
@@ -27,7 +27,7 @@ contract MTicketBrokerCore {
     // Emitted when a funds transfer for a winning ticket redemption is executed
     event WinningTicketTransfer(address indexed sender, address indexed recipient, uint256 amount);
     // Emitted when a sender requests an unlock
-    event Unlock(address indexed sender, uint256 startBlock, uint256 endBlock);
+    event Unlock(address indexed sender, uint256 startRound, uint256 endRound);
     // Emitted when a sender cancels an unlock
     event UnlockCancelled(address indexed sender);
     // Emitted when a sender withdraws its deposit & reserve

--- a/migrations/3_deploy_contracts.js
+++ b/migrations/3_deploy_contracts.js
@@ -34,7 +34,6 @@ module.exports = function(deployer, network) {
             TicketBroker,
             "TicketBroker",
             controller.address,
-            config.broker.freezePeriod,
             config.broker.unlockPeriod,
             config.broker.ticketValidityPeriod
         )
@@ -65,7 +64,6 @@ module.exports = function(deployer, network) {
 
         // Set TicketBroker parameters
         await broker.setUnlockPeriod(config.broker.unlockPeriod)
-        await broker.setFreezePeriod(config.broker.freezePeriod)
         await broker.setTicketValidityPeriod(config.broker.ticketValidityPeriod)
     })
 }

--- a/migrations/migrations.config.js
+++ b/migrations/migrations.config.js
@@ -11,7 +11,6 @@ module.exports = {
     broker: {
         // TODO: Consider updating these values prior to deploying to testnet
         unlockPeriod: new BN(40320), // approximately 7 days worth of blocks
-        freezePeriod: new BN(2),
         ticketValidityPeriod: new BN(2)
     },
     roundsManager: {

--- a/test/helpers/ticket.js
+++ b/test/helpers/ticket.js
@@ -43,10 +43,12 @@ const getTicketHash = ticketObj => {
     )
 }
 
-const defaultAuxData = () => {
+const defaultAuxData = () => createAuxData(DUMMY_TICKET_CREATION_ROUND, DUMMY_TICKET_CREATION_ROUND_BLOCK_HASH)
+
+const createAuxData = (creationRound, blockHash) => {
     return web3.eth.abi.encodeParameters(
         ["uint256", "bytes32"],
-        [DUMMY_TICKET_CREATION_ROUND, DUMMY_TICKET_CREATION_ROUND_BLOCK_HASH]
+        [creationRound, blockHash]
     )
 }
 
@@ -55,6 +57,7 @@ const isSet = v => {
 }
 
 module.exports = {
+    createAuxData,
     createTicket,
     createWinningTicket,
     getTicketHash,

--- a/test/unit/TicketBroker.js
+++ b/test/unit/TicketBroker.js
@@ -1524,7 +1524,7 @@ contract("TicketBroker", accounts => {
     })
 
     describe("claimableReserve", () => {
-        it("Returns 0 when the reserveHolder does not have a reserve", async () => {
+        it("returns 0 when the reserveHolder does not have a reserve", async () => {
             const numRecipients = 10
             await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
             assert.equal((await broker.claimableReserve(constants.NULL_ADDRESS, constants.NULL_ADDRESS)).toString(10), "0")
@@ -1545,7 +1545,7 @@ contract("TicketBroker", accounts => {
             assert.equal((await broker.claimableReserve(sender, constants.NULL_ADDRESS)).toString(10), "0")
         })
 
-        it("Returns claimable reserve for a claimaint if reserve was not claimed from", async () => {
+        it("returns claimable reserve for a claimaint if reserve was not claimed from", async () => {
             const numRecipients = 10
             const deposit = 1000
             const reserve = 1000
@@ -1575,7 +1575,7 @@ contract("TicketBroker", accounts => {
             )
         })
 
-        it("Returns claimable reserve for a claimant when reserve was claimed from", async () => {
+        it("returns claimable reserve for a claimant when reserve was claimed from", async () => {
             const numRecipients = 10
             const reserve = 1000
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
@@ -1596,7 +1596,7 @@ contract("TicketBroker", accounts => {
             )
         })
 
-        it("Returns 0 if claimant has claimed all of his claimableReserve", async () => {
+        it("returns 0 if claimant has claimed all of his claimableReserve", async () => {
             const numRecipients = 10
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
             await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)


### PR DESCRIPTION
This PR removes the freeze period from the TicketBroker contract. Instead of freezing the reserve for multiple rounds after the deposit is depleted, recipients in the active set can claim from the reserve up to their max allocation for the remainder of the round. At the beginning of the next round, the max allocation for each recipient in the active set in the round is calculated based on the reserve funds available at the beginning of the round.

Fixes #306 

See the below Discord conversation for additional context:

```
j0sh: The freeze period removal makes sense to me. Just want to clarify my own understanding on one point:

The original concern I had (the reason for re-reviewing things) was due to the fact that tickets could be valid for longer than a round, so if the reserve is "reset" after each round, will the O be assured that it still has its original float available, especially if someone submits a ticket that draws from the reserve at the very end of a round? (The O is still in the pool for the next round.)

There is this item: "record the claimable amount at the time of overspending " - does that mean, if the reserve is drawn, something will be written on-chain which says, "At round X, orchestrators were entitled to $Y" ? How does that work?
```

```
yondon: Ah so this is an additional edge case introduced by the proposed design that "resets" the reserve at the beginning of each round. At the beginning of each round, each O in the active set is allocated X /  Y where X is the reserve amount (before anyone has claimed from it during the round) and Y is the size of the active set. 

If someone claims from B's reserve at the end of round N, then B's reserve will be X' < X. When round N + 1 starts, O's float will be less than X / Y since B's reserve at the beginning of round N + 1 is less than X.

Another situation where O's float can be reduced when a new round begins is if the size of the active set increases. If the size of the active set is Y + 1 in round N + 1, then O's float in round N + 1 is reduced to X / (Y + 1).

In summary, the edge cases that can happen if O receives a winning ticket at the end of a round are:

- O is no longer in the active set in round N + 1 and thus cannot redeem its ticket

- The size of the active set increases to Y + 1 in round N + 1 and thus O might not receive the full ticket faceValue when redeeming if the ticket faceValue > X / (Y + 1)

- Someone claims from the reserve at the end of round N which reduces the reserve to X'. O might not receive the full ticket faceValue when redeeming in round N + 1 if the ticket faceValue > X'
The first 2 edge cases would remain even if a freeze period is used. The 3rd edge case would be removed if a freeze period is used

All of these edge cases are caused by a combination of 2 factors:

1) O receiving a winning ticket very close to the end of a round

2) Some other factor that is out of O's control (i.e. its membership in the active set in the next round, the size of the active set increasing in the next round, someone claiming from the reserve before the current round ends)

It is worth noting that 1) is somewhat controlled by O since O sets the winning probability of tickets - given that tickets should generally have a low winning probability in order to avoid frequent on-chain txs, the probability of receiving a winning ticket close to the end of a round should also be low.

2) is out of O's control, but one strategy that O could use is that if it does receive a winning ticket close to the end of a round, it can pay a slightly higher gas fee to include the tx on-chain faster. This would cut into O's profits a bit though so O might want to use heuristics to determine how likely it is that one of the factors for 2) will occur. For example, O could check its stake ranking in the active set and only pay a slightly higher gas fee if it has a very low ranking with a higher risk of being evicted from the set next round if someone with more stake comes along.
There is this item: "record the claimable amount at the time of overspending " - does that mean, if the reserve is drawn, something will be written on-chain which says, "At round X, orchestrators were entitled to $Y" ? How does that work?

Ah yeah that sentence could've been clearer...let me try to reword...

If overspending happens, the contract will record the reserve amount prior to the first claim that draws from the reserve. The reserve amount recorded is the "claimable amount". During the round, this amount can be divided by the size of the active set to calculate the allocation guaranteed to each member of the active set.

The reason why the contract records the reserve amount prior to the first claim that draws from the reserve when overspending happens is because we want to calculate the allocations based on the total reserve available before it started to decrease due to claims.

Example:

1. reserve = 100 activeSetSize = 10
2. Person A claims 5 so we record claimableAmount = 100
3. reserve = 95
4. Person B claims - we calculate the allocation as 100 / 10 (instead of 95 / 10). So, the max amount that can be claimed is 10
5. Person A claims - we calculate the allocation as (100 / 10) - 5. So, the max amount that can be claimed is 5. We subtract 5 since person A already claimed 5 during that round

However, I ended up moving to a different design mentioned in this comment: https://github.com/livepeer/protocol/issues/306#issuecomment-530104035

Instead of recording the reserve amount prior to the first claim that draws from the reserve when overspending happens, the contract just records the total claimed from the reserve in the round thus far. IMO, this is simpler to reason about.

Example:

1. reserve = 100 activeSetSize = 10 claimed = 0
2. Person A claims 5 so we record claimed = 5
3. reserve = 95 claimed = 5
4. Person B claims - we calculate the allocation as (95 + 5) / 10. So, the max amount that can be claimed is 10
5. Person A claims - we calculate the allocation as (95 + 5) / 10 - 5. So, the max amount that can be claimed is 5.

In a round, we calculate the total reserve available to members of the active set by adding the funds remaining in the reserve with the funds already claimed from the reserve for that round
```