### PR TITLE
bonding: EarningsClaimed event

### DIFF
--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -16,6 +16,7 @@ contract IBondingManager {
     event Rebond(address indexed delegate, address indexed delegator, uint256 unbondingLockId, uint256 amount);
     event WithdrawStake(address indexed delegator, uint256 unbondingLockId, uint256 amount, uint256 withdrawRound);
     event WithdrawFees(address indexed delegator);
+    event EarningsClaimed(address indexed delegate, address indexed delegator, uint256 rewards, uint256 fees, uint256 startRound, uint256 endRound);
 
     // Deprecated events
     // These event signatures can be used to construct the appropriate topic hashes to filter for past logs corresponding


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds an `EarningsClaimed` event to the `BondingManager` that will be emitted when a delegator claims earnings. 

```
   event EarningsClaimed(address indexed delegator, address indexed delegate, uint256 rewards, uint256 fees, uint256 startRound, uint256 endRound);
```

**Specific updates (required)**
- added `EarningsClaimed` event definition to `BondingManager` interface
- emit `EarningsClaimed` event from `updateDelegatorWithEarnings`
- add unit tests to check if the event gets emitted correctly

**How did you test each of these updates (required)**
Adjusted & ran unit and integation tests

**Does this pull request close any open issues?**
Fixes #305 

**Checklist:**
- [ ] README and other documentation updated
- [x] All unit & integration tests pass