### PR TITLE
Add Refunder contract

### DIFF
--- a/contracts/refund/IAlphaJobsManager.sol
+++ b/contracts/refund/IAlphaJobsManager.sol
@@ -1,0 +1,6 @@
+pragma solidity ^0.5.11;
+
+
+contract IAlphaJobsManager {
+    function broadcasters(address _broadcaster) public view returns (uint256 deposit, uint256 withdrawBlock);
+}

--- a/contracts/refund/Refunder.sol
+++ b/contracts/refund/Refunder.sol
@@ -1,0 +1,54 @@
+pragma solidity ^0.5.11;
+
+import "./IAlphaJobsManager.sol";
+
+
+contract Refunder {
+    // Reference to alpha JobsManager
+    IAlphaJobsManager public alphaJobsManager;
+
+    // Keeps track of addresses that have withdrawn their refund
+    mapping (address => bool) public withdrawn;
+
+    event FundsReceived(address from, uint256 amount);
+    event RefundWithdrawn(address indexed addr, uint256 amount);
+
+    /**
+     * @notice Refunder constructor
+     * @param _alphaJobsManagerAddr Address of alpha JobsManager
+     */
+    constructor(address _alphaJobsManagerAddr) public {
+        alphaJobsManager = IAlphaJobsManager(_alphaJobsManagerAddr);
+    }
+
+    /**
+     * @dev Receive and log receipt of ETH
+     */
+    function() external payable {
+        emit FundsReceived(msg.sender, msg.value);
+    }
+
+    /**
+     * @notice Withdraws the alpha JobsManager refund for the given address
+     * @param _addr The address to withdraw for
+     */
+    function withdraw(address payable _addr) external {
+        require(
+            !withdrawn[_addr],
+            "address has already withdrawn alpha JobsManager refund"
+        );
+
+        (uint256 deposit,) = alphaJobsManager.broadcasters(_addr);
+
+        require(
+            deposit > 0,
+            "address does not have a deposit with alpha JobsManager"
+        );
+
+        withdrawn[_addr] = true;
+
+        _addr.transfer(deposit);
+
+        emit RefundWithdrawn(_addr, deposit);
+    }
+}

--- a/contracts/test/mocks/AlphaJobsManagerMock.sol
+++ b/contracts/test/mocks/AlphaJobsManagerMock.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.5.11;
+
+
+contract AlphaJobsManagerMock {
+    struct Broadcaster {
+        uint256 deposit;
+        uint256 withdrawBlock;
+    }
+
+    mapping (address => Broadcaster) internal mockBroadcasters;
+
+    function setBroadcaster(address _addr, uint256 _deposit, uint256 _withdrawBlock) external {
+        mockBroadcasters[_addr].deposit = _deposit;
+        mockBroadcasters[_addr].withdrawBlock = _withdrawBlock;
+    }
+
+    function broadcasters(address _addr) public view returns (uint256 deposit, uint256 withdrawBlock) {
+        deposit = mockBroadcasters[_addr].deposit;
+        withdrawBlock = mockBroadcasters[_addr].withdrawBlock;
+    }
+}

