### PR TITLE
pm: Use isActiveTranscoder() when claiming from reserve

### DIFF
--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -29,10 +29,10 @@ contract IBondingManager {
     function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external;
     function slashTranscoder(address _transcoder, address _finder, uint256 _slashAmount, uint256 _finderFee) external;
     function setCurrentRoundTotalActiveStake() external;
-    
+
     // Public functions
     function getTranscoderPoolSize() public view returns (uint256);
     function transcoderTotalStake(address _transcoder) public view returns (uint256);
-    function isRegisteredTranscoder(address _transcoder) public view returns (bool);
+    function isActiveTranscoder(address _transcoder) public view returns (bool);
     function getTotalBonded() public view returns (uint256);
 }

--- a/contracts/pm/mixins/MixinReserve.sol
+++ b/contracts/pm/mixins/MixinReserve.sol
@@ -40,9 +40,7 @@ contract MixinReserve is MContractRegistry, MReserve {
 
         uint256 currentRound = roundsManager().currentRound();
 
-        // TODO: Check if claimant is active in the current round
-        // We are just checking if it is registered for now
-        if (!bondingManager().isRegisteredTranscoder(_claimant)) {
+        if (!bondingManager().isActiveTranscoder(_claimant)) {
             return 0;
         }
 

--- a/test/unit/TicketBroker.js
+++ b/test/unit/TicketBroker.js
@@ -206,7 +206,7 @@ contract("TicketBroker", accounts => {
             const allocation = reserve / numRecipients
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
             await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-            await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+            await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
             await broker.fundReserve({from: sender, value: reserve})
 
             const recipientRand = 5
@@ -230,7 +230,7 @@ contract("TicketBroker", accounts => {
             const allocation = reserve / numRecipients
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
             await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-            await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+            await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
             await broker.fundReserve({from: sender, value: reserve})
 
             const recipientRand = 5
@@ -384,7 +384,7 @@ contract("TicketBroker", accounts => {
             const allocation = reserve / numRecipients
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
             await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-            await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+            await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
             await broker.fundReserve({from: sender, value: reserve})
 
             const recipientRand = 5
@@ -412,7 +412,7 @@ contract("TicketBroker", accounts => {
             const allocation = reserve / numRecipients
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
             await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-            await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+            await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
             await broker.fundReserve({from: sender, value: reserve})
 
             const recipientRand = 5
@@ -685,7 +685,7 @@ contract("TicketBroker", accounts => {
                     await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
                     // Set the number of registered recipients to 0
                     await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), 0)
-                    await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), false)
+                    await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), false)
                     await broker.fundReserve({from: sender, value: 1000})
 
                     const recipientRand = 5
@@ -704,7 +704,7 @@ contract("TicketBroker", accounts => {
                     const numRecipients = 10
                     await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
                     await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-                    await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), false)
+                    await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), false)
                     await broker.fundReserve({from: sender, value: 1000})
 
                     const recipientRand = 5
@@ -725,7 +725,7 @@ contract("TicketBroker", accounts => {
                     const allocation = reserve / numRecipients
                     await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
                     await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-                    await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+                    await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
                     await broker.fundReserve({from: sender, value: reserve})
 
                     const recipientRand = 5
@@ -753,7 +753,7 @@ contract("TicketBroker", accounts => {
                     const partialAmount = 10
                     await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
                     await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-                    await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+                    await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
                     await broker.fundReserve({from: sender, value: reserve})
 
                     const recipientRand = 5
@@ -783,7 +783,7 @@ contract("TicketBroker", accounts => {
                     const numRecipients = 10
                     await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
                     await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-                    await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+                    await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
                     await broker.fundReserve({from: sender, value: 1000})
 
                     const recipientRand = 5
@@ -817,7 +817,7 @@ contract("TicketBroker", accounts => {
                     const numRecipients = 10
                     await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
                     await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-                    await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+                    await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
                     await broker.fundReserve({from: sender, value: 1000})
 
                     const recipientRand = 5
@@ -846,7 +846,7 @@ contract("TicketBroker", accounts => {
                     const numRecipients = 10
                     await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
                     await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-                    await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+                    await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
                     await broker.fundReserve({from: sender, value: 1000})
 
                     const recipientRand = 5
@@ -878,7 +878,7 @@ contract("TicketBroker", accounts => {
                     const fromBlock = (await web3.eth.getBlock("latest")).number
                     await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
                     await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-                    await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+                    await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
                     await broker.fundReserve({from: sender, value: reserve})
 
                     const recipientRand = 5
@@ -921,7 +921,7 @@ contract("TicketBroker", accounts => {
                         const deposit = 500
                         await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
                         await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-                        await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+                        await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
                         await broker.fundDeposit({from: sender, value: deposit})
 
                         const recipientRand = 5
@@ -954,7 +954,7 @@ contract("TicketBroker", accounts => {
                         const reserve = 50000
                         await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
                         await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-                        await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+                        await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
                         await broker.fundDeposit({from: sender, value: deposit})
                         await broker.fundReserve({from: sender, value: reserve})
 
@@ -1690,7 +1690,7 @@ contract("TicketBroker", accounts => {
         })
 
         it("returns 0 when the active transcoder pool size is 0", async () => {
-            await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+            await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
             await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), 0)
 
             const reserve = 1000
@@ -1704,7 +1704,7 @@ contract("TicketBroker", accounts => {
             const reserve = 1000
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
             await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-            await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+            await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
             await broker.fundDepositAndReserve(deposit, reserve, {from: sender, value: deposit+reserve})
             assert.equal(
                 (await broker.claimableReserve(sender, recipient)).toString(10),
@@ -1733,7 +1733,7 @@ contract("TicketBroker", accounts => {
             const reserve = 1000
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
             await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-            await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+            await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
             await broker.fundReserve({from: sender, value: reserve})
 
             const recipientRand = 5
@@ -1753,7 +1753,7 @@ contract("TicketBroker", accounts => {
             const numRecipients = 10
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
             await fixture.bondingManager.setMockUint256(functionSig("getTranscoderPoolSize()"), numRecipients)
-            await fixture.bondingManager.setMockBool(functionSig("isRegisteredTranscoder(address)"), true)
+            await fixture.bondingManager.setMockBool(functionSig("isActiveTranscoder(address)"), true)
             await broker.fundReserve({from: sender, value: 1000})
 
             let recipientRand = 5


### PR DESCRIPTION
This PR updates the `TicketBroker` to use `BondingManager.isActiveTranscoder()` instead of `BondingManager.isRegisteredTranscoder()` when calculating the claimable amount from a sender's reserve. This change will ensure that only active transcoders in the current round can claim from a sender's reserve which is the desired behavior because a sender's reserve should be committed to the members of the active set in the current round. Previously, `TicketBroker` was only checking if the claimant was a registered transcoder which was insufficient.

Fixes #339 