### PR TITLE
polling: Use QUORUM according to LIP-16

### DIFF
--- a/contracts/polling/PollCreator.sol
+++ b/contracts/polling/PollCreator.sol
@@ -5,9 +5,11 @@ import "../token/ILivepeerToken.sol";
 
 
 contract PollCreator {
-    // TODO: Update these values
-    uint256 public constant QUORUM = 20;
-    uint256 public constant THRESHOLD = 50;
+    // 33.33%
+    uint256 public constant QUORUM = 333300;
+    // 50%
+    uint256 public constant QUOTA = 500000;
+    // 10 rounds
     uint256 public constant POLL_PERIOD = 10 * 5760;
     uint256 public constant POLL_CREATION_COST = 100 * 1 ether;
 
@@ -18,7 +20,7 @@ contract PollCreator {
         bytes proposal,
         uint256 endBlock,
         uint256 quorum,
-        uint256 threshold
+        uint256 quota
     );
 
     constructor(address _tokenAddr) public {
@@ -46,7 +48,7 @@ contract PollCreator {
             _proposal,
             endBlock,
             QUORUM,
-            THRESHOLD
+            QUOTA
         );
     }
 }

--- a/test/unit/PollCreator.js
+++ b/test/unit/PollCreator.js
@@ -7,8 +7,8 @@ import {functionSig} from "../../utils/helpers"
 const PollCreator = artifacts.require("PollCreator")
 const GenericMock = artifacts.require("GenericMock")
 
-const QUORUM = 20
-const THRESHOLD = 50
+const QUORUM = 333300
+const QUOTA = 500000
 const POLL_PERIOD = 10 * 5760
 
 contract("PollCreator", accounts => {
@@ -61,7 +61,7 @@ contract("PollCreator", accounts => {
                 e => e.proposal == hash
                 && e.endBlock.toNumber() == end
                 && e.quorum.toNumber() == QUORUM
-                && e.threshold.toNumber() == THRESHOLD
+                && e.quota.toNumber() == QUOTA
                 ,
                 "PollCreated event not emitted correctly"
             )


### PR DESCRIPTION
Updates PollCreator to use the QUORUM parameter and the default parameter values described in [LIP-16](https://github.com/livepeer/LIPs/blob/master/LIPs/LIP-16.md).

Fixes #379 