--- a/test/unit/Refunder.js
+++ b/test/unit/Refunder.js
@@ -1,0 +1,118 @@
+import BN from "bn.js"
+import Fixture from "./helpers/Fixture"
+import expectRevertWithReason from "../helpers/expectFail"
+import truffleAssert from "truffle-assertions"
+
+const Refunder = artifacts.require("Refunder")
+const AlphaJobsManagerMock = artifacts.require("AlphaJobsManagerMock")
+
+contract("Refunder", accounts => {
+    let fixture
+
+    let refunder
+    let jobsManager
+
+    before(async () => {
+        fixture = new Fixture(web3)
+
+        jobsManager = await AlphaJobsManagerMock.new()
+        refunder = await Refunder.new(jobsManager.address)
+    })
+
+    beforeEach(async () => {
+        await fixture.setUp()
+    })
+
+    afterEach(async () => [
+        await fixture.tearDown()
+    ])
+
+    describe("constructor", () => {
+        it("sets alpha JobsManager", async () => {
+            assert.equal(await refunder.alphaJobsManager.call(), jobsManager.address)
+        })
+    })
+
+    describe("fallback", () => {
+        it("receives ETH", async () => {
+            const txRes = await refunder.sendTransaction({from: accounts[0], value: 1000})
+            truffleAssert.eventEmitted(
+                await truffleAssert.createTransactionResult(refunder, txRes.tx),
+                "FundsReceived",
+                ev => ev.from === accounts[0] && ev.amount.toString() === "1000"
+            )
+
+            assert.equal((await web3.eth.getBalance(refunder.address)).toString(), "1000")
+        })
+    })
+
+    describe("withdraw", () => {
+        it("should revert if address does not have a deposit with alpha JobsManager", async () => {
+            await expectRevertWithReason(
+                refunder.withdraw(accounts[1]),
+                "address does not have a deposit with alpha JobsManager"
+            )
+        })
+
+        it("should send refund to address", async () => {
+            const addr1 = accounts[1]
+            const addr2 = accounts[2]
+
+            // Make sure that addresses have not withdrawn
+            assert.isNotOk(await refunder.withdrawn(addr1))
+            assert.isNotOk(await refunder.withdrawn(addr2))
+
+            // Send funds to refunder
+            await refunder.sendTransaction({from: accounts[0], value: 1000})
+
+            await jobsManager.setBroadcaster(addr1, 700, 99)
+            await jobsManager.setBroadcaster(addr2, 300, 99)
+
+            let startRefunderBalance = new BN(await web3.eth.getBalance(refunder.address))
+            const startAddr1Balance = new BN(await web3.eth.getBalance(addr1))
+
+            let txRes = await refunder.withdraw(addr1)
+            truffleAssert.eventEmitted(txRes, "RefundWithdrawn", ev => {
+                return ev.addr === addr1 && ev.amount.toString() === "700"
+            })
+
+            let endRefunderBalance = new BN(await web3.eth.getBalance(refunder.address))
+            const endAddr1Balance = new BN(await web3.eth.getBalance(addr1))
+
+            assert.equal(startRefunderBalance.sub(endRefunderBalance).toString(), "700")
+            assert.equal(endAddr1Balance.sub(startAddr1Balance).toString(), "700")
+            assert.isOk(await refunder.withdrawn(addr1))
+
+            startRefunderBalance = endRefunderBalance
+            const startAddr2Balance = new BN(await web3.eth.getBalance(addr2))
+
+            txRes = await refunder.withdraw(addr2)
+            truffleAssert.eventEmitted(txRes, "RefundWithdrawn", ev => {
+                return ev.addr === addr2 && ev.amount.toString() === "300"
+            })
+
+            endRefunderBalance = new BN(await web3.eth.getBalance(refunder.address))
+            const endAddr2Balance = new BN(await web3.eth.getBalance(addr2))
+
+            assert.equal(startRefunderBalance.sub(endRefunderBalance).toString(), "300")
+            assert.equal(endAddr2Balance.sub(startAddr2Balance).toString(), "300")
+            assert.isOk(await refunder.withdrawn(addr2))
+        })
+
+        it("should revert if address has withdrawn", async () => {
+            const addr1 = accounts[1]
+
+            // Send funds to refunder
+            await refunder.sendTransaction({from: accounts[0], value: 1000})
+
+            await jobsManager.setBroadcaster(addr1, 700, 99)
+
+            await refunder.withdraw(addr1)
+
+            await expectRevertWithReason(
+                refunder.withdraw(addr1),
+                "address has already withdrawn alpha JobsManager refund"
+            )
+        })
+    })
+})


### PR DESCRIPTION
This PR adds a `Refunder` contract that reads the state of deposits in the `JobsManager` contract in order to determine the amount that an address is eligible to withdraw.

- The `Refunder` receives ETH via its fallback function. The total amount sent to the `Refunder` will be the sum of all outstanding deposits managed by the `JobsManager`
- The `withdraw()` function accepts an address as an argument. So, a third party address can submit the `withdraw()` call for another address
- If the provided address does not have a deposit with the `JobsManager`, the tx will revert
- If the provided address has already withdrawn its refund, the tx will revert

See the [upgrade plan](https://gist.github.com/yondonfu/c87756debb08d7839105c9bbece709c7) for more details on how the `Refunder` contract will be used.