### PR TITLE
Added temporary fix for london hardfork compatibility

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,7 +7,7 @@ import "hardhat-abi-exporter"
 
 // deployment plugins
 import "hardhat-deploy"
-import "hardhat-deploy-ethers"
+import "@nomiclabs/hardhat-ethers"
 
 import "solidity-coverage"
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -37,7 +37,7 @@ const config: HardhatUserConfig = {
     networks: {
         hardhat: {
             gas: 12000000,
-            hardfork: "berlin",
+            initialBaseFeePerGas: 0,
             allowUnlimitedContractSize: true,
             blockGasLimit: 12000000,
             accounts: {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/livepeer/protocol#readme",
   "devDependencies": {
-    "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.10",
+    "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers",
     "@nomiclabs/hardhat-etherscan": "^2.1.4",
     "@nomiclabs/hardhat-web3": "^2.0.0",
     "@typechain/ethers-v5": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ethereumjs-util": "^6.0.0",
     "ethers": "^5.4.1",
     "ethlint": "^1.2.5",
-    "hardhat": "^2.1.2",
+    "hardhat": "2.6.0",
     "hardhat-abi-exporter": "^2.2.1",
     "hardhat-deploy": "^0.7.4",
     "hardhat-deploy-ethers": "^0.3.0-beta.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -601,6 +601,7 @@
     fastq "^1.6.0"
 
 "@nomiclabs/hardhat-ethers@npm:hardhat-deploy-ethers", hardhat-deploy-ethers@^0.3.0-beta.10:
+  name "@nomiclabs/hardhat-ethers"
   version "0.3.0-beta.10"
   resolved "https://registry.yarnpkg.com/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.10.tgz#bccfcf635d380bbab3638960f6739fe4d396fc5f"
   integrity sha512-TeyriUshRZ7XVHOjMsDtTozIrdwLf3Bw+oZRYNhXdG/eut5HeDhjUFPfRlG7TI1lSLvkcB5dt7OxOtPYKDOxTg==
@@ -5170,7 +5171,7 @@ hardhat-gas-reporter@^1.0.4:
     eth-gas-reporter "^0.2.20"
     sha1 "^1.1.1"
 
-hardhat@^2.1.2:
+hardhat@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.6.0.tgz#a00a44d36559a880c170dca6363cc33f7545364b"
   integrity sha512-NEM2pe11QXWXB7k49heOLQA9vxihG4DJ0712KjMT9NYSZgLOMcWswJ3tvn+/ND6vzLn6Z4pqr2x/kWSfllWFuw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -600,7 +600,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nomiclabs/hardhat-ethers@npm:hardhat-deploy-ethers@^0.3.0-beta.10", hardhat-deploy-ethers@^0.3.0-beta.10:
+"@nomiclabs/hardhat-ethers@npm:hardhat-deploy-ethers", hardhat-deploy-ethers@^0.3.0-beta.10:
   version "0.3.0-beta.10"
   resolved "https://registry.yarnpkg.com/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.10.tgz#bccfcf635d380bbab3638960f6739fe4d396fc5f"
   integrity sha512-TeyriUshRZ7XVHOjMsDtTozIrdwLf3Bw+oZRYNhXdG/eut5HeDhjUFPfRlG7TI1lSLvkcB5dt7OxOtPYKDOxTg==
@@ -5170,7 +5170,7 @@ hardhat-gas-reporter@^1.0.4:
     eth-gas-reporter "^0.2.20"
     sha1 "^1.1.1"
 
-hardhat@2.6.0:
+hardhat@^2.1.2:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.6.0.tgz#a00a44d36559a880c170dca6363cc33f7545364b"
   integrity sha512-NEM2pe11QXWXB7k49heOLQA9vxihG4DJ0712KjMT9NYSZgLOMcWswJ3tvn+/ND6vzLn6Z4pqr2x/kWSfllWFuw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -600,7 +600,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nomiclabs/hardhat-ethers@npm:hardhat-deploy-ethers", hardhat-deploy-ethers@^0.3.0-beta.10:
+"@nomiclabs/hardhat-ethers@npm:hardhat-deploy-ethers@^0.3.0-beta.10", hardhat-deploy-ethers@^0.3.0-beta.10:
   version "0.3.0-beta.10"
   resolved "https://registry.yarnpkg.com/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.10.tgz#bccfcf635d380bbab3638960f6739fe4d396fc5f"
   integrity sha512-TeyriUshRZ7XVHOjMsDtTozIrdwLf3Bw+oZRYNhXdG/eut5HeDhjUFPfRlG7TI1lSLvkcB5dt7OxOtPYKDOxTg==
@@ -5170,7 +5170,7 @@ hardhat-gas-reporter@^1.0.4:
     eth-gas-reporter "^0.2.20"
     sha1 "^1.1.1"
 
-hardhat@^2.1.2:
+hardhat@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.6.0.tgz#a00a44d36559a880c170dca6363cc33f7545364b"
   integrity sha512-NEM2pe11QXWXB7k49heOLQA9vxihG4DJ0712KjMT9NYSZgLOMcWswJ3tvn+/ND6vzLn6Z4pqr2x/kWSfllWFuw==


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
The current `solidity-coverage` version overrides the gasPrice during execution and sets it equal to 1. This creates an issue with the EIP-1559 "baseFeePerGas". There is an open issue sc-forks/solidity-coverage/issues/652 to deal with this. This PR includes a temporary and "hacky" solution to overcome the issue by setting the `initialBaseFeePerGas` equal to 0 in the hardhat network config. However, moving forward this should not be the final solution. 

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- update hardhat version to v2.6.0
- set `initialBaseFeePerGas` equal to 0 in the hardhat config

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
ran `yarn test:coverage`

**Does this pull request close any open issues?**
<!-- Fixes # -->
closes #447 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn run test` pass
- [x] need to merge #456 before merging this
