### PR TITLE
ci: Block merges when there are fixup commits on the branch

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,11 @@
+name: Git Checks
+
+on: [push]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v1.1.1


### PR DESCRIPTION
This PR adds a GH action to block merges when there are fixup commits on the branch.