### PR TITLE
bonding: transcoder event changes

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -203,7 +203,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             tryToJoinActiveSet(msg.sender, delegators[msg.sender].delegatedAmount, currentRound.add(1));
         }
 
-        emit TranscoderUpdate(msg.sender, _rewardCut, _feeShare, transcoderPool.contains(msg.sender));
+        emit TranscoderUpdate(msg.sender, _rewardCut, _feeShare, transcoderPoolcontains(_transcoder));
     }
 
     /**
@@ -881,7 +881,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             transcoders[lastTranscoder].deactivationRound = _activationRound;
             pendingNextRoundTotalActiveStake = pendingNextRoundTotalActiveStake.sub(lastStake);
 
-            emit TranscoderEvicted(lastTranscoder);
+            emit TranscoderDeactivated(lastTranscoder, _activationRound);
         }
 
         transcoderPool.insert(_transcoder, _totalStake, address(0), address(0));
@@ -892,6 +892,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         t.deactivationRound = MAX_FUTURE_ROUND;
         t.earningsPoolPerRound[_activationRound].setStake(_totalStake);
         nextRoundTotalActiveStake = pendingNextRoundTotalActiveStake;
+        emit TranscoderActivated(_transcoder, _activationRound);
     }
 
     /**
@@ -904,8 +905,9 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         // 'EarningsPool.setStake()' is called whenever a transcoder becomes active again.
         transcoderPool.remove(_transcoder);
         nextRoundTotalActiveStake = nextRoundTotalActiveStake.sub(transcoderTotalStake(_transcoder));
-        transcoders[_transcoder].deactivationRound = roundsManager().currentRound().add(1);
-        emit TranscoderResigned(_transcoder);
+        uint256 deactivationRound = roundsManager().currentRound().add(1);
+        transcoders[_transcoder].deactivationRound = deactivationRound;
+        emit TranscoderDeactivated(_transcoder, deactivationRound);
     }
 
     /**

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -203,7 +203,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             tryToJoinActiveSet(msg.sender, delegators[msg.sender].delegatedAmount, currentRound.add(1));
         }
 
-        emit TranscoderUpdate(msg.sender, _rewardCut, _feeShare, transcoderPoolcontains(_transcoder));
+        emit TranscoderUpdate(msg.sender, _rewardCut, _feeShare);
     }
 
     /**

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -6,9 +6,9 @@ pragma solidity ^0.4.25;
  * TODO: switch to interface type
  */
 contract IBondingManager {
-    event TranscoderUpdate(address indexed transcoder, uint256 rewardCut, uint256 feeShare, bool registered);
-    event TranscoderEvicted(address indexed transcoder);
-    event TranscoderResigned(address indexed transcoder);
+    event TranscoderUpdate(address indexed transcoder, uint256 pendingRewardCut, uint256 pendingFeeShare, bool registered);
+    event TranscoderActivated(address indexed transcoder, uint256 activationRound);
+    event TranscoderDeactivated(address indexed transcoder, uint256 deactivationRound);
     event TranscoderSlashed(address indexed transcoder, address finder, uint256 penalty, uint256 finderReward);
     event Reward(address indexed transcoder, uint256 amount);
     event Bond(address indexed newDelegate, address indexed oldDelegate, address indexed delegator, uint256 additionalAmount, uint256 bondedAmount);
@@ -24,6 +24,8 @@ contract IBondingManager {
     // event Bond(address indexed delegate, address indexed delegator);
     // event Unbond(address indexed delegate, address indexed delegator);
     // event WithdrawStake(address indexed delegator);
+    // event TranscoderEvicted(address indexed transcoder);
+    // event TranscoderResigned(address indexed transcoder);
 
     // External functions
     function updateTranscoderWithFees(address _transcoder, uint256 _fees, uint256 _round) external;

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.4.25;
  * TODO: switch to interface type
  */
 contract IBondingManager {
-    event TranscoderUpdate(address indexed transcoder, uint256 pendingRewardCut, uint256 pendingFeeShare, bool registered);
+    event TranscoderUpdate(address indexed transcoder, uint256 rewardCut, uint256 feeShare);
     event TranscoderActivated(address indexed transcoder, uint256 activationRound);
     event TranscoderDeactivated(address indexed transcoder, uint256 deactivationRound);
     event TranscoderSlashed(address indexed transcoder, address finder, uint256 penalty, uint256 finderReward);
@@ -24,6 +24,7 @@ contract IBondingManager {
     // event Bond(address indexed delegate, address indexed delegator);
     // event Unbond(address indexed delegate, address indexed delegator);
     // event WithdrawStake(address indexed delegator);
+    // event TranscoderUpdate(address indexed transcoder, uint256 pendingRewardCut, uint256 pendingFeeShare, uint256 pendingPricePerSegment, bool registered);
     // event TranscoderEvicted(address indexed transcoder);
     // event TranscoderResigned(address indexed transcoder);
 

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -141,7 +141,7 @@ contract("BondingManager", accounts => {
                         e => e.transcoder == accounts[0] &&
                             e.rewardCut == 5 &&
                             e.feeShare == 10,
-                        "TranscoderUpdate event not correct"
+                        "TranscoderUpdate event not emitted correctly"
                     )
 
                     assert.equal(await bondingManager.nextRoundTotalActiveStake(), 1000, "wrong next total stake")
@@ -188,7 +188,7 @@ contract("BondingManager", accounts => {
                             e => e.transcoder == newTranscoder &&
                                     e.rewardCut == 5 &&
                                     e.feeShare == 10,
-                            "TranscoderUpdate event not correct"
+                            "TranscoderUpdate event not emitted correctly"
                         )
                         await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
 
@@ -224,7 +224,7 @@ contract("BondingManager", accounts => {
                             e => e.transcoder == newTranscoder &&
                                 e.rewardCut == 5 &&
                                 e.feeShare == 10,
-                            "TranscoderUpdate event not correct"
+                            "TranscoderUpdate event not emitted correctly"
                         )
                         await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
 
@@ -250,7 +250,7 @@ contract("BondingManager", accounts => {
                             e => e.transcoder == newTranscoder &&
                                 e.rewardCut == 5 &&
                                 e.feeShare == 10,
-                            "TranscoderUpdate event not correct"
+                            "TranscoderUpdate event not emitted correctly"
                         )
                         await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
                         assert.isFalse(await bondingManager.isActiveTranscoder(newTranscoder), "should not register caller as a transcoder in the pool")
@@ -1191,7 +1191,7 @@ contract("BondingManager", accounts => {
                     e => e.transcoder == transcoder2 && e.deactivationRound == currentRound + 2,
                     "TranscoderDeactivated event not emitted correctly"
                 )
-                
+
                 await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 2)
                 assert.isTrue(await bondingManager.isActiveTranscoder(transcoder))
                 // Check that transcoder2's deactivation round is the next round

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -140,8 +140,7 @@ contract("BondingManager", accounts => {
                         "TranscoderUpdate",
                         e => e.transcoder == accounts[0] &&
                             e.rewardCut == 5 &&
-                            e.feeShare == 10 &&
-                            e.registered,
+                            e.feeShare == 10,
                         "TranscoderUpdate event not correct"
                     )
 
@@ -188,8 +187,7 @@ contract("BondingManager", accounts => {
                             "TranscoderUpdate",
                             e => e.transcoder == newTranscoder &&
                                     e.rewardCut == 5 &&
-                                    e.feeShare == 10 &&
-                                    e.registered,
+                                    e.feeShare == 10,
                             "TranscoderUpdate event not correct"
                         )
                         await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
@@ -225,8 +223,7 @@ contract("BondingManager", accounts => {
                             "TranscoderUpdate",
                             e => e.transcoder == newTranscoder &&
                                 e.rewardCut == 5 &&
-                                e.feeShare == 10 &&
-                                !e.registered,
+                                e.feeShare == 10,
                             "TranscoderUpdate event not correct"
                         )
                         await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
@@ -252,8 +249,7 @@ contract("BondingManager", accounts => {
                             "TranscoderUpdate",
                             e => e.transcoder == newTranscoder &&
                                 e.rewardCut == 5 &&
-                                e.feeShare == 10 &&
-                                !e.registered,
+                                e.feeShare == 10,
                             "TranscoderUpdate event not correct"
                         )
                         await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound+1)
@@ -355,9 +351,9 @@ contract("BondingManager", accounts => {
                     const txRes = await bondingManager.bond(2000, transcoder2, {from: delegator})
                     truffleAssert.eventEmitted(
                         txRes,
-                        "TranscoderEvicted",
-                        e => e.transcoder == transcoder0,
-                        "TranscoderEvicted event not emitted correctly"
+                        "TranscoderDeactivated",
+                        e => e.transcoder == transcoder0 && e.deactivationRound == currentRound + 2,
+                        "TranscoderDeactivated event not emitted correctly"
                     )
                     await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 2)
                     assert.isTrue(await bondingManager.isActiveTranscoder(transcoder2))
@@ -374,6 +370,16 @@ contract("BondingManager", accounts => {
                 it("sets the deactivationRound for the evicted transcoder to the next round", async () => {
                     await bondingManager.bond(2000, transcoder2, {from: delegator})
                     assert.equal((await bondingManager.getTranscoder(transcoder0)).deactivationRound, currentRound + 2)
+                })
+
+                it("fires a TranscoderActivated event for the new transcoder", async () => {
+                    const txRes = await bondingManager.bond(2000, transcoder2, {from: delegator})
+                    truffleAssert.eventEmitted(
+                        txRes,
+                        "TranscoderActivated",
+                        e => e.transcoder == transcoder2 && e.activationRound == currentRound + 2,
+                        "TranscoderActivated event not emitted correctly"
+                    )
                 })
             })
 
@@ -394,7 +400,6 @@ contract("BondingManager", accounts => {
             })
 
             it("updates total stake in earnings pool for next round", async () => {
-                // evict transcoder0 from the pool
                 await bondingManager.bond(2000, transcoder2, {from: delegator})
                 const poolT2 = await bondingManager.getTranscoderEarningsPoolForRound(transcoder2, currentRound+2)
                 assert.equal(poolT2.totalStake, 2500)
@@ -1051,7 +1056,7 @@ contract("BondingManager", accounts => {
                 )
             })
 
-            describe("is a registered transcoder", () => {
+            describe("is an active transcoder", () => {
                 it("should resign as a transcoder", async () => {
                     // Caller is transcoder delegated to self
                     await bondingManager.unbond(1000, {from: transcoder})
@@ -1071,9 +1076,19 @@ contract("BondingManager", accounts => {
                     await bondingManager.unbond(1000, {from: transcoder})
                     assert.equal((await bondingManager.getTranscoder(transcoder)).deactivationRound, currentRound + 2)
                 })
+
+                it("should fire a TranscoderDeactivated event", async () => {
+                    const txRes = await bondingManager.unbond(1000, {from: transcoder})
+                    truffleAssert.eventEmitted(
+                        txRes,
+                        "TranscoderDeactivated",
+                        e => e.transcoder == transcoder && e.deactivationRound == currentRound + 2,
+                        "TranscoderDeactivated event not emitted correctly"
+                    )
+                })
             })
 
-            describe("is not a registered transcoder", () => {
+            describe("is not an active transcoder", () => {
                 it("should not update total active stake for the next round", async () => {
                     const startTotalStake = await bondingManager.nextRoundTotalActiveStake()
                     await bondingManager.unbond(1000, {from: delegator2})
@@ -1170,7 +1185,13 @@ contract("BondingManager", accounts => {
                 await bondingManager.transcoder(5, 10, {from: transcoder2})
 
                 const txRes = await bondingManager.rebond(unbondingLockID, {from: delegator})
-                truffleAssert.eventEmitted(txRes, "TranscoderEvicted", e => e.transcoder == transcoder2, "TranscoderEvicted event not emitted correctly")
+                truffleAssert.eventEmitted(
+                    txRes,
+                    "TranscoderDeactivated",
+                    e => e.transcoder == transcoder2 && e.deactivationRound == currentRound + 2,
+                    "TranscoderDeactivated event not emitted correctly"
+                )
+                
                 await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 2)
                 assert.isTrue(await bondingManager.isActiveTranscoder(transcoder))
                 // Check that transcoder2's deactivation round is the next round
@@ -1751,6 +1772,23 @@ contract("BondingManager", accounts => {
                     )
                 )
                 assert.equal((await bondingManager.getTranscoder(transcoder)).deactivationRound, currentRound + 2)
+            })
+
+            it("fires a TranscoderDeactivated event", async () => {
+                const txRes = await fixture.verifier.execute(
+                    bondingManager.address,
+                    functionEncodedABI(
+                        "slashTranscoder(address,address,uint256,uint256)",
+                        ["address", "uint256", "uint256", "uint256"],
+                        [transcoder, constants.NULL_ADDRESS, PERC_DIVISOR / 2, 0]
+                    )
+                )
+                truffleAssert.eventEmitted(
+                    await truffleAssert.createTransactionResult(bondingManager, txRes.tx),
+                    "TranscoderDeactivated",
+                    e => e.transcoder == transcoder && e.deactivationRound == currentRound + 2,
+                    "TranscoderDeactivated event not emitted correctly"
+                )
             })
         })
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR updates some contract events related to the transcoder with semantics that better fit the BondingManager update from #323 

**Specific updates (required)**
- removed `registered` argument from `TranscoderUpdate` event
- added a `TranscoderActivated` event when a transcoder gets inserted into the pool and is set to become active for the next round
- added a `TranscoderDeactivated` event, replacing both `TranscoderResigned` and `TranscoderEvicted`

**How did you test each of these updates (required)**
adjusted & ran test suite

**Checklist:**
- [ ] README and other documentation updated
- [x] All tests pass
