### PR TITLE
NATSPEC comments

### DIFF
--- a/contracts/Controller.sol
+++ b/contracts/Controller.sol
@@ -21,10 +21,10 @@ contract Controller is Pausable, IController {
         paused = true;
     }
 
-    /*
-     * @dev Register contract id and mapped address
+    /**
+     * @notice Register contract id and mapped address
      * @param _id Contract id (keccak256 hash of contract name)
-     * @param _contract Contract address
+     * @param _contractAddress Contract address
      */
     function setContractInfo(bytes32 _id, address _contractAddress, bytes20 _gitCommitHash) external onlyOwner {
         registry[_id].contractAddress = _contractAddress;
@@ -33,8 +33,8 @@ contract Controller is Pausable, IController {
         emit SetContractInfo(_id, _contractAddress, _gitCommitHash);
     }
 
-    /*
-     * @dev Update contract's controller
+    /**
+     * @notice Update contract's controller
      * @param _id Contract id (keccak256 hash of contract name)
      * @param _controller Controller address
      */
@@ -42,16 +42,16 @@ contract Controller is Pausable, IController {
         return IManager(registry[_id].contractAddress).setController(_controller);
     }
 
-    /*
-     * @dev Return contract info for a given contract id
+    /**
+     * @notice Return contract info for a given contract id
      * @param _id Contract id (keccak256 hash of contract name)
      */
     function getContractInfo(bytes32 _id) public view returns (address, bytes20) {
         return (registry[_id].contractAddress, registry[_id].gitCommitHash);
     }
 
-    /*
-     * @dev Get contract address for an id
+    /**
+     * @notice Get contract address for an id
      * @param _id Contract id
      */
     function getContract(bytes32 _id) public view returns (address) {

--- a/contracts/Manager.sol
+++ b/contracts/Manager.sol
@@ -36,8 +36,8 @@ contract Manager is IManager {
         controller = IController(_controller);
     }
 
-    /*
-     * @dev Set controller. Only callable by current controller
+    /**
+     * @notice Set controller. Only callable by current controller
      * @param _controller Controller contract address
      */
     function setController(address _controller) external onlyController {

--- a/contracts/ManagerProxy.sol
+++ b/contracts/ManagerProxy.sol
@@ -5,15 +5,15 @@ import "./ManagerProxyTarget.sol";
 
 /**
  * @title ManagerProxy
- * @dev A proxy contract that uses delegatecall to execute function calls on a target contract using its own storage context.
- * The target contract is a Manager contract that is registered with the Controller.
- * Note: Both this proxy contract and its target contract MUST inherit from ManagerProxyTarget in order to guarantee
- * that both contracts have the same storage layout. Differing storage layouts in a proxy contract and target contract can
- * potentially break the delegate proxy upgradeability mechanism
+ * @notice A proxy contract that uses delegatecall to execute function calls on a target contract using its own storage context.
+ The target contract is a Manager contract that is registered with the Controller.
+ * @dev Both this proxy contract and its target contract MUST inherit from ManagerProxyTarget in order to guarantee
+ that both contracts have the same storage layout. Differing storage layouts in a proxy contract and target contract can
+ potentially break the delegate proxy upgradeability mechanism
  */
 contract ManagerProxy is ManagerProxyTarget {
     /**
-     * @dev ManagerProxy constructor. Invokes constructor of base Manager contract with provided Controller address.
+     * @notice ManagerProxy constructor. Invokes constructor of base Manager contract with provided Controller address.
      * Also, sets the contract ID of the target contract that function calls will be executed on.
      * @param _controller Address of Controller that this contract will be registered with
      * @param _targetContractId contract ID of the target contract
@@ -23,10 +23,10 @@ contract ManagerProxy is ManagerProxyTarget {
     }
 
     /**
-     * @dev Uses delegatecall to execute function calls on this proxy contract's target contract using its own storage context.
-     * This fallback function will look up the address of the target contract using the Controller and the target contract ID.
-     * It will then use the calldata for a function call as the data payload for a delegatecall on the target contract. The return value
-     * of the executed function call will also be returned
+     * @notice Uses delegatecall to execute function calls on this proxy contract's target contract using its own storage context.
+     This fallback function will look up the address of the target contract using the Controller and the target contract ID.
+     It will then use the calldata for a function call as the data payload for a delegatecall on the target contract. The return value
+     of the executed function call will also be returned
      */
     function() external payable {
         address target = controller.getContract(targetContractId);

--- a/contracts/ManagerProxyTarget.sol
+++ b/contracts/ManagerProxyTarget.sol
@@ -5,10 +5,10 @@ import "./Manager.sol";
 
 /**
  * @title ManagerProxyTarget
- * @dev The base contract that target contracts used by a proxy contract should inherit from
- * Note: Both the target contract and the proxy contract (implemented as ManagerProxy) MUST inherit from ManagerProxyTarget in order to guarantee
- * that both contracts have the same storage layout. Differing storage layouts in a proxy contract and target contract can
- * potentially break the delegate proxy upgradeability mechanism
+ * @notice The base contract that target contracts used by a proxy contract should inherit from
+ * @dev Both the target contract and the proxy contract (implemented as ManagerProxy) MUST inherit from ManagerProxyTarget in order to guarantee
+ that both contracts have the same storage layout. Differing storage layouts in a proxy contract and target contract can
+ potentially break the delegate proxy upgradeability mechanism
  */
 contract ManagerProxyTarget is Manager {
     // Used to look up target contract address in controller's registry

--- a/contracts/ServiceRegistry.sol
+++ b/contracts/ServiceRegistry.sol
@@ -5,7 +5,7 @@ import "./ManagerProxyTarget.sol";
 
 /**
  * @title ServiceRegistry
- * @dev Maintains a registry of service metadata associated with service provider addresses (transcoders/orchestrators)
+ * @notice Maintains a registry of service metadata associated with service provider addresses (transcoders/orchestrators)
  */
 contract ServiceRegistry is ManagerProxyTarget {
     // Store service metadata
@@ -20,13 +20,13 @@ contract ServiceRegistry is ManagerProxyTarget {
     event ServiceURIUpdate(address indexed addr, string serviceURI);
 
     /**
-     * @dev ServiceRegistry constructor. Only invokes constructor of base Manager contract with provided Controller address
+     * @notice ServiceRegistry constructor. Only invokes constructor of base Manager contract with provided Controller address
      * @param _controller Address of a Controller that this contract will be registered with
      */
     constructor(address _controller) public Manager(_controller) {}
 
     /**
-     * @dev Stores service URI endpoint for the caller that can be used to send requests to the caller off-chain
+     * @notice Stores service URI endpoint for the caller that can be used to send requests to the caller off-chain
      * @param _serviceURI Service URI endpoint for the caller
      */
     function setServiceURI(string calldata _serviceURI) external {
@@ -36,7 +36,7 @@ contract ServiceRegistry is ManagerProxyTarget {
     }
 
     /**
-     * @dev Returns service URI endpoint stored for a given address
+     * @notice Returns service URI endpoint stored for a given address
      * @param _addr Address for which a service URI endpoint is desired
      */
     function getServiceURI(address _addr) public view returns (string memory) {

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -14,7 +14,7 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 /**
  * @title BondingManager
- * @dev Manages bonding, transcoder and rewards/fee accounting related operations of the Livepeer protocol
+ * @notice Manages bonding, transcoder and rewards/fee accounting related operations of the Livepeer protocol
  */
 contract BondingManager is ManagerProxyTarget, IBondingManager {
     using SafeMath for uint256;
@@ -142,13 +142,13 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev BondingManager constructor. Only invokes constructor of base Manager contract with provided Controller address
+     * @notice BondingManager constructor. Only invokes constructor of base Manager contract with provided Controller address
      * @param _controller Address of Controller that this contract will be registered with
      */
     constructor(address _controller) public Manager(_controller) {}
 
     /**
-     * @dev Set unbonding period. Only callable by Controller owner
+     * @notice Set unbonding period. Only callable by Controller owner
      * @param _unbondingPeriod Rounds between unbonding and possible withdrawal
      */
     function setUnbondingPeriod(uint64 _unbondingPeriod) external onlyControllerOwner {
@@ -158,7 +158,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Set number of active transcoders. Only callable by Controller owner
+     * @notice Set maximum number of active transcoders. Only callable by Controller owner
      * @param _numActiveTranscoders Number of active transcoders
      */
     function setNumActiveTranscoders(uint256 _numActiveTranscoders) external onlyControllerOwner {
@@ -168,7 +168,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Set max number of rounds a caller can claim earnings for at once. Only callable by Controller owner
+     * @notice Set max number of rounds a caller can claim earnings for at once. Only callable by Controller owner
      * @param _maxEarningsClaimsRounds Max number of rounds a caller can claim earnings for at once
      */
     function setMaxEarningsClaimsRounds(uint256 _maxEarningsClaimsRounds) external onlyControllerOwner {
@@ -282,7 +282,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Update transcoder's fee pool. Only callable by the TicketBroker
+     * @notice Update transcoder's fee pool. Only callable by the TicketBroker
      * @param _transcoder Transcoder address
      * @param _fees Fees to be added to the fee pool
      */
@@ -315,7 +315,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Slash a transcoder. Only callable by the Verifier
+     * @notice Slash a transcoder. Only callable by the Verifier
      * @param _transcoder Transcoder address
      * @param _finder Finder that proved a transcoder violated a slashing condition. Null address if there is no finder
      * @param _slashAmount Percentage of transcoder bond to be slashed
@@ -384,7 +384,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Called during round initialization to set the total active stake for the round. Only callable by the RoundsManager
+     * @notice Called during round initialization to set the total active stake for the round. Only callable by the RoundsManager
      */
     function setCurrentRoundTotalActiveStake() external onlyRoundsManager {
         currentRoundTotalActiveStake = nextRoundTotalActiveStake;
@@ -660,9 +660,10 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Returns pending bonded stake for a delegator from its lastClaimRound through an end round
+     * @notice Returns pending bonded stake for a delegator from its lastClaimRound through an end round
      * @param _delegator Address of delegator
      * @param _endRound The last round to compute pending stake from
+     * @return pending bonded stake for '_delegator' since last claiming rewards
      */
     function pendingStake(address _delegator, uint256 _endRound) public view returns (uint256) {
         uint256 currentRound = roundsManager().currentRound();
@@ -687,9 +688,10 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Returns pending fees for a delegator from its lastClaimRound through an end round
+     * @notice Returns pending fees for a delegator from its lastClaimRound through an end round
      * @param _delegator Address of delegator
      * @param _endRound The last round to compute pending fees from
+     * @return pending fees for '_delegator' since last claiming fees
      */
     function pendingFees(address _delegator, uint256 _endRound) public view returns (uint256) {
         uint256 currentRound = roundsManager().currentRound();
@@ -718,16 +720,18 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Returns total bonded stake for a transcoder
+     * @notice Returns total bonded stake for a transcoder
      * @param _transcoder Address of transcoder
+     * @return total bonded stake for a delegator
      */
     function transcoderTotalStake(address _transcoder) public view returns (uint256) {
         return delegators[_transcoder].delegatedAmount;
     }
 
-    /*
-     * @dev Computes transcoder status
+    /**
+     * @notice Computes transcoder status
      * @param _transcoder Address of transcoder
+     * @return registered or not registered transcoder status
      */
     function transcoderStatus(address _transcoder) public view returns (TranscoderStatus) {
         if (isRegisteredTranscoder(_transcoder)) return TranscoderStatus.Registered;
@@ -735,8 +739,9 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Computes delegator status
+     * @notice Computes delegator status
      * @param _delegator Address of delegator
+     * @return bonded, unbonded or pending delegator status
      */
     function delegatorStatus(address _delegator) public view returns (DelegatorStatus) {
         Delegator storage del = delegators[_delegator];
@@ -756,8 +761,14 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Return transcoder information
+     * @notice Return transcoder information
      * @param _transcoder Address of transcoder
+     * @return trancoder's last reward round
+     * @return transcoder's reward cut
+     * @return transcoder's fee share
+     * @return round in which transcoder's stake was last updated while active
+     * @return round in which transcoder became active
+     * @return round in which transcoder will no longer be active
      */
     function getTranscoder(
         address _transcoder
@@ -777,9 +788,18 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Return transcoder's token pools for a given round
+     * @notice Return transcoder's token pools for a given round
      * @param _transcoder Address of transcoder
      * @param _round Round number
+     * @return reward pool for delegates to '_transcoder'
+     * @return fee pool for delegates to '_trancoder'
+     * @return transcoder's total stake
+     * @return claimable stake left on transcoder's earningspool for '_round'
+     * @return transcoder's reward cut for '_round'
+     * @return transcoder's fee share for '_round'
+     * @return transcoder's rewards for '_round'
+     * @return transcoder's fees for '_round'
+     * @return true if transcoder has a split reward and fee pool
      */
     function getTranscoderEarningsPoolForRound(
         address _transcoder,
@@ -803,8 +823,15 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Return delegator info
+     * @notice Return delegator info
      * @param _delegator Address of delegator
+     * @return total amount bonded by '_delegator'
+     * @return amount of fees collected by '_delegator'
+     * @return address '_delegator' has bonded to
+     * @return total amount delegated to '_delegator'
+     * @return round in which bond for '_delegator' became effective
+     * @return round for which '_delegator' has last claimed earnings
+     * @return ID for the next unbonding lock created for '_delegator'
      */
     function getDelegator(
         address _delegator
@@ -825,9 +852,11 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Return delegator's unbonding lock info
+     * @notice Return delegator's unbonding lock info
      * @param _delegator Address of delegator
      * @param _unbondingLockId ID of unbonding lock
+     * @return amount of stake locked up by unbonding lock
+     * @return round in which 'amount' becomes available for withdrawal
      */
     function getDelegatorUnbondingLock(
         address _delegator,
@@ -843,44 +872,50 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Returns max size of transcoder pool
+     * @notice Returns max size of transcoder pool
+     * @return transcoder pool max size
      */
     function getTranscoderPoolMaxSize() public view returns (uint256) {
         return transcoderPoolV2.getMaxSize();
     }
 
     /**
-     * @dev Returns size of transcoder pool
+     * @notice Returns size of transcoder pool
+     * @return transcoder pool current size
      */
     function getTranscoderPoolSize() public view returns (uint256) {
         return transcoderPoolV2.getSize();
     }
 
     /**
-     * @dev Returns transcoder with most stake in pool
+     * @notice Returns transcoder with most stake in pool
+     * @return address for transcoder with highest stake in transcoder pool
      */
     function getFirstTranscoderInPool() public view returns (address) {
         return transcoderPoolV2.getFirst();
     }
 
     /**
-     * @dev Returns next transcoder in pool for a given transcoder
+     * @notice Returns next transcoder in pool for a given transcoder
      * @param _transcoder Address of a transcoder in the pool
+     * @return address for the transcoder after '_transcoder' in transcoder pool
      */
     function getNextTranscoderInPool(address _transcoder) public view returns (address) {
         return transcoderPoolV2.getNext(_transcoder);
     }
 
     /**
-     * @dev Return total bonded tokens
+     * @notice Return total bonded tokens
+     * @return total active stake for the current round
      */
     function getTotalBonded() public view returns (uint256) {
         return currentRoundTotalActiveStake;
     }
 
    /**
-     * @dev Return whether a transcoder is active for the current round
+     * @notice Return whether a transcoder is active for the current round
      * @param _transcoder Transcoder address
+     * @return true if transcoder is active
      */
     function isActiveTranscoder(address _transcoder) public view returns (bool) {
         Transcoder storage t = transcoders[_transcoder];
@@ -889,8 +924,9 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Return whether a transcoder is registered
+     * @notice Return whether a transcoder is registered
      * @param _transcoder Transcoder address
+     * @return true if transcoder is self-bonded
      */
     function isRegisteredTranscoder(address _transcoder) public view returns (bool) {
         Delegator storage d = delegators[_transcoder];
@@ -898,9 +934,10 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Return whether an unbonding lock for a delegator is valid
+     * @notice Return whether an unbonding lock for a delegator is valid
      * @param _delegator Address of delegator
      * @param _unbondingLockId ID of unbonding lock
+     * @return true if unbondingLock for ID has a non-zero withdraw round
      */
     function isValidUnbondingLock(address _delegator, uint256 _unbondingLockId) public view returns (bool) {
         // A unbonding lock is only valid if it has a non-zero withdraw round (the default value is zero)
@@ -1006,7 +1043,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @dev Remove transcoder
+     * @dev Remove a transcoder from the pool and deactivate it
      */
     function resignTranscoder(address _transcoder) internal {
         // Not zeroing 'Transcoder.lastActiveStakeUpdateRound' saves gas (5k when transcoder is evicted and 20k when transcoder is reinserted)
@@ -1124,6 +1161,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
     /**
      * @dev Return LivepeerToken interface
+     * @return Livepeer token contract registered with Controller
      */
     function livepeerToken() internal view returns (ILivepeerToken) {
         return ILivepeerToken(controller.getContract(keccak256("LivepeerToken")));
@@ -1131,6 +1169,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
     /**
      * @dev Return Minter interface
+     * @return Minter contract registered with Controller
      */
     function minter() internal view returns (IMinter) {
         return IMinter(controller.getContract(keccak256("Minter")));
@@ -1138,6 +1177,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
     /**
      * @dev Return RoundsManager interface
+     * @return RoundsManager contract registered with Controller
      */
     function roundsManager() internal view returns (IRoundsManager) {
         return IRoundsManager(controller.getContract(keccak256("RoundsManager")));

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.11;
 
 
-/*
+/**
  * @title Interface for BondingManager
  * TODO: switch to interface type
  */

--- a/contracts/libraries/MathUtils.sol
+++ b/contracts/libraries/MathUtils.sol
@@ -9,7 +9,7 @@ library MathUtils {
     // Divisor used for representing percentages
     uint256 public constant PERC_DIVISOR = 1000000;
 
-    /*
+    /**
      * @dev Returns whether an amount is a valid percentage out of PERC_DIVISOR
      * @param _amount Amount that is supposed to be a percentage
      */
@@ -17,7 +17,7 @@ library MathUtils {
         return _amount <= PERC_DIVISOR;
     }
 
-    /*
+    /**
      * @dev Compute percentage of a value with the percentage represented by a fraction
      * @param _amount Amount to take the percentage of
      * @param _fracNum Numerator of fraction representing the percentage
@@ -27,7 +27,7 @@ library MathUtils {
         return _amount.mul(percPoints(_fracNum, _fracDenom)).div(PERC_DIVISOR);
     }
 
-    /*
+    /**
      * @dev Compute percentage of a value with the percentage represented by a fraction over PERC_DIVISOR
      * @param _amount Amount to take the percentage of
      * @param _fracNum Numerator of fraction representing the percentage with PERC_DIVISOR as the denominator
@@ -36,7 +36,7 @@ library MathUtils {
         return _amount.mul(_fracNum).div(PERC_DIVISOR);
     }
 
-    /*
+    /**
      * @dev Compute percentage representation of a fraction
      * @param _fracNum Numerator of fraction represeting the percentage
      * @param _fracDenom Denominator of fraction represeting the percentage

--- a/contracts/libraries/SortedDoublyLL.sol
+++ b/contracts/libraries/SortedDoublyLL.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.11;
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 
-/*
+/**
  * @title A sorted doubly linked list with nodes sorted in descending order. Optionally accepts insert position hints
  *
  * Given a new node with a `key`, a hint is of the form `(prevId, nextId)` s.t. `prevId` and `nextId` are adjacent in the list.
@@ -33,7 +33,7 @@ library SortedDoublyLL {
         mapping (address => Node) nodes;     // Track the corresponding ids for each node in the list
     }
 
-    /*
+    /**
      * @dev Set the maximum size of the list
      * @param _size Maximum size
      */
@@ -43,7 +43,7 @@ library SortedDoublyLL {
         self.maxSize = _size;
     }
 
-    /*
+    /**
      * @dev Add a node to the list
      * @param _id Node's id
      * @param _key Node's key
@@ -96,7 +96,7 @@ library SortedDoublyLL {
         self.size = self.size.add(1);
     }
 
-    /*
+    /**
      * @dev Remove a node from the list
      * @param _id Node's id
      */
@@ -136,7 +136,7 @@ library SortedDoublyLL {
         self.size = self.size.sub(1);
     }
 
-    /*
+    /**
      * @dev Update the key of a node in the list
      * @param _id Node's id
      * @param _newKey Node's new key
@@ -156,86 +156,96 @@ library SortedDoublyLL {
         }
     }
 
-    /*
+    /**
      * @dev Checks if the list contains a node
-     * @param _transcoder Address of transcoder
+     * @param _id Address of transcoder
+     * @return true if '_id' is in list
      */
     function contains(Data storage self, address _id) public view returns (bool) {
         // List only contains non-zero keys, so if key is non-zero the node exists
         return self.nodes[_id].key > 0;
     }
 
-    /*
+    /**
      * @dev Checks if the list is full
+     * @return true if list is full
      */
     function isFull(Data storage self) public view returns (bool) {
         return self.size == self.maxSize;
     }
 
-    /*
+    /**
      * @dev Checks if the list is empty
+     * @return true if list is empty
      */
     function isEmpty(Data storage self) public view returns (bool) {
         return self.size == 0;
     }
 
-    /*
+    /**
      * @dev Returns the current size of the list
+     * @return current size of the list
      */
     function getSize(Data storage self) public view returns (uint256) {
         return self.size;
     }
 
-    /*
+    /**
      * @dev Returns the maximum size of the list
      */
     function getMaxSize(Data storage self) public view returns (uint256) {
         return self.maxSize;
     }
 
-    /*
+    /**
      * @dev Returns the key of a node in the list
      * @param _id Node's id
+     * @return key for node with '_id'
      */
     function getKey(Data storage self, address _id) public view returns (uint256) {
         return self.nodes[_id].key;
     }
 
-    /*
+    /**
      * @dev Returns the first node in the list (node with the largest key)
+     * @return address for the head of the list
      */
     function getFirst(Data storage self) public view returns (address) {
         return self.head;
     }
 
-    /*
+    /**
      * @dev Returns the last node in the list (node with the smallest key)
+     * @return address for the tail of the list
      */
     function getLast(Data storage self) public view returns (address) {
         return self.tail;
     }
 
-    /*
+    /**
      * @dev Returns the next node (with a smaller key) in the list for a given node
      * @param _id Node's id
+     * @return address for the node following node in list with '_id'
      */
     function getNext(Data storage self, address _id) public view returns (address) {
         return self.nodes[_id].nextId;
     }
 
-    /*
+    /**
      * @dev Returns the previous node (with a larger key) in the list for a given node
      * @param _id Node's id
+     * address for the node before node in list with '_id'
      */
     function getPrev(Data storage self, address _id) public view returns (address) {
         return self.nodes[_id].prevId;
     }
 
-    /*
+    /**
      * @dev Check if a pair of nodes is a valid insertion point for a new node with the given key
      * @param _key Node's key
      * @param _prevId Id of previous node for the insert position
      * @param _nextId Id of next node for the insert position
+     * @return if the insert position is valid
      */
     function validInsertPosition(Data storage self, uint256 _key, address _prevId, address _nextId) public view returns (bool) {
         if (_prevId == address(0) && _nextId == address(0)) {
@@ -253,7 +263,7 @@ library SortedDoublyLL {
         }
     }
 
-    /*
+    /**
      * @dev Descend the list (larger keys to smaller keys) to find a valid insert position
      * @param _key Node's key
      * @param _startId Id of node to start ascending the list from
@@ -276,7 +286,7 @@ library SortedDoublyLL {
         return (prevId, nextId);
     }
 
-    /*
+    /**
      * @dev Ascend the list (smaller keys to larger keys) to find a valid insert position
      * @param _key Node's key
      * @param _startId Id of node to start descending the list from
@@ -299,7 +309,7 @@ library SortedDoublyLL {
         return (prevId, nextId);
     }
 
-    /*
+    /**
      * @dev Find the insert position for a new node with the given key
      * @param _key Node's key
      * @param _prevId Id of previous node for the insert position

--- a/contracts/pm/TicketBroker.sol
+++ b/contracts/pm/TicketBroker.sol
@@ -27,7 +27,7 @@ contract TicketBroker is
     {}
 
     /**
-     * @dev Sets unlockPeriod value. Only callable by the Controller owner
+     * @notice Sets unlockPeriod value. Only callable by the Controller owner
      * @param _unlockPeriod Value for unlockPeriod
      */
     function setUnlockPeriod(uint256 _unlockPeriod) external onlyControllerOwner {
@@ -35,7 +35,7 @@ contract TicketBroker is
     }
 
     /**
-     * @dev Sets ticketValidityPeriod value. Only callable by the Controller owner
+     * @notice Sets ticketValidityPeriod value. Only callable by the Controller owner
      * @param _ticketValidityPeriod Value for ticketValidityPeriod
      */
     function setTicketValidityPeriod(uint256 _ticketValidityPeriod) external onlyControllerOwner {

--- a/contracts/pm/mixins/MixinContractRegistry.sol
+++ b/contracts/pm/mixins/MixinContractRegistry.sol
@@ -4,7 +4,7 @@ import "../../ManagerProxyTarget.sol";
 import "./interfaces/MContractRegistry.sol";
 
 
-contract MixinContractRegistry is MContractRegistry, ManagerProxyTarget {
+contract MixinContractRegistry is MContractRegistry, ManagerProxyTarget { 
     /**
      * @dev Checks if the current round has been initialized
      */

--- a/contracts/pm/mixins/MixinTicketBrokerCore.sol
+++ b/contracts/pm/mixins/MixinTicketBrokerCore.sol
@@ -62,7 +62,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     }
 
     /**
-     * @dev Adds ETH to the caller's deposit
+     * @notice Adds ETH to the caller's deposit
      */
     function fundDeposit()
         external
@@ -74,7 +74,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     }
 
     /**
-     * @dev Adds ETH to the caller's reserve
+     * @notice Adds ETH to the caller's reserve
      */
     function fundReserve()
         external
@@ -86,7 +86,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     }
 
     /**
-     * @dev Adds ETH to the caller's deposit and reserve
+     * @notice Adds ETH to the caller's deposit and reserve
      * @param _depositAmount Amount of ETH to add to the caller's deposit
      * @param _reserveAmount Amount of ETH to add to the caller's reserve
      */
@@ -105,8 +105,8 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     }
 
     /**
-     * @dev Redeems a winning ticket that has been signed by a sender and reveals the
-     * recipient recipientRand that corresponds to the recipientRandHash included in the ticket
+     * @notice Redeems a winning ticket that has been signed by a sender and reveals the
+     recipient recipientRand that corresponds to the recipientRandHash included in the ticket
      * @param _ticket Winning ticket to be redeemed in order to claim payment
      * @param _sig Sender's signature over the hash of `_ticket`
      * @param _recipientRand The preimage for the recipientRandHash included in `_ticket`
@@ -181,7 +181,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     }
 
     /**
-     * @dev Initiates the unlock period for the caller
+     * @notice Initiates the unlock period for the caller
      */
     function unlock() public whenSystemNotPaused {
         Sender storage sender = senders[msg.sender];
@@ -199,7 +199,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     }
 
     /**
-     * @dev Cancels the unlock period for the caller
+     * @notice Cancels the unlock period for the caller
      */
     function cancelUnlock() public whenSystemNotPaused {
         Sender storage sender = senders[msg.sender];
@@ -208,7 +208,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     }
 
     /**
-     * @dev Withdraws all ETH from the caller's deposit and reserve
+     * @notice Withdraws all ETH from the caller's deposit and reserve
      */
     function withdraw() public whenSystemNotPaused {
         Sender storage sender = senders[msg.sender];
@@ -238,7 +238,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     }
 
     /**
-     * @dev Returns whether a sender is currently in the unlock period
+     * @notice Returns whether a sender is currently in the unlock period
      * @param _sender Address of sender
      * @return Boolean indicating whether `_sender` has an unlock in progress
      */
@@ -248,7 +248,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     }
 
     /**
-     * @dev Returns info about a sender
+     * @notice Returns info about a sender
      * @param _sender Address of sender
      * @return Info about the sender for `_sender`
      */
@@ -275,7 +275,7 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
     }
 
     /**
-     * @dev Validates a winning ticket (succeeds or reverts)
+     * @dev Validates a winning ticket, succeeds or reverts
      * @param _ticket Winning ticket to be validated
      * @param _ticketHash Hash of `_ticket`
      * @param _sig Sender's signature over `_ticketHash`

--- a/contracts/pm/mixins/MixinWrappers.sol
+++ b/contracts/pm/mixins/MixinWrappers.sol
@@ -9,8 +9,7 @@ import "./interfaces/MContractRegistry.sol";
 contract MixinWrappers is MContractRegistry, MTicketBrokerCore {
 
     /**
-     * @dev Redeems multiple winning tickets. The function will redeem all of the provided
-     * tickets and handle any failures gracefully without reverting the entire function
+     * @notice Redeems multiple winning tickets. The function will redeem all of the provided tickets and handle any failures gracefully without reverting the entire function
      * @param _tickets Array of winning tickets to be redeemed in order to claim payment
      * @param _sigs Array of sender signatures over the hash of tickets (`_sigs[i]` corresponds to `_tickets[i]`)
      * @param _recipientRands Array of preimages for the recipientRandHash included in each ticket (`_recipientRands[i]` corresponds to `_tickets[i]`)
@@ -35,8 +34,8 @@ contract MixinWrappers is MContractRegistry, MTicketBrokerCore {
 
     /**
      * @dev Redeems a winning ticket that has been signed by a sender and reveals the
-     * recipient recipientRand that corresponds to the recipientRandHash included in the ticket
-     * This function wraps `redeemWinningTicket()` and returns false if the underlying call reverts
+     recipient recipientRand that corresponds to the recipientRandHash included in the ticket
+     This function wraps `redeemWinningTicket()` and returns false if the underlying call reverts
      * @param _ticket Winning ticket to be redeemed in order to claim payment
      * @param _sig Sender's signature over the hash of `_ticket`
      * @param _recipientRand The preimage for the recipientRandHash included in `_ticket`

--- a/contracts/pm/mixins/interfaces/MReserve.sol
+++ b/contracts/pm/mixins/interfaces/MReserve.sol
@@ -15,14 +15,14 @@ contract MReserve {
     event ReserveClaimed(address indexed reserveHolder, address claimant, uint256 amount);
 
     /**
-     * @dev Returns info about a reserve
+     * @notice Returns info about a reserve
      * @param _reserveHolder Address of reserve holder
      * @return Info about the reserve for `_reserveHolder`
      */
     function getReserveInfo(address _reserveHolder) public view returns (ReserveInfo memory info);
 
     /**
-     * @dev Returns the amount of funds claimed by a claimant from a reserve
+     * @notice Returns the amount of funds claimed by a claimant from a reserve
      * @param _reserveHolder Address of reserve holder
      * @param _claimant Address of claimant
      * @return Amount of funds claimed by `_claimant` from the reserve for `_reserveHolder`

--- a/contracts/rounds/RoundsManager.sol
+++ b/contracts/rounds/RoundsManager.sol
@@ -11,7 +11,7 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 /**
  * @title RoundsManager
- * @dev Manages round progression and other blockchain time related operations of the Livepeer protocol
+ * @notice Manages round progression and other blockchain time related operations of the Livepeer protocol
  */
 contract RoundsManager is ManagerProxyTarget, IRoundsManager {
     using SafeMath for uint256;
@@ -34,13 +34,13 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
     mapping (uint256 => bytes32) internal _blockHashForRound;
 
     /**
-     * @dev RoundsManager constructor. Only invokes constructor of base Manager contract with provided Controller address
+     * @notice RoundsManager constructor. Only invokes constructor of base Manager contract with provided Controller address
      * @param _controller Address of Controller that this contract will be registered with
      */
     constructor(address _controller) public Manager(_controller) {}
 
     /**
-     * @dev Set round length. Only callable by the controller owner
+     * @notice Set round length. Only callable by the controller owner
      * @param _roundLength Round length in blocks
      */
     function setRoundLength(uint256 _roundLength) external onlyControllerOwner {
@@ -64,7 +64,7 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
     }
 
     /**
-     * @dev Set round lock amount. Only callable by the controller owner
+     * @notice Set round lock amount. Only callable by the controller owner
      * @param _roundLockAmount Round lock amount as a % of the number of blocks in a round
      */
     function setRoundLockAmount(uint256 _roundLockAmount) external onlyControllerOwner {
@@ -76,7 +76,7 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
     }
 
     /**
-     * @dev Initialize the current round. Called once at the start of any round
+     * @notice Initialize the current round. Called once at the start of any round
      */
     function initializeRound() external whenSystemNotPaused {
         uint256 currRound = currentRound();
@@ -98,14 +98,14 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
     }
 
     /**
-     * @dev Return current block number
+     * @notice Return current block number
      */
     function blockNum() public view returns (uint256) {
         return block.number;
     }
 
     /**
-     * @dev Return blockhash for a block
+     * @notice Return blockhash for a block
      */
     function blockHash(uint256 _block) public view returns (bytes32) {
         uint256 currentBlock = blockNum();
@@ -116,7 +116,7 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
     }
 
     /**
-     * @dev Return blockhash for a round
+     * @notice Return blockhash for a round
      * @param _round Round number
      * @return Blockhash for `_round`
      */
@@ -125,7 +125,7 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
     }
 
     /**
-     * @dev Return current round
+     * @notice Return current round
      */
     function currentRound() public view returns (uint256) {
         // Compute # of rounds since roundLength was last updated
@@ -135,7 +135,7 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
     }
 
     /**
-     * @dev Return start block of current round
+     * @notice Return start block of current round
      */
     function currentRoundStartBlock() public view returns (uint256) {
         // Compute # of rounds since roundLength was last updated
@@ -145,14 +145,14 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
     }
 
     /**
-     * @dev Check if current round is initialized
+     * @notice Check if current round is initialized
      */
     function currentRoundInitialized() public view returns (bool) {
         return lastInitializedRound == currentRound();
     }
 
     /**
-     * @dev Check if we are in the lock period of the current round
+     * @notice Check if we are in the lock period of the current round
      */
     function currentRoundLocked() public view returns (bool) {
         uint256 lockedBlocks = MathUtils.percOf(roundLength, roundLockAmount);

--- a/contracts/test/mocks/GenericMock.sol
+++ b/contracts/test/mocks/GenericMock.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.11;
 
 
-/*
+/**
  * @title A mock contract that can set/return mock values and execute functions
  * on target contracts
  */
@@ -20,7 +20,7 @@ contract GenericMock {
     // Track function selectors and mapped mock values
     mapping (bytes4 => MockValue) mockValues;
 
-    /*
+    /**
      * @dev Return mock value for a functione
      */
     function() external payable {
@@ -43,7 +43,7 @@ contract GenericMock {
         }
     }
 
-    /*
+    /**
      * @dev Call a function on a target address using provided calldata for a function
      * @param _target Target contract to call with data
      * @param _data Transaction data to be used to call the target contract
@@ -54,7 +54,7 @@ contract GenericMock {
         require(ok, string(res));
     }
 
-    /*
+    /**
      * @dev Set a mock uint256 value for a function
      * @param _func Function selector (bytes4(keccak256(FUNCTION_SIGNATURE)))
      * @param _value Mock uint256 value
@@ -65,7 +65,7 @@ contract GenericMock {
         mockValues[_func].set = true;
     }
 
-    /*
+    /**
      * @dev Set a mock bytes32 value for a function
      * @param _func Function selector (bytes4(keccak256(FUNCTION_SIGNATURE)))
      * param _value Mock bytes32 value
@@ -76,7 +76,7 @@ contract GenericMock {
         mockValues[_func].set = true;
     }
 
-    /*
+    /**
      * @dev Set a mock bool value for a function
      * @param _func Function selector (bytes4(keccak256(FUNCTION_SIGNATURE)))
      * @param _value Mock bool value
@@ -87,7 +87,7 @@ contract GenericMock {
         mockValues[_func].set = true;
     }
 
-    /*
+    /**
      * @dev Set a mock address value for a function
      * @param _func Function selector (bytes4(keccak256(FUNCTION_SIGNATURE)))
      * @param _value Mock address value
@@ -98,7 +98,7 @@ contract GenericMock {
         mockValues[_func].set = true;
     }
 
-    /*
+    /**
      * @dev Load a uint256 value into memory and return it
      * @param _value Uint256 value
      */
@@ -111,7 +111,7 @@ contract GenericMock {
         }
     }
 
-    /*
+    /**
      * @dev Load a bytes32 value into memory and return it
      * @param _value Bytes32 value
      */
@@ -124,7 +124,7 @@ contract GenericMock {
         }
     }
 
-    /*
+    /**
      * @dev Load a bool value into memory and return it
      * @param _value Bool value
      */
@@ -137,7 +137,7 @@ contract GenericMock {
         }
     }
 
-    /*
+    /**
      * @dev Load an address value into memory and return it
      * @param _value Address value
      */

--- a/contracts/token/LivepeerTokenFaucet.sol
+++ b/contracts/token/LivepeerTokenFaucet.sol
@@ -5,7 +5,7 @@ import "./ILivepeerToken.sol";
 import "../zeppelin/Ownable.sol";
 
 
-/*
+/**
  * @title Faucet for the Livepeer Token
  */
 contract LivepeerTokenFaucet is Ownable {
@@ -32,8 +32,8 @@ contract LivepeerTokenFaucet is Ownable {
 
     event Request(address indexed to, uint256 amount);
 
-    /*
-     * @dev LivepeerTokenFacuet constructor
+    /**
+     * @notice LivepeerTokenFacuet constructor
      * @param _token Address of LivepeerToken
      * @param _requestAmount Amount of token sent to sender for a request
      * @param _requestWait Amount of time a sender must wait between request (denominated in hours)
@@ -44,24 +44,24 @@ contract LivepeerTokenFaucet is Ownable {
         requestWait = _requestWait;
     }
 
-    /*
-     * @dev Add an address to the whitelist
+    /**
+     * @notice Add an address to the whitelist
      * @param _addr Address to be whitelisted
      */
     function addToWhitelist(address _addr) external onlyOwner {
         isWhitelisted[_addr] = true;
     }
 
-    /*
-     * @dev Remove an address from the whitelist
+    /**
+     * @notice Remove an address from the whitelist
      * @param _addr Address to be removed from whitelist
      */
     function removeFromWhitelist(address _addr) external onlyOwner {
         isWhitelisted[_addr] = false;
     }
 
-    /*
-     * @dev Request an amount of token to be sent to sender
+    /**
+     * @notice Request an amount of token to be sent to sender
      */
     function request() external validRequest {
         if (!isWhitelisted[msg.sender]) {

--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -54,7 +54,7 @@ contract Minter is Manager, IMinter {
     }
 
     /**
-     * @dev Minter constructor
+     * @notice Minter constructor
      * @param _inflation Base inflation rate as a percentage of current total token supply
      * @param _inflationChange Change in inflation rate each round (increase or decrease) if target bonding rate is not achieved
      * @param _targetBondingRate Target bonding rate as a percentage of total bonded tokens / total token supply
@@ -73,7 +73,7 @@ contract Minter is Manager, IMinter {
     }
 
     /**
-     * @dev Set targetBondingRate. Only callable by Controller owner
+     * @notice Set targetBondingRate. Only callable by Controller owner
      * @param _targetBondingRate Target bonding rate as a percentage of total bonded tokens / total token supply
      */
     function setTargetBondingRate(uint256 _targetBondingRate) external onlyControllerOwner {
@@ -86,7 +86,7 @@ contract Minter is Manager, IMinter {
     }
 
     /**
-     * @dev Set inflationChange. Only callable by Controller owner
+     * @notice Set inflationChange. Only callable by Controller owner
      * @param _inflationChange Inflation change as a percentage of total token supply
      */
     function setInflationChange(uint256 _inflationChange) external onlyControllerOwner {
@@ -99,7 +99,7 @@ contract Minter is Manager, IMinter {
     }
 
     /**
-     * @dev Migrate to a new Minter by transferring ownership of the token as well
+     * @notice Migrate to a new Minter by transferring ownership of the token as well
      * as the current Minter's token balance to the new Minter. Only callable by Controller when system is paused
      * @param _newMinter Address of new Minter
      */
@@ -124,7 +124,7 @@ contract Minter is Manager, IMinter {
     }
 
     /**
-     * @dev Create reward based on a fractional portion of the mintable tokens for the current round
+     * @notice Create reward based on a fractional portion of the mintable tokens for the current round
      * @param _fracNum Numerator of fraction (active transcoder's stake)
      * @param _fracDenom Denominator of fraction (total active stake)
      */
@@ -143,7 +143,7 @@ contract Minter is Manager, IMinter {
     }
 
     /**
-     * @dev Transfer tokens to a receipient. Only callable by BondingManager - always trusts BondingManager
+     * @notice Transfer tokens to a receipient. Only callable by BondingManager - always trusts BondingManager
      * @param _to Recipient address
      * @param _amount Amount of tokens
      */
@@ -152,7 +152,7 @@ contract Minter is Manager, IMinter {
     }
 
     /**
-     * @dev Burn tokens. Only callable by BondingManager - always trusts BondingManager
+     * @notice Burn tokens. Only callable by BondingManager - always trusts BondingManager
      * @param _amount Amount of tokens to burn
      */
     function trustedBurnTokens(uint256 _amount) external onlyBondingManager whenSystemNotPaused {
@@ -160,7 +160,7 @@ contract Minter is Manager, IMinter {
     }
 
     /**
-     * @dev Withdraw ETH to a recipient. Only callable by BondingManager or TicketBroker - always trusts these two contracts
+     * @notice Withdraw ETH to a recipient. Only callable by BondingManager or TicketBroker - always trusts these two contracts
      * @param _to Recipient address
      * @param _amount Amount of ETH
      */
@@ -169,14 +169,14 @@ contract Minter is Manager, IMinter {
     }
 
     /**
-     * @dev Deposit ETH to this contract. Only callable by the currently registered Minter or JobsManager
+     * @notice Deposit ETH to this contract. Only callable by the currently registered Minter or JobsManager
      */
     function depositETH() external payable onlyMinterOrJobsManager whenSystemNotPaused returns (bool) {
         return true;
     }
 
     /**
-     * @dev Set inflation and mintable tokens for the round. Only callable by the RoundsManager
+     * @notice Set inflation and mintable tokens for the round. Only callable by the RoundsManager
      */
     function setCurrentRewardTokens() external onlyRoundsManager whenSystemNotPaused {
         setInflation();

--- a/contracts/token/VariableSupplyToken.sol
+++ b/contracts/token/VariableSupplyToken.sol
@@ -6,9 +6,9 @@ import "../zeppelin/MintableToken.sol";
 contract VariableSupplyToken is MintableToken {
     event Burn(address indexed burner, uint256 value);
 
-    /*
+    /**
      * @dev Burns a specific amount of the sender's tokens
-     * @param _value The amount of tokens to be burned
+     * @param _amount The amount of tokens to be burned
      */
     function burn(uint256 _amount) public {
         _burn(msg.sender, _amount);


### PR DESCRIPTION
This PR adds proper NATSPEC comment formatting to all contracts.

- Changed some minor semantic details in BondingManager.js
- Changed most `@dev` tags to `@notice` to distinguish end-user description from extra developer comments

Fixes #130