### PR TITLE
bonding: onlyVerifier modifier for slashTranscoder()

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -100,6 +100,12 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         _;
     }
 
+    // Check if sender is Verifier
+    modifier onlyVerifier() {
+        require(msg.sender == controller.getContract(keccak256("Verifier")));
+        _;
+    }
+
     // Check if current round is initialized
     modifier currentRoundInitialized() {
         require(roundsManager().currentRoundInitialized());
@@ -594,7 +600,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     )
         external
         whenSystemNotPaused
-        onlyTicketBroker
+        onlyVerifier
     {
         Delegator storage del = delegators[_transcoder];
 

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -1517,7 +1517,7 @@ contract("BondingManager", accounts => {
             await fixture.controller.pause()
 
             await expectThrow(
-                fixture.ticketBroker.execute(
+                fixture.verifier.execute(
                     bondingManager.address,
                     functionEncodedABI(
                         "slashTranscoder(address,address,uint256,uint256)",
@@ -1534,7 +1534,7 @@ contract("BondingManager", accounts => {
 
         it("decreases transcoder's bondedAmount", async () => {
             const startBondedAmount = (await bondingManager.getDelegator(transcoder))[0].toNumber()
-            await fixture.ticketBroker.execute(
+            await fixture.verifier.execute(
                 bondingManager.address,
                 functionEncodedABI(
                     "slashTranscoder(address,address,uint256,uint256)",
@@ -1550,7 +1550,7 @@ contract("BondingManager", accounts => {
         describe("transcoder is bonded", () => {
             it("updates delegated amount and total bonded tokens", async () => {
                 const startTotalBonded = await bondingManager.getTotalBonded()
-                await fixture.ticketBroker.execute(
+                await fixture.verifier.execute(
                     bondingManager.address,
                     functionEncodedABI(
                         "slashTranscoder(address,address,uint256,uint256)",
@@ -1572,7 +1572,7 @@ contract("BondingManager", accounts => {
 
             it("still decreases transcoder's bondedAmount", async () => {
                 const startBondedAmount = (await bondingManager.getDelegator(transcoder))[0].toNumber()
-                await fixture.ticketBroker.execute(
+                await fixture.verifier.execute(
                     bondingManager.address,
                     functionEncodedABI(
                         "slashTranscoder(address,address,uint256,uint256)",
@@ -1588,7 +1588,7 @@ contract("BondingManager", accounts => {
 
         describe("transcoder is registered", () => {
             it("removes transcoder from the pool", async () => {
-                await fixture.ticketBroker.execute(
+                await fixture.verifier.execute(
                     bondingManager.address,
                     functionEncodedABI(
                         "slashTranscoder(address,address,uint256,uint256)",
@@ -1603,7 +1603,7 @@ contract("BondingManager", accounts => {
             describe("transcoder is active", () => {
                 it("removes transcoder from active set for the current round", async () => {
                     const startTotalActiveStake = await bondingManager.getTotalActiveStake(currentRound + 1)
-                    await fixture.ticketBroker.execute(
+                    await fixture.verifier.execute(
                         bondingManager.address,
                         functionEncodedABI(
                             "slashTranscoder(address,address,uint256,uint256)",
@@ -1623,7 +1623,7 @@ contract("BondingManager", accounts => {
             it("still decreases transcoder's bondedAmount", () => {
                 it("still decreases transcoder's bondedAmount", async () => {
                     const startBondedAmount = (await bondingManager.getDelegator(transcoder))[0]
-                    await fixture.ticketBroker.execute(
+                    await fixture.verifier.execute(
                         bondingManager.address,
                         functionEncodedABI(
                             "slashTranscoder(address,address,uint256,uint256)",
@@ -1646,7 +1646,7 @@ contract("BondingManager", accounts => {
                     assert.equal(e.returnValues.finderReward, 250, "should fire TranscoderSlashed event with finder reward computed with finderFee")
                 })
 
-                await fixture.ticketBroker.execute(
+                await fixture.verifier.execute(
                     bondingManager.address,
                     functionEncodedABI(
                         "slashTranscoder(address,address,uint256,uint256)",
@@ -1665,7 +1665,7 @@ contract("BondingManager", accounts => {
                     assert.equal(e.returnValues.finderReward, 0, "should fire TranscoderSlashed event with finder reward of 0")
                 })
 
-                await fixture.ticketBroker.execute(
+                await fixture.verifier.execute(
                     bondingManager.address,
                     functionEncodedABI(
                         "slashTranscoder(address,address,uint256,uint256)",
@@ -1691,7 +1691,7 @@ contract("BondingManager", accounts => {
                     assert.equal(e.returnValues.finderReward, 0, "should fire TranscoderSlashed event with finder reward of 0")
                 })
 
-                await fixture.ticketBroker.execute(
+                await fixture.verifier.execute(
                     bondingManager.address,
                     functionEncodedABI(
                         "slashTranscoder(address,address,uint256,uint256)",


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR replaces `onlyTicketBroker` with a newly introduced `onlyVerifier` modifier

**Specific updates (required)**
- added an `onlyVerifier` modifier that checks if the caller is the `Verifier` contract (0x000...) in streamflow
- replace `onlyTicketBroker` with `onlyVerifier` on `bondingManager.slashTranscoder()`
- adjust `slashTranscoder` unit tests in `BondingManager.js` to call from the mock verifier instead of ticketBroker

**How did you test each of these updates (required)**
Adjusted & ran unit and integration tests

**Does this pull request close any open issues?**
Fixes #315 

**Checklist:**
- [ ] README and other documentation updated
- [x] All unit & integration tests pass