### PR TITLE
bondingManager: remove pendingRewardCut and pendingFeeShare

### DIFF
--- a/contracts/bonding/libraries/EarningsPool.sol
+++ b/contracts/bonding/libraries/EarningsPool.sol
@@ -30,15 +30,12 @@ library EarningsPool {
     }
 
     /**
-     * @dev Initialize a EarningsPool struct
+     * @dev Sets transcoderRewardCut and transcoderFeeshare for an EarningsPool
      * @param earningsPool Storage pointer to EarningsPool struct
-     * @param _stake Total stake of the transcoder during the earnings pool's round
      * @param _rewardCut Reward cut of transcoder during the earnings pool's round
      * @param _feeShare Fee share of transcoder during the earnings pool's round
      */
-    function init(EarningsPool.Data storage earningsPool, uint256 _stake, uint256 _rewardCut, uint256 _feeShare) internal {
-        earningsPool.totalStake = _stake;
-        earningsPool.claimableStake = _stake;
+    function setCommission(EarningsPool.Data storage earningsPool, uint256 _rewardCut, uint256 _feeShare) internal {
         earningsPool.transcoderRewardCut = _rewardCut;
         earningsPool.transcoderFeeShare = _feeShare;
         // We set this flag to true here to differentiate between EarningsPool structs created using older versions of this library.
@@ -48,21 +45,21 @@ library EarningsPool {
     }
 
     /**
+     * @dev Sets totalStake and claimableStake for an EarningsPool
+     * @param earningsPool Storage pointer to EarningsPool struct
+     * @param _stake Total stake of the transcoder during the earnings pool's round
+     */
+    function setStake(EarningsPool.Data storage earningsPool, uint256 _stake) internal {
+        earningsPool.totalStake = _stake;
+        earningsPool.claimableStake = _stake;
+    }
+
+    /**
      * @dev Return whether this earnings pool has claimable shares i.e. is there unclaimed stake
      * @param earningsPool Storage pointer to EarningsPool struct
      */
     function hasClaimableShares(EarningsPool.Data storage earningsPool) internal view returns (bool) {
         return earningsPool.claimableStake > 0;
-    }
-
-    function activateStake(EarningsPool.Data storage earningsPool, uint256 _stake) internal {
-        earningsPool.totalStake = _stake;
-        earningsPool.claimableStake = _stake;
-    }
-
-    function deactivateStake(EarningsPool.Data storage earningsPool) internal {
-        earningsPool.totalStake = 0;
-        earningsPool.claimableStake = 0;
     }
 
     /** 

--- a/contracts/test/TestEarningsPool.sol
+++ b/contracts/test/TestEarningsPool.sol
@@ -9,31 +9,12 @@ contract TestEarningsPool {
 
     function beforeEach() public {
         fixture = new EarningsPoolFixture();
-        fixture.init(1000, 500000, 500000);
+        fixture.setStake(1000);
+        fixture.setCommission(500000, 500000);
     }
 
-    function test_init() public {
-        (
-            uint256 rewardPool, 
-            uint256 feePool, 
-            uint256 transcoderRewardPool, 
-            uint256 transcoderFeePool, 
-            bool hasTranscoderRewardFeePool, 
-            uint256 totalStake, 
-            uint256 claimableStake, 
-            uint256 rewardCut, 
-            uint256 feeShare
-        ) = fixture.getEarningsPool();
-        Assert.equal(rewardPool, 0, "wrong rewardPool");
-        Assert.equal(feePool, 0, "wrong feePool");
-        Assert.equal(transcoderRewardPool, 0, "wrong transcoderRewardPool");
-        Assert.equal(transcoderFeePool, 0, "wrong transcoderFeePool");
-        Assert.equal(hasTranscoderRewardFeePool, true, "wrong hasTranscoderRewardFeePool");
-        Assert.equal(totalStake, 1000, "wrong totalStake");
-        Assert.equal(claimableStake, 1000, "wrong claimableStake");
-        Assert.equal(rewardCut, 500000, "wrong transcoderRewardCut");
-        Assert.equal(feeShare, 500000, "wrong transcoderFeeShare");
-    }
+    // todo setCommission test 
+    // todo setStake test
 
     function test_addToFeePool() public {
         fixture.addToFeePool(1000);
@@ -49,7 +30,7 @@ contract TestEarningsPool {
 
     function test_addToFeePool_noDelegatorFees() public {
         // feeShare = 0% - no delegator fees
-        fixture.init(1000, 500000, 0);
+        fixture.setCommission(500000, 0);
         fixture.addToFeePool(1000);
         Assert.equal(fixture.getFeePool(), 0, "should put 0 fees in delegator fee pool");
         Assert.equal(fixture.getTranscoderFeePool(), 1000, "should put all fees in transcoder fee pool");
@@ -57,7 +38,7 @@ contract TestEarningsPool {
 
     function test_addToFeePool_noTranscoderFees() public {
         // feeShare = 100% - no transcoder fees
-        fixture.init(1000, 500000, 1000000);
+        fixture.setCommission(500000, 1000000);
         fixture.addToFeePool(1000);
         Assert.equal(fixture.getFeePool(), 1000, "should put all fees in delegator fee pool");
         Assert.equal(fixture.getTranscoderFeePool(), 0, "should put 0 fees in transcoder fee pool");
@@ -77,7 +58,7 @@ contract TestEarningsPool {
 
     function test_addToRewardPool_noDelegatorRewards() public {
         // rewardCut = 100% - no delegator rewards
-        fixture.init(1000, 1000000, 500000);
+        fixture.setCommission(1000000, 500000);
         fixture.addToRewardPool(1000);
         Assert.equal(fixture.getRewardPool(), 0, "should put 0 rewards in delegator reward pool");
         Assert.equal(fixture.getTranscoderRewardPool(), 1000, "should put all rewards in transcoder reward pool");
@@ -85,7 +66,7 @@ contract TestEarningsPool {
 
     function test_addToRewardPool_noRewards() public {
         // rewardCut = 0% - no transcoder rewards
-        fixture.init(1000, 0, 500000);
+        fixture.setCommission(0, 500000);
         fixture.addToRewardPool(1000);
         Assert.equal(fixture.getRewardPool(), 1000, "should put all rewards in delegator reward pool");
         Assert.equal(fixture.getTranscoderRewardPool(), 0, "should put 0 rewards in transcoder reward pool");

--- a/contracts/test/TestEarningsPool2.sol
+++ b/contracts/test/TestEarningsPool2.sol
@@ -9,7 +9,8 @@ contract TestEarningsPool2 {
 
     function beforeEach() public {
         fixture = new EarningsPoolFixture();
-        fixture.init(1000, 500000, 500000);
+        fixture.setStake(1000);
+        fixture.setCommission(500000, 500000);
     }
 
     function test_claimShare_notTranscoder() public {
@@ -25,7 +26,7 @@ contract TestEarningsPool2 {
         Assert.equal(fixture.getClaimableStake(), 500, "should decrease claimable stake by stake of claimant");
     }
 
-   function test_claimShare_isTranscoder() public {
+    function test_claimShare_isTranscoder() public {
         fixture.addToFeePool(1000);
         fixture.addToRewardPool(1000);
         (uint256 fees, uint256 rewards) = fixture.claimShare(500, true);
@@ -98,7 +99,8 @@ contract TestEarningsPool2 {
     }
 
     function test_feePoolShare_noClaimableStake() public {
-        fixture.init(0, 0, 0);
+        fixture.setStake(0);
+        fixture.setCommission(0, 0);
         Assert.equal(fixture.feePoolShare(500, false), 0, "should return 0 if no claimable stake");
     }
 
@@ -113,7 +115,8 @@ contract TestEarningsPool2 {
     }
 
     function test_rewardPoolShare_noClaimableStake() public {
-        fixture.init(0, 0, 0);
+        fixture.setStake(0);
+        fixture.setCommission(0, 0);
         Assert.equal(fixture.rewardPoolShare(500, false), 0, "should return 0 if no claimable stake");
     }
 
@@ -132,7 +135,8 @@ contract TestEarningsPool2 {
     }
 
     function test_hasClaimableShares_zeroClaimableStake() public {
-        fixture.init(0, 0, 0);
+        fixture.setStake(0);
+        fixture.setCommission(0, 0);
         Assert.equal(fixture.hasClaimableShares(), false, "should return false when pool has zero claimable stake");
     }
 }

--- a/contracts/test/TestEarningsPoolNoTranscoderRewardFeePool.sol
+++ b/contracts/test/TestEarningsPoolNoTranscoderRewardFeePool.sol
@@ -9,7 +9,8 @@ contract TestEarningsPoolNoTranscoderRewardFeePool {
 
     function beforeEach() public {
         fixture = new EarningsPoolFixture();
-        fixture.init(1000, 500000, 500000);
+        fixture.setStake(1000);
+        fixture.setCommission(500000, 500000);
         fixture.setHasTranscoderRewardFeePool(false);
     }
 
@@ -119,7 +120,8 @@ contract TestEarningsPoolNoTranscoderRewardFeePool {
     }
 
     function test_feePoolShare_noClaimableStake() public {
-        fixture.init(0, 0, 0);
+        fixture.setStake(0);
+        fixture.setCommission(0, 0);
         fixture.setHasTranscoderRewardFeePool(false);
         Assert.equal(fixture.feePoolShare(500, false), 0, "should return 0 if no claimable stake");
     }
@@ -135,7 +137,8 @@ contract TestEarningsPoolNoTranscoderRewardFeePool {
     }
 
     function test_rewardPoolShare_noClaimableStake() public {
-        fixture.init(0, 0, 0);
+        fixture.setStake(0);
+        fixture.setCommission(0, 0);
         fixture.setHasTranscoderRewardFeePool(false);
         Assert.equal(fixture.rewardPoolShare(500, false), 0, "should return 0 if no claimable stake");
     }
@@ -155,7 +158,8 @@ contract TestEarningsPoolNoTranscoderRewardFeePool {
     }
 
     function test_hasClaimableShares_zeroClaimableStake() public {
-        fixture.init(0, 0, 0);
+        fixture.setStake(0);
+        fixture.setCommission(0, 0);
         fixture.setHasTranscoderRewardFeePool(false);
         Assert.equal(fixture.hasClaimableShares(), false, "should return false when pool has zero claimable stake");
     }

--- a/contracts/test/mocks/EarningsPoolFixture.sol
+++ b/contracts/test/mocks/EarningsPoolFixture.sol
@@ -8,8 +8,12 @@ contract EarningsPoolFixture {
 
     EarningsPool.Data pool;
 
-    function init(uint256 _stake, uint256 _rewardCut, uint256 _feeShare) public {
-        pool.init(_stake, _rewardCut, _feeShare);
+    function setCommission(uint256 _rewardCut, uint256 _feeShare) public {
+        pool.setCommission(_rewardCut, _feeShare);
+    }
+
+    function setStake(uint256 _stake) public {
+        pool.setStake(_stake);
     }
 
     function setHasTranscoderRewardFeePool(bool _hasTranscoderRewardFeePool) public {

--- a/test/integration/Rewards.js
+++ b/test/integration/Rewards.js
@@ -88,10 +88,10 @@ contract("Rewards", accounts => {
             const currentRound = await roundsManager.currentRound()
             const d = await bondingManager.getDelegator(addr)
 
-            if (d[5].toNumber() < currentRound.toNumber()) {
+            if (d.lastClaimRound.toNumber() < currentRound.toNumber()) {
                 return await bondingManager.pendingStake(addr, currentRound)
             } else {
-                return d[0]
+                return d.bondedAmount
             }
         }
 

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -125,10 +125,8 @@ contract("BondingManager", accounts => {
                 await bondingManager.transcoder(5, 10)
 
                 let tInfo = await bondingManager.getTranscoder(accounts[0])
-                assert.equal(tInfo[1], 0, "wrong rewardCut")
-                assert.equal(tInfo[2], 0, "wrong feeShare")
-                assert.equal(tInfo[3], 5, "wrong pendingRewardCut")
-                assert.equal(tInfo[4], 10, "wrong pendingFeeShare")
+                assert.equal(tInfo[1], 5, "wrong rewardCut")
+                assert.equal(tInfo[2], 10, "wrong feeShare")
             })
 
             describe("transcoder pool is not full", () => {
@@ -186,6 +184,8 @@ contract("BondingManager", accounts => {
                         // Caller bonds 6000 which is more than transcoder with least delegated stake
                         await bondingManager.bond(6000, newTranscoder, {from: newTranscoder})
                         await bondingManager.transcoder(5, 10, {from: newTranscoder})
+                        await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
+
                         await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
 
                         // Subtract evicted transcoder's delegated stake and add new transcoder's delegated stake
@@ -257,18 +257,14 @@ contract("BondingManager", accounts => {
                 await bondingManager.transcoder(5, 10)
 
                 let tInfo = await bondingManager.getTranscoder(accounts[0])
-                assert.equal(tInfo[1], 0, "wrong rewardCut")
-                assert.equal(tInfo[2], 0, "wrong feeShare")
-                assert.equal(tInfo[3], 5, "wrong pendingRewardCut")
-                assert.equal(tInfo[4], 10, "wrong pendingFeeShare")
+                assert.equal(tInfo[1], 5, "wrong rewardCut")
+                assert.equal(tInfo[2], 10, "wrong feeShare")
 
                 await bondingManager.transcoder(10, 15)
 
                 tInfo = await bondingManager.getTranscoder(accounts[0])
-                assert.equal(tInfo[1], 0, "wrong rewardCut")
-                assert.equal(tInfo[2], 0, "wrong feeShare")
-                assert.equal(tInfo[3], 10, "wrong pendingRewardCut")
-                assert.equal(tInfo[4], 15, "wrong pendingFeeShare")
+                assert.equal(tInfo[1], 10, "wrong rewardCut")
+                assert.equal(tInfo[2], 15, "wrong feeShare")
             })
         })
     })
@@ -1540,37 +1536,8 @@ contract("BondingManager", accounts => {
 
         it("should set the active transcoder set for the current round", async () => {
             await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
-
-            const tInfo0 = await bondingManager.getTranscoder(transcoder0)
-            assert.equal(tInfo0[1], tInfo0[3].toNumber(), "should set rewardCut to pendingRewardCut")
-            assert.equal(tInfo0[2], tInfo0[4].toNumber(), "should set feeShare to pendingFeeShare")
-            const earningsPool0 = await bondingManager.getTranscoderEarningsPoolForRound(transcoder0, currentRound + 1)
-            assert.equal(earningsPool0[0], 0, "should set delegator reward pool to 0")
-            assert.equal(earningsPool0[1], 0, "should set delegator fee pool to 0")
-            assert.equal(earningsPool0[2], 1000, "should set total stake for earnings pool to transcoder's total stake for the round")
-            assert.equal(earningsPool0[3], 1000, "should set claimable stake for earnings pool to current total stake")
-            assert.equal(earningsPool0[4], 5, "should set transcoder reward cut")
-            assert.equal(earningsPool0[5], 10, "should set transcoder fee share")
-            assert.equal(earningsPool0[6], 0, "should set transcoder reward pool to 0")
-            assert.equal(earningsPool0[7], 0, "should set transcoder fee pool to 0")
-            assert.equal(earningsPool0[8], true, "should set hasTranscoderRewardFeePool flag to true")
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
             assert.isOk(await bondingManager.isActiveTranscoder(transcoder0), "should set transcoder as active for current round")
-
-            const tInfo1 = await bondingManager.getTranscoder(transcoder1)
-            assert.equal(tInfo1[1], tInfo1[3].toNumber(), "should set rewardCut to pendingRewardCut")
-            assert.equal(tInfo1[2], tInfo1[4].toNumber(), "should set feeShare to pendingFeeShare")
-            const earningsPool1 = await bondingManager.getTranscoderEarningsPoolForRound(transcoder1, currentRound + 1)
-            assert.equal(earningsPool1[0], 0, "should set delegator reward pool to 0")
-            assert.equal(earningsPool1[1], 0, "should set delegator fee pool to 0")
-            assert.equal(earningsPool1[2], 1000, "should set total stake for earnings pool to transcoder's total stake for the round")
-            assert.equal(earningsPool1[3], 1000, "should set claimable stake for earnings pool to current total stake")
-            assert.equal(earningsPool1[4], 5, "should set transcoder reward cut")
-            assert.equal(earningsPool1[5], 10, "should set transcoder fee share")
-            assert.equal(earningsPool1[6], 0, "should set transcoder reward pool to 0")
-            assert.equal(earningsPool1[7], 0, "should set transcoder fee pool to 0")
-            assert.equal(earningsPool1[8], true, "should set hasTranscoderRewardFeePool flag to true")
-
             assert.isOk(await bondingManager.isActiveTranscoder(transcoder1), "should set transcoder as active for current round")
 
             assert.equal(await bondingManager.nextRoundTotalActiveStake(), 2000, "should set total active stake to sum of total stake of all active transcoders")
@@ -1591,7 +1558,6 @@ contract("BondingManager", accounts => {
             await bondingManager.transcoder(5, 10, {from: transcoder})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
-            await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
             await fixture.minter.setMockUint256(functionSig("createReward(uint256,uint256)"), 1000)
         })
 
@@ -1608,14 +1574,13 @@ contract("BondingManager", accounts => {
         })
 
         it("should fail if caller is not an active transcoder for the current round", async () => {
-            await expectThrow(bondingManager.reward({from: nonTranscoder}))
+            await expectRevertWithReason(bondingManager.reward({from: nonTranscoder}), "caller must be an active transcoder")
         })
 
         it("should fail if caller already called reward during the current round", async () => {
             await bondingManager.reward({from: transcoder})
-
             // This should fail because transcoder already called reward during the current round
-            await expectThrow(bondingManager.reward({from: transcoder}))
+            await expectRevertWithReason(bondingManager.reward({from: transcoder}), "caller has already called reward for the current round")
         })
 
         it("should update caller with rewards", async () => {
@@ -1647,7 +1612,7 @@ contract("BondingManager", accounts => {
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
-            await bondingManager.transcoder(5, 10, {from: transcoder})
+            await bondingManager.transcoder(100, 100, {from: transcoder})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
         })
@@ -1695,7 +1660,7 @@ contract("BondingManager", accounts => {
             )
 
             const earningsPool = await bondingManager.getTranscoderEarningsPoolForRound(transcoder, currentRound + 1)
-            assert.equal(earningsPool[1], 1000, "should update fees in earnings pool for current round")
+            assert.equal(earningsPool.transcoderFeePool, 1000, "should update fees in earnings pool for current round")
         })
     })
 
@@ -1977,13 +1942,15 @@ contract("BondingManager", accounts => {
         beforeEach(async () => {
             await fixture.roundsManager.setMockBool(functionSig("currentRoundInitialized()"), true)
             await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), false)
-            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound - 1)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
             await bondingManager.transcoder(50 * PERC_MULTIPLIER, 25 * PERC_MULTIPLIER, {from: transcoder})
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
             await bondingManager.bond(3000, transcoder, {from: delegator1})
             await bondingManager.bond(3000, transcoder, {from: delegator2})
             await bondingManager.bond(3000, transcoder, {from: delegator3})
+            await fixture.roundsManager.execute(bondingManager.address, functionSig("setCurrentRoundTotalActiveStake()"))
 
             transcoderRewards = Math.floor(1000 * .5)
             transcoderFees = Math.floor(1000 * .75)
@@ -1991,7 +1958,9 @@ contract("BondingManager", accounts => {
             delegatorFees = 1000 - transcoderFees
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
-            await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
+            await fixture.minter.setMockUint256(functionSig("createReward(uint256,uint256)"), 1000)
+            await bondingManager.reward({from: transcoder})
+
             await fixture.ticketBroker.execute(
                 bondingManager.address,
                 functionEncodedABI(
@@ -2000,8 +1969,6 @@ contract("BondingManager", accounts => {
                     [transcoder, 1000, currentRound + 1]
                 )
             )
-            await fixture.minter.setMockUint256(functionSig("createReward(uint256,uint256)"), 1000)
-            await bondingManager.reward({from: transcoder})
         })
 
         it("should fail if system is paused", async () => {
@@ -2017,11 +1984,11 @@ contract("BondingManager", accounts => {
         })
 
         it("should fail if provided endRound is before caller's lastClaimRound", async () => {
-            await expectThrow(bondingManager.claimEarnings(currentRound - 1, {from: delegator1}))
+            await expectRevertWithReason(bondingManager.claimEarnings(currentRound - 1, {from: delegator1}), "end round must be after last claim round")
         })
 
         it("should fail if provided endRound is in the future", async () => {
-            await expectThrow(bondingManager.claimEarnings(currentRound + 2, {from: delegator1}))
+            await expectRevertWithReason(bondingManager.claimEarnings(currentRound + 2, {from: delegator1}), "end round must be before or equal to current round")
         })
 
         it("updates caller's lastClaimRound", async () => {
@@ -2033,9 +2000,10 @@ contract("BondingManager", accounts => {
         describe("caller has a delegate", () => {
             it("should fail if endRound - lastClaimRound > maxEarningsClaimsRounds (too many rounds to claim through)", async () => {
                 const maxEarningsClaimsRounds = await bondingManager.maxEarningsClaimsRounds.call()
-                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + maxEarningsClaimsRounds.toNumber() + 1)
+                const maxClaimRound = currentRound + 1 + maxEarningsClaimsRounds.toNumber()
+                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), maxClaimRound + 1)
 
-                await expectThrow(bondingManager.claimEarnings(currentRound + 21, {from: delegator1}))
+                await expectRevertWithReason(bondingManager.claimEarnings(maxClaimRound+ 1, {from: delegator1}), "too many rounds to claim through")
             })
 
             it("should claim earnings for 1 round", async () => {
@@ -2101,7 +2069,8 @@ contract("BondingManager", accounts => {
                 const acceptableDelta = 2
 
                 await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 2)
-                await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
+                await fixture.minter.setMockUint256(functionSig("createReward(uint256,uint256)"), 1000)
+                await bondingManager.reward({from: transcoder})
                 await fixture.ticketBroker.execute(
                     bondingManager.address,
                     functionEncodedABI(
@@ -2110,8 +2079,6 @@ contract("BondingManager", accounts => {
                         [transcoder, 1000, currentRound + 2]
                     )
                 )
-                await fixture.minter.setMockUint256(functionSig("createReward(uint256,uint256)"), 1000)
-                await bondingManager.reward({from: transcoder})
 
                 const startDInfo1 = await bondingManager.getDelegator(delegator1)
                 await bondingManager.claimEarnings(currentRound + 2, {from: delegator1})
@@ -2233,33 +2200,32 @@ contract("BondingManager", accounts => {
         beforeEach(async () => {
             await fixture.roundsManager.setMockBool(functionSig("currentRoundInitialized()"), true)
             await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), false)
-            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound - 2)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
             await bondingManager.transcoder(50 * PERC_MULTIPLIER, 25 * PERC_MULTIPLIER, {from: transcoder})
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound - 1)
             await bondingManager.bond(1000, transcoder, {from: delegator})
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
+
+            await fixture.ticketBroker.execute(
+                bondingManager.address,
+                functionEncodedABI(
+                    "updateTranscoderWithFees(address,uint256,uint256)",
+                    ["address", "uint256", "uint256"],
+                    [transcoder, 1000, currentRound]
+                )
+            )
+            await fixture.minter.setMockUint256(functionSig("createReward(uint256,uint256)"), 1000)
+            await bondingManager.reward({from: transcoder})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
-            await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
             await fixture.ticketBroker.execute(
                 bondingManager.address,
                 functionEncodedABI(
                     "updateTranscoderWithFees(address,uint256,uint256)",
                     ["address", "uint256", "uint256"],
                     [transcoder, 1000, currentRound + 1]
-                )
-            )
-            await fixture.minter.setMockUint256(functionSig("createReward(uint256,uint256)"), 1000)
-            await bondingManager.reward({from: transcoder})
-
-            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 2)
-            await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
-            await fixture.ticketBroker.execute(
-                bondingManager.address,
-                functionEncodedABI(
-                    "updateTranscoderWithFees(address,uint256,uint256)",
-                    ["address", "uint256", "uint256"],
-                    [transcoder, 1000, currentRound + 2]
                 )
             )
             await fixture.minter.setMockUint256(functionSig("createReward(uint256,uint256)"), 1000)
@@ -2271,18 +2237,17 @@ contract("BondingManager", accounts => {
         })
 
         it("should fail if endRound is before lastClaimRound", async () => {
-            await expectThrow(bondingManager.pendingStake(delegator, currentRound - 1))
+            await expectThrow(bondingManager.pendingStake(delegator, currentRound - 2))
         })
 
         it("should fail if endRound = lastClaimRound", async () => {
-            await expectThrow(bondingManager.pendingStake(delegator, currentRound))
+            await expectThrow(bondingManager.pendingStake(delegator, currentRound - 1))
         })
 
         it("should return pending rewards for 1 round", async () => {
             const pendingRewards0 = 250
-
             assert.equal(
-                await bondingManager.pendingStake(delegator, currentRound + 1),
+                (await bondingManager.pendingStake(delegator, currentRound)),
                 1000 + pendingRewards0,
                 "should return sum of bondedAmount and pending rewards for 1 round"
             )
@@ -2293,7 +2258,7 @@ contract("BondingManager", accounts => {
             const pendingRewards1 = Math.floor((500 * (1250 * PERC_DIVISOR / 3000)) / PERC_DIVISOR)
 
             assert.equal(
-                await bondingManager.pendingStake(delegator, currentRound + 2),
+                (await bondingManager.pendingStake(delegator, currentRound + 1)).toString(),
                 1000 + pendingRewards0 + pendingRewards1,
                 "should return sum of bondedAmount and pending rewards for 2 rounds"
             )
@@ -2301,15 +2266,15 @@ contract("BondingManager", accounts => {
 
         describe("no claimable shares for the round", async () => {
             beforeEach(async () => {
-                await bondingManager.claimEarnings(currentRound + 2, {from: delegator})
+                await bondingManager.claimEarnings(currentRound + 1, {from: delegator})
 
-                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 3)
+                await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 2)
             })
 
             it("should return bondedAmount + 0 (pending rewards)", async () => {
                 const bondedAmount = 1000 + 250 + Math.floor((500 * (1250 * PERC_DIVISOR / 3000)) / PERC_DIVISOR)
 
-                assert.equal(await bondingManager.pendingStake(delegator, currentRound + 3), bondedAmount, "should return sum of bondedAmount + 0 (pending rewards) for 1 round")
+                assert.equal(await bondingManager.pendingStake(delegator, currentRound + 2), bondedAmount, "should return sum of bondedAmount + 0 (pending rewards) for 1 round")
             })
         })
 
@@ -2318,7 +2283,7 @@ contract("BondingManager", accounts => {
                 const pendingRewards = 500 + 250
 
                 assert.equal(
-                    await bondingManager.pendingStake(transcoder, currentRound + 1),
+                    await bondingManager.pendingStake(transcoder, currentRound),
                     1000 + pendingRewards,
                     "should return sum of bondedAmount and pending rewards as both a delegator and transcoder for a round"
                 )
@@ -2334,14 +2299,14 @@ contract("BondingManager", accounts => {
         beforeEach(async () => {
             await fixture.roundsManager.setMockBool(functionSig("currentRoundInitialized()"), true)
             await fixture.roundsManager.setMockBool(functionSig("currentRoundLocked()"), false)
-            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound - 1)
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
             await bondingManager.transcoder(50 * PERC_MULTIPLIER, 25 * PERC_MULTIPLIER, {from: transcoder})
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
             await bondingManager.bond(1000, transcoder, {from: delegator})
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
-            await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
             await fixture.ticketBroker.execute(
                 bondingManager.address,
                 functionEncodedABI(
@@ -2352,9 +2317,10 @@ contract("BondingManager", accounts => {
             )
             await fixture.minter.setMockUint256(functionSig("createReward(uint256,uint256)"), 1000)
             await bondingManager.reward({from: transcoder})
+            // because we call reward after updateTranscoderWithFees earningsPool.hasTranscoderRewardFeePool will be false
+            // and fees will not be divided up, how can we ensure this value is true at the beginning of a round for the current earningsPool?
 
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 2)
-            await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
             await fixture.ticketBroker.execute(
                 bondingManager.address,
                 functionEncodedABI(
@@ -2381,8 +2347,7 @@ contract("BondingManager", accounts => {
 
         it("should return pending fees for 1 round", async () => {
             const pendingFees0 = 125
-
-            assert.equal(await bondingManager.pendingFees(delegator, currentRound + 1), pendingFees0, "should return sum of collected fees and pending fees for 1 round")
+            assert.equal((await bondingManager.pendingFees(delegator, currentRound + 1)).toString(), pendingFees0, "should return sum of collected fees and pending fees for 1 round")
         })
 
         it("should return pending fees for > 1 round", async () => {
@@ -2434,6 +2399,7 @@ contract("BondingManager", accounts => {
 
             await bondingManager.bond(1000, transcoder, {from: transcoder})
             await bondingManager.transcoder(5, 10, {from: transcoder})
+            await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
         })
 
         it("should return 0 transcoder is not active", async () => {
@@ -2441,9 +2407,7 @@ contract("BondingManager", accounts => {
         })
 
         it("should return active transcoder's total stake for round", async () => {
-            await fixture.roundsManager.execute(bondingManager.address, functionSig("setActiveTranscoders()"))
-
-            assert.equal(await bondingManager.activeTranscoderTotalStake(transcoder, currentRound), 1000, "should return active transcoder's total stake for round")
+            assert.equal(await bondingManager.activeTranscoderTotalStake(transcoder, currentRound + 1), 1000, "should return active transcoder's total stake for round")
         })
     })
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This pull request removes initialisation of earningsPool when `setActiveTranscoderSet` is called as well as any notion of `pendingRewardCut` and `pendingFeeShare`

Instead a transcoder will now call `reward()` to lock in his commissions, the stake for a transcoder's earningsPool will be set as bonding, unbonding, rebonding, slashing or updating a transcoder with rewards happens. 

**Specific updates (required)**
- Deprecated `pendingRewardCut` and `pendingFeeShare`
- Removed `EarningsPool.init` and replaced it with two other methods: `EarningsPool.setCommissions()` to set `feeCut` and `rewardShare` on the `EarningsPool` for a round and `EarningsPool.setStake()` to set the `totalStake` and `claimableStake` on the `EarningsPool` for a round
- Added a check to `bondingManager.updateTranscoderWithFees` to see whether a transcoder has already called `reward()` and thereby populated the `transcoderRewardShare` and `transcoderFeeCut` on its `EarningsPool` for the current round, if this is not the case the fees will be distributed according to the values set on the `Transcoder` struct. 
- added npm run commands: `npm run lint:fix` to run the linter with the `--fix` flag and `npm run test:describe <describe block message>` to run tests for specific describe blocks. 

**How did you test each of these updates (required)**
Adjusted & ran unit and integation tests

**Does this pull request close any open issues?**
Fixes #301

**Checklist:**
- [ ] README and other documentation updated
- [x] All unit & integration tests pass
