### PR TITLE
pm: Change unlock period to be round based

### DIFF
--- a/contracts/pm/mixins/interfaces/MTicketBrokerCore.sol
+++ b/contracts/pm/mixins/interfaces/MTicketBrokerCore.sol
@@ -27,7 +27,7 @@ contract MTicketBrokerCore {
     // Emitted when a funds transfer for a winning ticket redemption is executed
     event WinningTicketTransfer(address indexed sender, address indexed recipient, uint256 amount);
     // Emitted when a sender requests an unlock
-    event Unlock(address indexed sender, uint256 startBlock, uint256 endBlock);
+    event Unlock(address indexed sender, uint256 startRound, uint256 endRound);
     // Emitted when a sender cancels an unlock
     event UnlockCancelled(address indexed sender);
     // Emitted when a sender withdraws its deposit & reserve

--- a/test/helpers/ticket.js
+++ b/test/helpers/ticket.js
@@ -43,10 +43,12 @@ const getTicketHash = ticketObj => {
     )
 }
 
-const defaultAuxData = () => {
+const defaultAuxData = () => createAuxData(DUMMY_TICKET_CREATION_ROUND, DUMMY_TICKET_CREATION_ROUND_BLOCK_HASH)
+
+const createAuxData = (creationRound, blockHash) => {
     return web3.eth.abi.encodeParameters(
         ["uint256", "bytes32"],
-        [DUMMY_TICKET_CREATION_ROUND, DUMMY_TICKET_CREATION_ROUND_BLOCK_HASH]
+        [creationRound, blockHash]
     )
 }
 
@@ -55,6 +57,7 @@ const isSet = v => {
 }
 
 module.exports = {
+    createAuxData,
     createTicket,
     createWinningTicket,
     getTicketHash,


### PR DESCRIPTION
This PR updates the unlock period to be round based which makes the unlock period consistent with other time based variables in the rest of the contracts. Furthermore, the addition of a `withdrawRound` for the sender allows us to prevent reserve claims after the sender's unlock period is over which avoids an edge case with a reserve's `claimedForRound` and `claimedByAddress` mappings not being cleared upon withdrawal round N and being non-zero after a funding operation in that same round.