### PR TITLE
Various fixes

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -561,7 +561,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     function pendingStake(address _delegator, uint256 _endRound) public view returns (uint256) {
         uint256 currentRound = roundsManager().currentRound();
         Delegator storage del = delegators[_delegator];
-        
+
         require(_endRound <= currentRound, "end round must be before or equal to current round");
         require(_endRound > del.lastClaimRound, "end round must be after last claim round");
 

--- a/contracts/pm/TicketBroker.sol
+++ b/contracts/pm/TicketBroker.sol
@@ -17,19 +17,14 @@ contract TicketBroker is
     MixinWrappers
 {
     constructor(
-        address _controller,
-        uint256 _unlockPeriod,
-        uint256 _ticketValidityPeriod
+        address _controller
     )
         public
         MixinContractRegistry(_controller)
         MixinReserve()
         MixinTicketBrokerCore()
         MixinTicketProcessor()
-    {
-        unlockPeriod = _unlockPeriod;
-        ticketValidityPeriod = _ticketValidityPeriod;
-    }
+    {}
 
     /**
      * @dev Sets unlockPeriod value. Only callable by the Controller owner

--- a/contracts/pm/TicketBroker.sol
+++ b/contracts/pm/TicketBroker.sol
@@ -44,6 +44,8 @@ contract TicketBroker is
      * @param _ticketValidityPeriod Value for ticketValidityPeriod
      */
     function setTicketValidityPeriod(uint256 _ticketValidityPeriod) external onlyControllerOwner {
+        require(_ticketValidityPeriod > 0, "ticketValidityPeriod must be greater than 0");
+
         ticketValidityPeriod = _ticketValidityPeriod;
     }
 }

--- a/contracts/pm/mixins/MixinWrappers.sol
+++ b/contracts/pm/mixins/MixinWrappers.sol
@@ -60,17 +60,7 @@ contract MixinWrappers is MContractRegistry, MTicketBrokerCore {
         );
 
         // Call `redeemWinningTicket()`
-        assembly {
-            // call will return false upon hitting a revert
-            success := call(
-                gas,                                   // Forward all gas
-                address,                               // Address of this contract (calling self)
-                0,                                     // Send 0 ETH
-                add(redeemWinningTicketCalldata, 32),  // Start of calldata (skip first 32 bytes containing array length)
-                mload(redeemWinningTicketCalldata),    // Length of calldata (first 32 bytes contains array length)
-                0,                                     // Ignore start of output
-                0                                      // Ignore size of output
-            )
-        }
+        // solium-disable-next-line
+        (success,) = address(this).call(redeemWinningTicketCalldata);
     }
 }

--- a/migrations/3_deploy_contracts.js
+++ b/migrations/3_deploy_contracts.js
@@ -25,15 +25,10 @@ module.exports = function(deployer, network) {
             await lpDeployer.deployAndRegister(LivepeerTokenFaucet, "LivepeerTokenFaucet", token.address, config.faucet.requestAmount, config.faucet.requestWait)
         }
 
-        // TODO: Consider using a initializer instead of an
-        // explicit constructor in base TicketBroker since
-        // upgradeable proxies do not use explicit constructors
         const broker = await lpDeployer.deployProxyAndRegister(
             TicketBroker,
             "TicketBroker",
-            controller.address,
-            config.broker.unlockPeriod,
-            config.broker.ticketValidityPeriod
+            controller.address
         )
         const bondingManager = await lpDeployer.deployProxyAndRegister(BondingManager, "BondingManager", controller.address)
 

--- a/test/unit/TicketBroker.js
+++ b/test/unit/TicketBroker.js
@@ -55,6 +55,28 @@ contract("TicketBroker", accounts => {
         await fixture.tearDown()
     })
 
+    describe("setTicketValidityPeriod", () => {
+        it("should fail if caller is not Controller owner", async () => {
+            await expectRevertWithReason(
+                broker.setTicketValidityPeriod(200, {from: accounts[1]}),
+                "caller must be Controller owner"
+            )
+        })
+
+        it("should fail if provided value is 0", async () => {
+            await expectRevertWithReason(
+                broker.setTicketValidityPeriod(0),
+                "ticketValidityPeriod must be greater than 0"
+            )
+        })
+
+        it("sets ticketValidityPeriod", async () => {
+            await broker.setTicketValidityPeriod(200)
+
+            assert.equal("200", (await broker.ticketValidityPeriod()).toString())
+        })
+    })
+
     describe("fundDeposit", () => {
         it("should fail if the system is paused", async () => {
             await fixture.controller.pause()

--- a/test/unit/TicketBroker.js
+++ b/test/unit/TicketBroker.js
@@ -55,6 +55,21 @@ contract("TicketBroker", accounts => {
         await fixture.tearDown()
     })
 
+    describe("setUnlockPeriod", () => {
+        it("should fail if caller is not Controller owner", async () => {
+            await expectRevertWithReason(
+                broker.setUnlockPeriod(200, {from: accounts[1]}),
+                "caller must be Controller owner"
+            )
+        })
+
+        it("sets unlockPeriod", async () => {
+            await broker.setUnlockPeriod(200)
+
+            assert.equal("200", (await broker.unlockPeriod()).toString())
+        })
+    })
+
     describe("setTicketValidityPeriod", () => {
         it("should fail if caller is not Controller owner", async () => {
             await expectRevertWithReason(

--- a/test/unit/TicketBroker.js
+++ b/test/unit/TicketBroker.js
@@ -33,11 +33,9 @@ contract("TicketBroker", accounts => {
         fixture = new Fixture(web3)
         await fixture.deploy()
 
-        broker = await TicketBroker.new(
-            fixture.controller.address,
-            unlockPeriod,
-            ticketValidityPeriod
-        )
+        broker = await TicketBroker.new(fixture.controller.address)
+        await broker.setUnlockPeriod(unlockPeriod)
+        await broker.setTicketValidityPeriod(ticketValidityPeriod)
 
         await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound)
         await fixture.roundsManager.setMockBytes32(


### PR DESCRIPTION
This PR includes the following commits:

- 8b7797c: Use `<address>.call()` instead of assembly in TicketBroker. Fixes #345 

- d1c52ea: Adds a check for non-zero values in `TicketBroker.setTicketValidityPeriod()` and adds tests. Fixes #346 

- edfd64c: Adds tests for `TicketBroker.setUnlockPeriod()`

- f7e6ac3: Fix a linting error in BondingManager

- 4e64c16: Use an empty constructor in TicketBroker because any state updates in the constructor will not be invoked when interacting with a proxy that uses the TicketBroker implementation. We can just use the available setters instead.