### PR TITLE
pm: add whenSystemNotPaused and currentRoundInitialized modifiers

### DIFF
--- a/contracts/Manager.sol
+++ b/contracts/Manager.sol
@@ -22,7 +22,7 @@ contract Manager is IManager {
 
     // Check if controller is not paused
     modifier whenSystemNotPaused() {
-        require(!controller.paused());
+        require(!controller.paused(), "system is paused");
         _;
     }
 

--- a/contracts/pm/mixins/MixinContractRegistry.sol
+++ b/contracts/pm/mixins/MixinContractRegistry.sol
@@ -4,7 +4,15 @@ import "../../ManagerProxyTarget.sol";
 import "./interfaces/MContractRegistry.sol";
 
 
-contract MixinContractRegistry is ManagerProxyTarget, MContractRegistry {
+contract MixinContractRegistry is MContractRegistry, ManagerProxyTarget {
+    /**
+     * @dev Checks if the current round has been initialized
+     */
+    modifier currentRoundInitialized() {
+        require(roundsManager().currentRoundInitialized(), "current round is not initialized");
+        _;
+    }
+
     constructor(address _controller)
         internal
         Manager(_controller)

--- a/contracts/pm/mixins/MixinTicketBrokerCore.sol
+++ b/contracts/pm/mixins/MixinTicketBrokerCore.sol
@@ -67,6 +67,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     function fundDeposit()
         external
         payable
+        whenSystemNotPaused
         processDeposit(msg.sender, msg.value)
     {
         processFunding(msg.value);
@@ -78,6 +79,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     function fundReserve()
         external
         payable
+        whenSystemNotPaused
         processReserve(msg.sender, msg.value)
     {
         processFunding(msg.value);
@@ -94,6 +96,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     )
         external
         payable
+        whenSystemNotPaused
         checkDepositReserveETHValueSplit(_depositAmount, _reserveAmount)
         processDeposit(msg.sender, _depositAmount)
         processReserve(msg.sender, _reserveAmount)
@@ -114,6 +117,8 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
         uint256 _recipientRand
     )
         public
+        whenSystemNotPaused
+        currentRoundInitialized
     {
         bytes32 ticketHash = getTicketHash(_ticket);
 
@@ -178,7 +183,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     /**
      * @dev Initiates the unlock period for the caller
      */
-    function unlock() public {
+    function unlock() public whenSystemNotPaused {
         Sender storage sender = senders[msg.sender];
 
         require(
@@ -196,7 +201,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     /**
      * @dev Cancels the unlock period for the caller
      */
-    function cancelUnlock() public {
+    function cancelUnlock() public whenSystemNotPaused {
         Sender storage sender = senders[msg.sender];
 
         _cancelUnlock(sender, msg.sender);
@@ -205,7 +210,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     /**
      * @dev Withdraws all ETH from the caller's deposit and reserve
      */
-    function withdraw() public {
+    function withdraw() public whenSystemNotPaused {
         Sender storage sender = senders[msg.sender];
 
         uint256 deposit = sender.deposit;

--- a/contracts/pm/mixins/MixinWrappers.sol
+++ b/contracts/pm/mixins/MixinWrappers.sol
@@ -3,9 +3,11 @@ pragma solidity ^0.4.25;
 pragma experimental ABIEncoderV2;
 
 import "./interfaces/MTicketBrokerCore.sol";
+import "./interfaces/MContractRegistry.sol";
 
 
-contract MixinWrappers is MTicketBrokerCore {
+contract MixinWrappers is MContractRegistry, MTicketBrokerCore {
+
     /**
      * @dev Redeems multiple winning tickets. The function will redeem all of the provided
      * tickets and handle any failures gracefully without reverting the entire function
@@ -19,6 +21,8 @@ contract MixinWrappers is MTicketBrokerCore {
         uint256[] _recipientRands
     )
         public
+        whenSystemNotPaused
+        currentRoundInitialized
     {
         for (uint256 i = 0; i < _tickets.length; i++) {
             redeemWinningTicketNoRevert(

--- a/contracts/pm/mixins/interfaces/MContractRegistry.sol
+++ b/contracts/pm/mixins/interfaces/MContractRegistry.sol
@@ -7,6 +7,22 @@ import "../../../rounds/IRoundsManager.sol";
 
 contract MContractRegistry {
     /**
+     * @notice Checks if the system is paused
+     * @dev Executes the 'whenSystemNotPaused' modifier 'MixinContractRegistry' inherits from 'Manager.sol'
+     */
+    modifier whenSystemNotPaused() {
+        _;
+    }
+
+    /**
+     * @notice Checks if the current round has been initialized
+     * @dev Executes the 'currentRoundInitialized' modifier in 'MixinContractRegistry'
+     */
+    modifier currentRoundInitialized() {
+        _;
+    }
+
+    /**
      * @dev Returns an instance of the IBondingManager interface
      */
     function bondingManager() internal view returns (IBondingManager);

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -3,6 +3,7 @@ import expectThrow from "../helpers/expectThrow"
 import {contractId, functionSig, functionEncodedABI} from "../../utils/helpers"
 import {constants} from "../../utils/constants"
 import BN from "bn.js"
+import {expectRevertWithReason} from "../helpers/expectFail"
 
 const BondingManager = artifacts.require("BondingManager")
 
@@ -981,7 +982,7 @@ contract("BondingManager", accounts => {
         it("should fail if system is paused", async () => {
             await fixture.controller.pause()
 
-            await expectThrow(bondingManager.rebond(unbondingLockID, {from: delegator}))
+            await expectRevertWithReason(bondingManager.rebond(unbondingLockID, {from: delegator}), "system is paused")
         })
 
         it("should fail if current round is not initialized", async () => {
@@ -1081,7 +1082,10 @@ contract("BondingManager", accounts => {
             await bondingManager.unbond(500, {from: delegator})
             await fixture.controller.pause()
 
-            await expectThrow(bondingManager.rebondFromUnbonded(transcoder, unbondingLockID, {from: delegator}))
+            await expectRevertWithReason(
+                bondingManager.rebondFromUnbonded(transcoder, unbondingLockID, {from: delegator}),
+                "system is paused"
+            )
         })
 
         it("should fail if current round is not initialized", async () => {
@@ -1204,7 +1208,7 @@ contract("BondingManager", accounts => {
         it("should fail if system is paused", async () => {
             await fixture.controller.pause()
 
-            await expectThrow(bondingManager.withdrawStake(unbondingLockID, {from: delegator}))
+            await expectRevertWithReason(bondingManager.withdrawStake(unbondingLockID, {from: delegator}), "system is paused")
         })
 
         it("should fail if current round is not initialized", async () => {
@@ -1277,7 +1281,7 @@ contract("BondingManager", accounts => {
         it("should fail if system is paused", async () => {
             await fixture.controller.pause()
 
-            await expectThrow(bondingManager.withdrawFees({from: transcoder0}))
+            await expectRevertWithReason(bondingManager.withdrawFees({from: transcoder0}), "system is paused")
         })
 
         it("should fail if current round is not initialized", async () => {
@@ -1391,7 +1395,7 @@ contract("BondingManager", accounts => {
         it("should fail if system is paused", async () => {
             await fixture.controller.pause()
 
-            await expectThrow(bondingManager.reward({from: transcoder}))
+            await expectRevertWithReason(bondingManager.reward({from: transcoder}), "system is paused")
         })
 
         it("should fail if current round is not initialized", async () => {
@@ -1818,7 +1822,7 @@ contract("BondingManager", accounts => {
         it("should fail if system is paused", async () => {
             await fixture.controller.pause()
 
-            await expectThrow(bondingManager.claimEarnings(currentRound + 1, {from: delegator1}))
+            await expectRevertWithReason(bondingManager.claimEarnings(currentRound + 1, {from: delegator1}), "system is paused")
         })
 
         it("should fail if current round is not initialized", async () => {

--- a/test/unit/RoundsManager.js
+++ b/test/unit/RoundsManager.js
@@ -3,6 +3,7 @@ import expectThrow from "../helpers/expectThrow"
 import {contractId} from "../../utils/helpers"
 import {constants} from "../../utils/constants"
 import truffleAssert from "truffle-assertions"
+import {expectRevertWithReason} from "../helpers/expectFail"
 
 const RoundsManager = artifacts.require("RoundsManager")
 
@@ -170,7 +171,7 @@ contract("RoundsManager", accounts => {
             await fixture.rpc.waitUntilNextBlockMultiple(roundLength.toNumber())
             await fixture.controller.pause()
 
-            await expectThrow(roundsManager.initializeRound())
+            await expectRevertWithReason(roundsManager.initializeRound(), "system is paused")
         })
 
         it("should fail if current round is already initialized", async () => {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds a modifier to external/public `TicketBroker` functions and disallows ticket redemption if the round is not initialized.

**Specific updates (required)**
- Moved all external/public state mutating functions in the `pm` package to `TicketBroker.sol` so we can use `Manager.whenSystemNotPaused`. 
- Added `currentRoundInitialized` modifier to `TicketBroker`
- Add `whenSystemNotPaused` modifier to all external/public functions
- Add `currentRountInitialized` modifier to `redeemWinningTicket` and `batchRedeemWinningTickets`
- Added a revert message for `Manager.whenSystemNotPaused`

**How did you test each of these updates (required)**
Adjusted & ran unit and integation tests

**Does this pull request close any open issues?**
Fixes #308 

**Checklist:**
- [ ] README and other documentation updated
- [x] All unit & integration tests pass
