### PR TITLE
Fix Solidity unit test runner

### DIFF
--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,5 +1,9 @@
 const Migrations = artifacts.require("./Migrations.sol")
 
-module.exports = function(deployer) {
+module.exports = function(deployer, network) {
+    if (network === "unitTest") {
+        return
+    }
+
     deployer.deploy(Migrations)
 }

--- a/migrations/2_deploy_libraries.js
+++ b/migrations/2_deploy_libraries.js
@@ -1,7 +1,11 @@
 const SortedDoublyLL = artifacts.require("SortedDoublyLL")
 const BondingManager = artifacts.require("BondingManager")
 
-module.exports = function(deployer) {
+module.exports = function(deployer, network) {
+    if (network === "unitTest") {
+        return
+    }
+
     deployer.deploy(SortedDoublyLL)
     deployer.link(SortedDoublyLL, BondingManager)
 }

--- a/migrations/3_deploy_contracts.js
+++ b/migrations/3_deploy_contracts.js
@@ -13,6 +13,10 @@ const LivepeerTokenFaucet = artifacts.require("LivepeerTokenFaucet")
 const ManagerProxy = artifacts.require("ManagerProxy")
 
 module.exports = function(deployer, network) {
+    if (network === "unitTest") {
+        return
+    }
+
     deployer.then(async () => {
         const lpDeployer = new ContractDeployer(deployer, Controller, ManagerProxy)
 

--- a/migrations/4_genesis.js
+++ b/migrations/4_genesis.js
@@ -7,6 +7,10 @@ const ManagerProxy = artifacts.require("ManagerProxy")
 const LivepeerToken = artifacts.require("LivepeerToken")
 
 module.exports = function(deployer, network, accounts) {
+    if (network === "unitTest") {
+        return
+    }
+
     deployer.then(async () => {
         const lpDeployer = new ContractDeployer(deployer, Controller, ManagerProxy)
 

--- a/migrations/5_deploy_poll.js
+++ b/migrations/5_deploy_poll.js
@@ -3,7 +3,11 @@ const {contractId} = require("../utils/helpers")
 const Controller = artifacts.require("Controller")
 const PollCreator = artifacts.require("PollCreator")
 
-module.exports = function(deployer) {
+module.exports = function(deployer, network) {
+    if (network === "unitTest") {
+        return
+    }
+
     deployer.then(async () => {
         const controller = await Controller.deployed()
         const tokenAddr = await controller.getContract(contractId("LivepeerToken"))

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -21,7 +21,7 @@ ganache_running() {
 }
 
 start_ganache() {
-    if [ "$SOLIDITY_COVERAGE" = false ]; then
+    if [ "$SOLIDITY_COVERAGE" != true ]; then
         echo "Starting new ganache instance at port $ganache_port"
         node_modules/.bin/ganache-cli -k istanbul -l 0x7A1200 -a 310 > /dev/null &
     fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -38,5 +38,10 @@ fi
 if [ "$SOLIDITY_COVERAGE" = true ]; then
     node_modules/.bin/truffle run coverage
 else
-    node_modules/.bin/truffle test "$@"
+    args="$@"
+    if echo $args | grep -q "unit"; then
+        node_modules/.bin/truffle test --network=unitTest $args
+    else
+        node_modules/.bin/truffle test $args
+    fi
 fi

--- a/truffle.js
+++ b/truffle.js
@@ -58,6 +58,13 @@ module.exports = {
             network_id: "*", // Match any network id
             gas: 8000000
         },
+        // This network should be used when running unit tests so migrations can be skipped
+        unitTest: {
+            host: "localhost",
+            port: 8545,
+            network_id: "*",
+            gas: 8000000
+        },
         parityDev: {
             host: "parity-dev",
             port: 8545,

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -9,6 +9,10 @@ export function functionSig(name) {
     return ethUtil.bufferToHex(ethUtil.sha3(name).slice(0, 4))
 }
 
+export function eventSig(name) {
+    return ethUtil.bufferToHex(ethUtil.sha3(name))
+}
+
 export function functionEncodedABI(name, params, values) {
     return ethUtil.bufferToHex(Buffer.concat([ethUtil.sha3(name).slice(0, 4), ethAbi.rawEncode(params, values)]))
 }


### PR DESCRIPTION
This PR contains a few updates that make running tests locally easier/a bit faster and also fixes an issue with the Solidity unit test runner.

fd7e690: Fix a check in `test.sh` that was preventing the script from starting ganache in the background
ab02f7d: Skip migrations when running contract unit tests because unit tests will handle contract deployment/initialization. Migrations will still be run for contract integration tests.
c4a40d3: Fix the Solidity unit test runner (we use a JS helper from another project to run unit tests written in Solidity due to some quirks with the coverage reporting tool). Previously, failed assertions were not being reported by the test runner.