### PR TITLE
Revert Minter changes to match mainnet implementation

### DIFF
--- a/contracts/pm/mixins/MixinTicketProcessor.sol
+++ b/contracts/pm/mixins/MixinTicketProcessor.sol
@@ -18,7 +18,7 @@ contract MixinTicketProcessor is MContractRegistry, MTicketProcessor {
      */
     function processFunding(uint256 _amount) internal {
         // Send funds to Minter
-        minter().trustedDepositETH.value(_amount)();
+        minter().depositETH.value(_amount)();
     }
 
     /**

--- a/contracts/test/mocks/MinterMock.sol
+++ b/contracts/test/mocks/MinterMock.sol
@@ -4,12 +4,7 @@ import "./GenericMock.sol";
 
 contract MinterMock is GenericMock {
 
-    event TrustedBurnETH(uint256 amount);
     event TrustedWithdrawETH(address to, uint256 amount);
-
-    function trustedBurnETH(uint256 _amount) external {
-        emit TrustedBurnETH(_amount);
-    }
 
     function trustedWithdrawETH(address _to, uint256 _amount) external {
         emit TrustedWithdrawETH(_to, _amount);

--- a/contracts/token/IMinter.sol
+++ b/contracts/token/IMinter.sol
@@ -15,8 +15,7 @@ contract IMinter {
     function trustedTransferTokens(address _to, uint256 _amount) external;
     function trustedBurnTokens(uint256 _amount) external;
     function trustedWithdrawETH(address payable _to, uint256 _amount) external;
-    function trustedBurnETH(uint256 _amount) external;
-    function trustedDepositETH() external payable;
+    function depositETH() external payable returns (bool);
     function setCurrentRewardTokens() external;
 
     // Public functions

--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -41,21 +41,15 @@ contract Minter is Manager, IMinter {
         _;
     }
 
-    // Checks if caller is TicketBroker
-    modifier onlyTicketBroker() {
-        require(msg.sender == controller.getContract(keccak256("TicketBroker")));
+    // Checks if caller is either BondingManager or JobsManager
+    modifier onlyBondingManagerOrJobsManager() {
+        require(msg.sender == controller.getContract(keccak256("BondingManager")) || msg.sender == controller.getContract(keccak256("JobsManager")));
         _;
     }
 
-    // Checks if caller is either BondingManager or TicketBroker
-    modifier onlyBondingManagerOrTicketBroker() {
-        require(msg.sender == controller.getContract(keccak256("BondingManager")) || msg.sender == controller.getContract(keccak256("TicketBroker")));
-        _;
-    }
-
-    // Checks if caller is either the currently registered Minter or TicketBroker
-    modifier onlyMinterOrTicketBroker() {
-        require(msg.sender == controller.getContract(keccak256("Minter")) || msg.sender == controller.getContract(keccak256("TicketBroker")));
+    // Checks if caller is either the currently registered Minter or JobsManager
+    modifier onlyMinterOrJobsManager() {
+        require(msg.sender == controller.getContract(keccak256("Minter")) || msg.sender == controller.getContract(keccak256("JobsManager")));
         _;
     }
 
@@ -126,7 +120,7 @@ contract Minter is Manager, IMinter {
         // Transfer current Minter's token balance to new Minter
         livepeerToken().transfer(address(_newMinter), livepeerToken().balanceOf(address(this)));
         // Transfer current Minter's ETH balance to new Minter
-        _newMinter.trustedDepositETH.value(address(this).balance)();
+        _newMinter.depositETH.value(address(this).balance)();
     }
 
     /**
@@ -170,20 +164,15 @@ contract Minter is Manager, IMinter {
      * @param _to Recipient address
      * @param _amount Amount of ETH
      */
-    function trustedWithdrawETH(address payable _to, uint256 _amount) external onlyBondingManagerOrTicketBroker whenSystemNotPaused {
+    function trustedWithdrawETH(address payable _to, uint256 _amount) external onlyBondingManagerOrJobsManager whenSystemNotPaused {
         _to.transfer(_amount);
     }
 
     /**
-     * @dev Deposit ETH to this contract. Only callable by the currently registered Minter or TicketBroker
+     * @dev Deposit ETH to this contract. Only callable by the currently registered Minter or JobsManager
      */
-    function trustedDepositETH() external payable onlyMinterOrTicketBroker whenSystemNotPaused {}
-
-    /**
-     * @dev Burn ETH held by this contract. Only callable by the currently registered TicketBroker
-     */
-    function trustedBurnETH(uint256 _amount) external onlyTicketBroker whenSystemNotPaused {
-        address(0).transfer(_amount);
+    function depositETH() external payable onlyMinterOrJobsManager whenSystemNotPaused returns (bool) {
+        return true;
     }
 
     /**

--- a/migrations/3_deploy_contracts.js
+++ b/migrations/3_deploy_contracts.js
@@ -30,6 +30,10 @@ module.exports = function(deployer, network) {
             "TicketBroker",
             controller.address
         )
+        // Register TicketBroker with JobsManager contract ID because in a production system the Minter likely will not be upgraded to be
+        // aware of the TicketBroker contract ID and it will only be aware of the JobsManager contract ID
+        await lpDeployer.register("JobsManager", broker.address)
+
         const bondingManager = await lpDeployer.deployProxyAndRegister(BondingManager, "BondingManager", controller.address)
 
         let roundsManager

--- a/test/integration/BroadcasterWithdrawalFlow.js
+++ b/test/integration/BroadcasterWithdrawalFlow.js
@@ -22,7 +22,7 @@ contract("BroadcasterWithdrawalFlow", accounts => {
         const controller = await Controller.deployed()
         await controller.unpause()
 
-        const brokerAddr = await controller.getContract(contractId("TicketBroker"))
+        const brokerAddr = await controller.getContract(contractId("JobsManager"))
         broker = await TicketBroker.at(brokerAddr)
 
         const bondingManagerAddr = await controller.getContract(contractId("BondingManager"))

--- a/test/integration/TicketFlow.js
+++ b/test/integration/TicketFlow.js
@@ -28,7 +28,7 @@ contract("TicketFlow", accounts => {
         controller = await Controller.deployed()
         await controller.unpause()
 
-        const brokerAddr = await controller.getContract(contractId("TicketBroker"))
+        const brokerAddr = await controller.getContract(contractId("JobsManager"))
         broker = await TicketBroker.at(brokerAddr)
 
         const bondingManagerAddr = await controller.getContract(contractId("BondingManager"))

--- a/test/unit/Minter.js
+++ b/test/unit/Minter.js
@@ -136,7 +136,7 @@ contract("Minter", accounts => {
         })
 
         it("should transfer ownership of the token, current token balance and current ETH balance to new minter", async () => {
-            await fixture.ticketBroker.execute(minter.address, functionSig("trustedDepositETH()"), {from: accounts[1], value: 100})
+            await fixture.ticketBroker.execute(minter.address, functionSig("depositETH()"), {from: accounts[1], value: 100})
 
             const newMinter = await GenericMock.new()
             const controllerAddr = await minter.controller.call()
@@ -289,7 +289,7 @@ contract("Minter", accounts => {
     })
 
     describe("trustedWithdrawETH", () => {
-        it("should fail if caller is not BondingManager or TicketBroker", async () => {
+        it("should fail if caller is not BondingManager or JobsManager", async () => {
             await expectThrow(minter.trustedWithdrawETH(accounts[1], 100))
         })
 
@@ -312,12 +312,12 @@ contract("Minter", accounts => {
             await expectThrow(fixture.bondingManager.execute(minter.address, functionEncodedABI("trustedWithdrawETH(address,uint256)", ["address", "uint256"], [accounts[1], 100])))
         })
 
-        it("should fail if insufficient balance when caller is ticketBroker", async () => {
+        it("should fail if insufficient balance when caller is JobsManager", async () => {
             await expectThrow(fixture.ticketBroker.execute(minter.address, functionEncodedABI("trustedWithdrawETH(address,uint256)", ["address", "uint256"], [accounts[1], 100])))
         })
 
         it("should transfer ETH to receiving address when caller is BondingManager", async () => {
-            await fixture.ticketBroker.execute(minter.address, functionSig("trustedDepositETH()"), {from: accounts[1], value: 100})
+            await fixture.ticketBroker.execute(minter.address, functionSig("depositETH()"), {from: accounts[1], value: 100})
             const startBalance = new BN(await web3.eth.getBalance(accounts[1]))
             await fixture.bondingManager.execute(minter.address, functionEncodedABI("trustedWithdrawETH(address,uint256)", ["address", "uint256"], [accounts[1], 100]))
             const endBalance = new BN(await web3.eth.getBalance(accounts[1]))
@@ -328,8 +328,8 @@ contract("Minter", accounts => {
             assert.equal(endBalance.sub(startBalance), 100, "wrong change in withdrawing caller")
         })
 
-        it("should transfer ETH to receiving address when caller is ticketBroker", async () => {
-            await fixture.ticketBroker.execute(minter.address, functionSig("trustedDepositETH()"), {from: accounts[1], value: 100})
+        it("should transfer ETH to receiving address when caller is JobsManager", async () => {
+            await fixture.ticketBroker.execute(minter.address, functionSig("depositETH()"), {from: accounts[1], value: 100})
             const startBalance = new BN(await web3.eth.getBalance(accounts[1]))
             await fixture.ticketBroker.execute(minter.address, functionEncodedABI("trustedWithdrawETH(address,uint256)", ["address", "uint256"], [accounts[1], 100]))
             const endBalance = new BN(await web3.eth.getBalance(accounts[1]))
@@ -341,9 +341,9 @@ contract("Minter", accounts => {
         })
     })
 
-    describe("trustedDepositETH", () => {
-        it("should fail if caller is not currently registered Minter or TicketBroker", async () => {
-            await expectThrow(minter.trustedDepositETH({from: accounts[1], value: 100}))
+    describe("depositETH", () => {
+        it("should fail if caller is not currently registered Minter or JobsManager", async () => {
+            await expectThrow(minter.depositETH({from: accounts[1], value: 100}))
         })
 
         it("should fail if Controller is paused", async () => {
@@ -352,7 +352,7 @@ contract("Minter", accounts => {
             await expectThrow(
                 fixture.ticketBroker.execute(
                     minter.address,
-                    functionSig("trustedDepositETH()"),
+                    functionSig("depositETH()"),
                     {from: accounts[1], value: 100}
                 )
             )
@@ -361,58 +361,16 @@ contract("Minter", accounts => {
         it("should receive ETH from currently registered Minter", async () => {
             // Register mock Minter
             const mockMinter = await fixture.deployAndRegister(GenericMock, "Minter")
-            // Call trustedDepositETH on this Minter from currently registered Minter
-            await mockMinter.execute(minter.address, functionSig("trustedDepositETH()"), {from: accounts[1], value: 100})
+            // Call depositETH on this Minter from currently registered Minter
+            await mockMinter.execute(minter.address, functionSig("depositETH()"), {from: accounts[1], value: 100})
 
             assert.equal(await web3.eth.getBalance(minter.address), 100, "wrong minter balance")
         })
 
-        it("should receive ETH from TicketBroker", async () => {
-            await fixture.ticketBroker.execute(minter.address, functionSig("trustedDepositETH()"), {from: accounts[1], value: 100})
+        it("should receive ETH from JobsManager", async () => {
+            await fixture.ticketBroker.execute(minter.address, functionSig("depositETH()"), {from: accounts[1], value: 100})
 
             assert.equal(await web3.eth.getBalance(minter.address), 100, "wrong minter balance")
-        })
-    })
-
-    describe("trustedBurnETH", () => {
-        it("should fail if caller is not currently registered TicketBroker", async () => {
-            await expectThrow(minter.trustedBurnETH(100, {from: accounts[1]}))
-        })
-
-        it("should fail if Controller is paused", async () => {
-            await fixture.ticketBroker.execute(minter.address, functionSig("trustedDepositETH()"), {from: accounts[1], value: 1000})
-            await fixture.controller.pause()
-
-            await expectThrow(
-                fixture.ticketBroker.execute(
-                    minter.address,
-                    functionEncodedABI(
-                        "trustedBurnETH(uint256)",
-                        ["uint256"],
-                        [100]
-                    ),
-                    {from: accounts[1]}
-                )
-            )
-        })
-
-        it("should burn ETH if caller is TicketBroker", async () => {
-            await fixture.ticketBroker.execute(minter.address, functionSig("trustedDepositETH()"), {from: accounts[1], value: 1000})
-            const startBalance = new BN(await web3.eth.getBalance(minter.address))
-
-            await fixture.ticketBroker.execute(
-                minter.address,
-                functionEncodedABI(
-                    "trustedBurnETH(uint256)",
-                    ["uint256"],
-                    [100]
-                ),
-                {from: accounts[1]}
-            )
-
-            const endBalance = new BN(await web3.eth.getBalance(minter.address))
-
-            assert.equal(startBalance.sub(endBalance).toString(), "100")
         })
     })
 

--- a/test/unit/helpers/Fixture.js
+++ b/test/unit/helpers/Fixture.js
@@ -23,15 +23,23 @@ export default class Fixture {
         this.minter = await this.deployAndRegister(MinterMock, "Minter")
         this.bondingManager = await this.deployAndRegister(BondingManagerMock, "BondingManager")
         this.roundsManager = await this.deployAndRegister(GenericMock, "RoundsManager")
+        this.jobsManager = await this.deployAndRegister(GenericMock, "JobsManager")
         this.ticketBroker = await this.deployAndRegister(GenericMock, "TicketBroker")
+        // Register TicketBroker with JobsManager contract ID because in a production system the Minter likely will not be upgraded to be
+        // aware of the TicketBroker contract ID and it will only be aware of the JobsManager contract ID
+        await this.register("JobsManager", this.ticketBroker.address)
         this.verifier = await this.deployAndRegister(GenericMock, "Verifier")
+    }
+
+    async register(name, addr) {
+        // Use dummy Git commit hash
+        const commitHash = web3.utils.asciiToHex("0x123")
+        await this.controller.setContractInfo(contractId(name), addr, commitHash)
     }
 
     async deployAndRegister(artifact, name, ...args) {
         const contract = await artifact.new(...args)
-        // Use dummy Git commit hash
-        const commitHash = web3.utils.asciiToHex("0x123")
-        await this.controller.setContractInfo(contractId(name), contract.address, commitHash)
+        await this.register(name, contract.address)
         return contract
     }
 

--- a/utils/contractDeployer.js
+++ b/utils/contractDeployer.js
@@ -29,10 +29,14 @@ class ContractDeployer {
         return this.controller
     }
 
+    async register(name, addr) {
+        const commitHash = await this.getGitHeadCommitHash()
+        await this.controller.setContractInfo(contractId(name), addr, commitHash)
+    }
+
     async deployAndRegister(artifact, name, ...args) {
         const contract = await this.deploy(artifact, ...args)
-        const commitHash = await this.getGitHeadCommitHash()
-        await this.controller.setContractInfo(contractId(name), contract.address, commitHash)
+        await this.register(name, contract.address)
         return contract
     }
 


### PR DESCRIPTION
This PR reverts changes in the Minter to logically match the mainnet implementation (excluding compiler version, revert reasons, etc.). One thing to note is that contracts will use the JobsManager contract ID to interact with the TicketBroker.

Fixes #347