### PR TITLE
fix SortedDoublyLL link when using unitTest network

### DIFF
--- a/migrations/2_deploy_libraries.js
+++ b/migrations/2_deploy_libraries.js
@@ -2,10 +2,7 @@ const SortedDoublyLL = artifacts.require("SortedDoublyLL")
 const BondingManager = artifacts.require("BondingManager")
 
 module.exports = function(deployer, network) {
-    if (network === "unitTest") {
-        return
-    }
-
+    if (network  === "unitTest") return
     deployer.deploy(SortedDoublyLL)
     deployer.link(SortedDoublyLL, BondingManager)
 }

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -6,6 +6,7 @@ import BN from "bn.js"
 import truffleAssert from "truffle-assertions"
 
 const BondingManager = artifacts.require("BondingManager")
+const LinkedList = artifacts.require("SortedDoublyLL")
 
 const {DelegatorStatus, TranscoderStatus} = constants
 
@@ -24,6 +25,8 @@ contract("BondingManager", accounts => {
         fixture = new Fixture(web3)
         await fixture.deploy()
 
+        const ll = await LinkedList.new()
+        BondingManager.link("SortedDoublyLL", ll.address)
         bondingManager = await fixture.deployAndRegister(BondingManager, "BondingManager", fixture.controller.address)
 
         await bondingManager.setUnbondingPeriod(UNBONDING_PERIOD)


### PR DESCRIPTION
#386 skips migrations when using the `unitTest` network, but it also skips linking `DoublySortedLL` to the `BondingManager`. 

This PR fixes the linking when using the `unitTest` network. 

To reproduce the issue check out #386 and run `./node_modules/.bin/truffle test test/unit/BondingManager.js --network=unitTest` 

The following error will be returned 

```
  1) Contract: BondingManager
       "before all" hook in "Contract: BondingManager":
     Error: BondingManager contains unresolved libraries. You must deploy and link the following libraries before you can deploy a new version of BondingManager: SortedDoublyLL
```