### PR TITLE
Separated concerns for orchestrator and delegator

### DIFF
--- a/contracts/bonding/Delegations.sol
+++ b/contracts/bonding/Delegations.sol
@@ -121,7 +121,7 @@ library Delegations {
     ) internal {
         _pool.delegations[_delegator].shares = _pool.delegations[_delegator].shares - _amount;
         _pool.totalShares = _pool.totalShares - _amount;
-        _pool.activeFeeShares -= _amount;
+        // _pool.activeFeeShares -= _amount;
     }
 
     /**

--- a/contracts/bonding/IStakingManager.sol
+++ b/contracts/bonding/IStakingManager.sol
@@ -4,47 +4,32 @@
 pragma solidity 0.8.4;
 
 /**
- * @title Interface for BondingManager
+ * @title Interface for StakingManager
  */
 interface IStakingManager {
-    event TranscoderUpdate(address indexed transcoder, uint256 rewardCut, uint256 feeShare);
-    event TranscoderActivated(address indexed transcoder, uint256 activationRound);
-    event TranscoderDeactivated(address indexed transcoder, uint256 deactivationRound);
-    event TranscoderSlashed(address indexed transcoder, address finder, uint256 penalty, uint256 finderReward);
-    event Reward(address indexed transcoder, uint256 amount);
-    event Bond(address indexed delegate, address indexed delegator, uint256 additionalAmount, uint256 bondedAmount);
-    event Unbond(
-        address indexed delegate,
-        address indexed delegator,
-        uint256 unbondingLockId,
-        uint256 amount,
-        uint256 withdrawRound
-    );
-    event Rebond(address indexed delegate, address indexed delegator, uint256 unbondingLockId, uint256 amount);
+    event OrchestratorUpdate(address indexed orchestrator, uint256 rewardCut, uint256 feeShare);
+    event OrchestratorActivated(address indexed orchestrator, uint256 activationRound);
+    event OrchestratorDeactivated(address indexed orchestrator, uint256 deactivationRound);
+    event Reward(address indexed orchestrator, uint256 amount);
+
+    event Stake(address indexed orchestrator, uint256 amount);
+    event Unstake(address indexed orchestrator, uint256 amount, uint256 lockID);
+
+    event Delegate(address indexed delegator, address indexed orchestrator, uint256 amount);
+    event Undelegate(address indexed delegator, address indexed orchestrator, uint256 amount, uint256 lockID);
+
     event WithdrawStake(address indexed delegator, uint256 unbondingLockId, uint256 amount, uint256 withdrawRound);
     event WithdrawFees(address indexed delegator);
-    event EarningsClaimed(
-        address indexed delegate,
-        address indexed delegator,
-        uint256 rewards,
-        uint256 fees,
-        uint256 startRound,
-        uint256 endRound
-    );
 
     // External functions
-    function updateTranscoderWithFees(
-        address _transcoder,
-        uint256 _fees,
-        uint256 _round
-    ) external;
+    function updateOrchestratorWithFees(address _orchestrator, uint256 _fees) external;
 
     function setCurrentRoundTotalActiveStake() external;
 
     // Public functions
-    function getTranscoderPoolSize() external view returns (uint256);
+    function getOrchestratorPoolSize() external view returns (uint256);
 
-    function isActiveTranscoder(address _transcoder) external view returns (bool);
+    function isActiveOrchestrator(address _orchestrator) external view returns (bool);
 
-    function getTotalBonded() external view returns (uint256);
+    function getTotalStaked() external view returns (uint256);
 }

--- a/contracts/bonding/StakingManager.sol
+++ b/contracts/bonding/StakingManager.sol
@@ -19,7 +19,7 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
     using SortedDoublyLL for SortedDoublyLL.Data;
     using Delegations for Delegations.Pool;
 
-    // The various states a transcoder can be in
+    // The various states a orchestrator can be in
     enum OrchestratorStatus {
         NotRegistered,
         Registered,
@@ -28,39 +28,39 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
 
     struct Orchestrator {
         // Time-keeping
-        uint256 activationRound; // Round in which the transcoder became active - 0 if inactive
+        uint256 activationRound; // Round in which the orchestrator became active - 0 if inactive
         uint256 deactivationRound;
         // Commission accounting
         uint256 rewardShare; // % of reward shared with delegations
         uint256 feeShare; // % of fees shared with delegations
-        uint256 rewardCommissions; // reward earned from commission (not shared with delegators)
         uint256 feeCommissions; // fees earned from commission (not shared with delegators)
         uint256 lastRewardRound;
         // Delegation Pool
         Delegations.Pool delegationPool;
     }
 
-    // Represents an amount of tokens that are being unbonded
-    struct UnbondingLock {
+    // Represents an amount of tokens that are being undelegate
+    struct UnstakingLock {
+        address owner; // address which owns undelegated amount
         address orchestrator;
-        uint256 amount; // Amount of tokens being unbonded
-        uint256 withdrawRound; // Round at which unbonding period is over and tokens can be withdrawn
+        uint256 amount; // Amount of tokens being ustaked
+        uint256 withdrawRound; // Round at which undelegation period is over and tokens can be withdrawn
     }
 
-    // Time between unbonding and possible withdrawl in rounds
-    uint64 public unbondingPeriod;
+    // Time between unstaking and possible withdrawal in rounds
+    uint64 public unstakingPeriod;
 
     mapping(address => Orchestrator) private orchestrators;
-    mapping(uint256 => UnbondingLock) public unbondingLocks;
-    uint256 private lastUnbondingLockID;
+    mapping(uint256 => UnstakingLock) public unstakingLocks;
+    uint256 private lastUnstakingLockID;
 
     // The total active stake (sum of the stake of active set members) for the current round
     uint256 public currentRoundTotalActiveStake;
     // The total active stake (sum of the stake of active set members) for the next round
     uint256 public nextRoundTotalActiveStake;
 
-    // The transcoder pool is used to keep track of the transcoders that are eligible for activation.
-    // The pool keeps track of the pending active set in round N and the start of round N + 1 transcoders
+    // The orchestrator pool is used to keep track of the orchestrators that are eligible for activation.
+    // The pool keeps track of the pending active set in round N and the start of round N + 1 orchestrators
     // in the pool are locked into the active set for round N + 1
     SortedDoublyLL.Data private orchestratorPoolV2;
 
@@ -76,30 +76,23 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
         _;
     }
 
-    // Check if sender is Verifier
-    modifier onlyVerifier() {
-        _onlyVerifier();
-        _;
-    }
-
     // Check if current round is initialized
     modifier currentRoundInitialized() {
         _currentRoundInitialized();
         _;
     }
 
-    modifier autoClaimFees(address _delegate) {
-        _claimFees(_delegate, payable(msg.sender));
+    modifier autoClaimFees(address _orchestrator, address _delegator) {
+        _claimFees(_orchestrator, payable(_delegator));
         _;
     }
 
     /**
-     * @notice BondingManager constructor. Only invokes constructor of base Manager contract with provided Controller address
+     * @notice StakingManager constructor. Only invokes constructor of base Manager contract with provided Controller address
      * @dev This constructor will not initialize any state variables besides `controller`. The following setter functions
      * should be used to initialize state variables post-deployment:
-     * - setUnbondingPeriod()
-     * - setNumActiveTranscoders()
-     * - setMaxEarningsClaimsRounds()
+     * - setUnstakingPeriod()
+     * - setNumActiveOrchestrators()
      * @param _controller Address of Controller that this contract will be registered with
      */
     constructor(address _controller) Manager(_controller) {}
@@ -107,299 +100,276 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
     /**
      * PROTOCOL PARAMETERRS
      */
-    /**
-     * @notice Set unbonding period. Only callable by Controller owner
-     * @param _unbondingPeriod Rounds between unbonding and possible withdrawal
-     */
-    function setUnbondingPeriod(uint64 _unbondingPeriod) external onlyControllerOwner {
-        unbondingPeriod = _unbondingPeriod;
 
-        emit ParameterUpdate("unbondingPeriod");
+    /**
+     * @notice Set undelegation period. Only callable by Controller owner
+     * @param _unstakingPeriod Rounds between unstaking and possible withdrawal
+     */
+    function setUnstakingPeriod(uint64 _unstakingPeriod) external onlyControllerOwner {
+        unstakingPeriod = _unstakingPeriod;
+
+        emit ParameterUpdate("unstakingPeriod");
     }
 
     /**
-     * @notice Set maximum number of active transcoders. Only callable by Controller owner
-     * @param _numActiveTranscoders Number of active transcoders
+     * @notice Set maximum number of active orchestrators. Only callable by Controller owner
+     * @param _numActiveOrchestrators Number of active orchestrators
      */
-    function setNumActiveTranscoders(uint256 _numActiveTranscoders) external onlyControllerOwner {
-        orchestratorPoolV2.setMaxSize(_numActiveTranscoders);
+    function setNumActiveOrchestrators(uint256 _numActiveOrchestrators) external onlyControllerOwner {
+        orchestratorPoolV2.setMaxSize(_numActiveOrchestrators);
 
-        emit ParameterUpdate("numActiveTranscoders");
+        emit ParameterUpdate("numActiveOrchestrators");
     }
 
     /**
-     * STAKING & DELEGATION ACTIONS
+     * STAKING & DELEGATION
      */
 
     /**
-     * @notice Delegate stake towards a specific address
-     * @param _amount The amount of tokens to stake
-     * @param _orchestrator The address of the transcoder to stake towards
-     * @param _oldDelegateNewPosPrev The address of the previous transcoder in the pool for the old delegate
-     * @param _oldDelegateNewPosNext The address of the next transcoder in the pool for the old delegate
-     * @param _currDelegateNewPosPrev The address of the previous transcoder in the pool for the current delegate
-     * @param _currDelegateNewPosNext The address of the next transcoder in the pool for the current delegate
+     * @notice Stake an _amount of LPT for the caller and registers the account as an Orchestrator.
+     * @dev If the caller enters, or is already in the orchestrator pool, the caller can provide an optional hint for its insertion position in the
+     * pool via the `_newPosPrev` and `_newPosNext` params. A linear search will be executed starting at the hint to find the correct position.
+     * In the best case, the hint is the correct position so no search is executed. See SortedDoublyLL.sol details on list hints
+     * @param _amount Amount of tokens to stake
+     * @param _newPosPrev Address of previous orchestrator in pool if the caller enters or is in the pool
+     * @param _newPosNext Address of next orchestrator in pool if the caller enters or is in the pool
      */
-    function bond(
+    function stake(
+        uint256 _amount,
+        address _newPosPrev,
+        address _newPosNext
+    ) external {
+        _delegate(_amount, msg.sender, msg.sender, _newPosPrev, _newPosNext);
+        emit Stake(msg.sender, _amount);
+    }
+
+    /**
+     * @notice Stake an _amount of LPT on behalf of another account '_for'. It transfers custody of the staked LPT to '_for' and registers the account as an Orchestrator.
+     * @dev If the caller enters, or is already in the orchestrator pool, the caller can provide an optional hint for its insertion position in the
+     * pool via the `_newPosPrev` and `_newPosNext` params. A linear search will be executed starting at the hint to find the correct position.
+     * In the best case, the hint is the correct position so no search is executed. See SortedDoublyLL.sol details on list hints
+     * @param _amount Amount of tokens to stake
+     * @param _newPosPrev Address of previous orchestrator in pool if the enters or is in the pool
+     * @param _newPosNext Address of next orchestrator in pool if the caller enters or is in the pool
+     */
+    function stakeFor(
+        uint256 _amount,
+        address _for,
+        address _newPosPrev,
+        address _newPosNext
+    ) external {
+        _delegate(_amount, _for, _for, _newPosPrev, _newPosNext);
+        emit Stake(_for, _amount);
+    }
+
+    /**
+     * @notice Unstake an amount of LPT from the caller. If the caller fully unstakes it resigns its status as an Orchestrator.
+     * @dev If the caller remains in the orchestrator pool, the caller can provide an optional hint for its insertion position in the
+     * pool via the `_newPosPrev` and `_newPosNext` params. A linear search will be executed starting at the hint to find the correct position.
+     * In the best case, the hint is the correct position so no search is executed. See SortedDoublyLL.sol details on list hints
+     * @param _amount Amount of tokens to unstake
+     * @param _newPosPrev Address of previous orchestrator in pool if the caller remains in the pool
+     * @param _newPosNext Address of next orchestrator in pool if the caller remains in the pool
+     */
+    function unstake(
+        uint256 _amount,
+        address _newPosPrev,
+        address _newPosNext
+    ) external {
+        uint256 lockID = _undelegate(_amount, msg.sender, msg.sender, _newPosPrev, _newPosNext);
+        emit Unstake(msg.sender, _amount, lockID);
+    }
+
+    /**
+     * @notice Restake LPT that was previously unstaked, but is still pending withdrawal, for the caller using an unstaking lock.
+     * @dev If the caller is in the orchestrator pool, the caller can provide an optional hint for the delegate's insertion position in the
+     * pool via the `_newPosPrev` and `_newPosNext` params. A linear search will be executed starting at the hint to find the correct position.
+     * In the best case, the hint is the correct position so no search is executed. See SortedDoublyLL.sol details on list hints
+     * @param _unstakingLockID ID of unstaking lock to restake with
+     * @param _newPosPrev Address of previous orchestrator in pool if the caller enters or is in the pool
+     * @param _newPosNext Address of next orchestrator in pool if the caller enters or is in the pool
+     */
+    function restake(
+        uint256 _unstakingLockID,
+        address _newPosPrev,
+        address _newPosNext
+    ) external {
+        _redelegate(_unstakingLockID, msg.sender, _newPosPrev, _newPosNext);
+    }
+
+    /**
+     * @notice Delegate an _amount of LPT for the caller to an Orchestrator to earn a share of its rewards and fees.
+     * @dev If the Orchestrator being delegated to enters, or is already in the orchestrator pool, the caller can provide an optional hint for its insertion position in the
+     * pool via the `_newPosPrev` and `_newPosNext` params. A linear search will be executed starting at the hint to find the correct position.
+     * In the best case, the hint is the correct position so no search is executed. See SortedDoublyLL.sol details on list hints
+     * @param _amount Amount of tokens to delegate
+     * @param _newPosPrev Address of previous orchestrator in pool if the delegate enters, or is already in the pool
+     * @param _newPosNext Address of next orchestrator in pool if the delegate enters, or is already in the pool
+     */
+    function delegate(
         uint256 _amount,
         address _orchestrator,
-        address _oldDelegateNewPosPrev,
-        address _oldDelegateNewPosNext,
-        address _currDelegateNewPosPrev,
-        address _currDelegateNewPosNext
+        address _newPosPrev,
+        address _newPosNext
     ) external {
-        _bond(
-            _amount,
-            _orchestrator,
-            msg.sender,
-            _oldDelegateNewPosPrev,
-            _oldDelegateNewPosNext,
-            _currDelegateNewPosPrev,
-            _currDelegateNewPosNext
-        );
+        require(_orchestrator != msg.sender, "CANNOT_SELF_DELEGATE");
+        _delegate(_amount, _orchestrator, msg.sender, _newPosPrev, _newPosNext);
+        emit Delegate(msg.sender, _orchestrator, _amount);
     }
 
     /**
-     * @notice Delegate stake towards a specific address on behalf of another address
-     * @param _amount The amount of tokens to stake
-     * @param _orchestrator The address of the transcoder to stake towards
-     * @param _for The address which will own the stake
-     * @param _oldDelegateNewPosPrev The address of the previous transcoder in the pool for the old delegate
-     * @param _oldDelegateNewPosNext The address of the next transcoder in the pool for the old delegate
-     * @param _currDelegateNewPosPrev The address of the previous transcoder in the pool for the current delegate
-     * @param _currDelegateNewPosNext The address of the next transcoder in the pool for the current delegate
+     * @notice Delegate an _amount of LPT  for another account '_for' to an Orchestrator. This transfers the custody of the staked LPT to '_for' and makes the account eligible to earn a share of the Orchestrator's rewards and fees.
+     * @dev If the Orchestrator being delegated to enters, or is already in the orchestrator pool, the caller can provide an optional hint for its insertion position in the
+     * pool via the `_newPosPrev` and `_newPosNext` params. A linear search will be executed starting at the hint to find the correct position.
+     * In the best case, the hint is the correct position so no search is executed. See SortedDoublyLL.sol details on list hints
+     * @param _amount Amount of tokens to delegate
+     * @param _newPosPrev Address of previous orchestrator in pool if the delegate enters, or is already  in the pool
+     * @param _newPosNext Address of next orchestrator in pool if the delegate enters, or is already in the pool
      */
-    function bondFor(
+    function delegateFor(
         uint256 _amount,
         address _orchestrator,
         address _for,
-        address _oldDelegateNewPosPrev,
-        address _oldDelegateNewPosNext,
-        address _currDelegateNewPosPrev,
-        address _currDelegateNewPosNext
+        address _newPosPrev,
+        address _newPosNext
     ) external {
-        _bond(
-            _amount,
-            _orchestrator,
-            _for,
-            _oldDelegateNewPosPrev,
-            _oldDelegateNewPosNext,
-            _currDelegateNewPosPrev,
-            _currDelegateNewPosNext
-        );
+        require(_orchestrator != _for, "CANNOT_SELF_DELEGATE");
+        _delegate(_amount, _orchestrator, _for, _newPosPrev, _newPosNext);
+        emit Delegate(_for, _orchestrator, _amount);
     }
 
     /**
-     * @notice Delegate stake towards a specific address and updates the transcoder pool using optional list hints if needed
-     * @dev If the caller is decreasing the stake of its old delegate in the transcoder pool, the caller can provide an optional hint
-     * for the insertion position of the old delegate via the `_oldDelegateNewPosPrev` and `_oldDelegateNewPosNext` params.
-     * If the caller is delegating to a delegate that is in the transcoder pool, the caller can provide an optional hint for the
-     * insertion position of the delegate via the `_currDelegateNewPosPrev` and `_currDelegateNewPosNext` params.
-     * In both cases, a linear search will be executed starting at the hint to find the correct position. In the best case, the hint
-     * is the correct position so no search is executed. See SortedDoublyLL.sol for details on list hints
-     * @param _amount The amount of tokens to stake.
-     * @param _orchestrator The address of the transcoder to stake towards
-     * @param _for The address which will own the stake
-     * @param _oldDelegateNewPosPrev The address of the previous transcoder in the pool for the old delegate
-     * @param _oldDelegateNewPosNext The address of the next transcoder in the pool for the old delegate
-     * @param _currDelegateNewPosPrev The address of the previous transcoder in the pool for the current delegate
-     * @param _currDelegateNewPosNext The address of the next transcoder in the pool for the current delegate
+     * @notice Partially or completely change a delegation from one Orchestrator to another. Only delegations whereby the existing orchestrator is not the caller can be changed.
+     * @dev If the Orchestrator being delegated to enters, or is already in the orchestrator pool, the caller can provide an optional hint for its insertion position in the
+     * pool via the `_newPosPrev` and `_newPosNext` params. A linear search will be executed starting at the hint to find the correct position.
+     * In the best case, the hint is the correct position so no search is executed. See SortedDoublyLL.sol details on list hints
+     * @param _amount Amount of tokens to change for the delegation
+     * @param _oldOrchestrator Address of the Orchestrator to delegate LPT away from
+     * @param _newOrchestrator Address of the Orchestrator to delegate LPT to
+     * @param _oldOrchestratorNewPosPrev Address of the previous orchestrator in pool for '_oldOrchestrator' if it remains in the pool
+     * @param _oldOrchestratorNewPosNext Address of the next orchestrator in pool for '_oldOrchestrator' if it remains in the pool
+     * @param _newOrchestratorNewPosPrev Address of the previous orchestrator in the pool for '_newOrchestrator' if it enters or is in the pool
+     * @param _newOrchestratorNewPosNext Address of the next orchestrator in the pool for '_newOrchestrator' if it enters or is in the pool
      */
-    function _bond(
+    function changeDelegation(
         uint256 _amount,
-        address _orchestrator,
-        address _for,
-        address _oldDelegateNewPosPrev,
-        address _oldDelegateNewPosNext,
-        address _currDelegateNewPosPrev,
-        address _currDelegateNewPosNext
-    ) internal whenSystemNotPaused currentRoundInitialized autoClaimFees(_orchestrator) {
-        if (_orchestrator != _for) {
-            require(!isRegisteredOrchestrator(_for), "ORCHESTRATOR_CAN_NOT_DELEGATE");
+        address _oldOrchestrator,
+        address _newOrchestrator,
+        address _oldOrchestratorNewPosPrev,
+        address _oldOrchestratorNewPosNext,
+        address _newOrchestratorNewPosPrev,
+        address _newOrchestratorNewPosNext
+    ) external {
+        // If _oldOrchestrator == msg.sender , revert
+        require(msg.sender != _oldOrchestrator, "CANNOT_CHANGE_DELEGATION_FOR_SELF");
+        // cannot change zero amount
+        require(_amount > 0, "ZERO_CHANGE_DELEGATION_AMOUNT");
+
+        // 1. Subtract stake for oldOrchestrator
+        Delegations.Pool storage oldPool = orchestrators[_oldOrchestrator].delegationPool;
+
+        if (orchestratorPoolV2.contains(_oldOrchestrator)) {
+            uint256 oldOrchestratorStake = oldPool.poolTotalStake();
+            _decreaseOrchTotalStake(
+                _oldOrchestrator,
+                oldOrchestratorStake,
+                _amount,
+                _oldOrchestratorNewPosPrev,
+                _oldOrchestratorNewPosNext
+            );
         }
 
-        // cannot delegate zero amount
-        require(_amount > 0, "ZERO_DELEGATION_AMOUNT");
+        oldPool.unstake(msg.sender, _amount);
 
-        // Bond total to stake to new orchestrator
-        Delegations.Pool storage newPool = orchestrators[_orchestrator].delegationPool;
-        uint256 oldTotalStake = newPool.poolTotalStake();
-        newPool.stake(_for, _amount);
+        emit Undelegate(msg.sender, _oldOrchestrator, _amount, 0);
+
+        // cfr. undelegate
+        // 2. Add stake to new orchestrator
+        Delegations.Pool storage newPool = orchestrators[_newOrchestrator].delegationPool;
+        newPool.stake(msg.sender, _amount);
+        uint256 newOrchestratorStake = newPool.poolTotalStake();
 
         _increaseOrchTotalStake(
-            _orchestrator,
-            oldTotalStake,
+            _newOrchestrator,
+            newOrchestratorStake,
             _amount,
-            _currDelegateNewPosPrev,
-            _currDelegateNewPosNext
+            _newOrchestratorNewPosPrev,
+            _newOrchestratorNewPosNext
         );
 
-        // Transfer the LPT to the Minter
-        livepeerToken().transferFrom(_for, address(minter()), _amount);
-
-        emit Bond(_orchestrator, _for, _amount, newPool.stakeOf(_for));
+        emit Delegate(msg.sender, _newOrchestrator, _amount);
     }
 
     /**
-     * @notice Unbond an amount of the delegator's bonded stake
-     * @param _amount Amount of tokens to unbond
-     */
-    function unbond(uint256 _amount) external {
-        unbondWithHint(msg.sender, _amount, address(0), address(0));
-    }
-
-    /**
-     * @notice Unbond an amount of the delegator's bonded stake and updates the transcoder pool using an optional list hint if needed
-     * @dev If the caller remains in the transcoder pool, the caller can provide an optional hint for its insertion position in the
+     * @notice Undelegate an amount of LPT for the caller from the provided '_orchestrator'.
+     * @dev If the Orchestrator being undelegated from remains in the orchestrator pool, the caller can provide an optional hint for its insertion position in the
      * pool via the `_newPosPrev` and `_newPosNext` params. A linear search will be executed starting at the hint to find the correct position.
      * In the best case, the hint is the correct position so no search is executed. See SortedDoublyLL.sol details on list hints
-     * @param _amount Amount of tokens to unbond
-     * @param _newPosPrev Address of previous transcoder in pool if the caller remains in the pool
-     * @param _newPosNext Address of next transcoder in pool if the caller remains in the pool
+     * @param _amount Amount of tokens to undelegate
+     * @param _newPosPrev Address of previous orchestrator in pool if '_orchestrator' remains in the pool
+     * @param _newPosNext Address of next orchestrator in pool if '_orchestrator' remains in the pool
      */
-    function unbondWithHint(
-        address _delegate,
+    function undelegate(
         uint256 _amount,
+        address _orchestrator,
         address _newPosPrev,
         address _newPosNext
-    ) public whenSystemNotPaused currentRoundInitialized autoClaimFees(_delegate) {
-        require(_amount > 0, "ZERO_UNBOND_AMOUNT");
-
-        uint256 delegatorStake = stakeOf(_delegate, msg.sender);
-        require(delegatorStake > 0, "CALLER_NOT_BONDED");
-        require(_amount <= delegatorStake, "AMOUNT_EXCEEDS_STAKE");
-
-        uint256 amount = _amount;
-
-        // If the delegator is an orchestrator, draw from commission first
-        if (msg.sender == _delegate) {
-            Orchestrator storage orch = orchestrators[_delegate];
-            uint256 rewardCommissions = orch.rewardCommissions;
-            uint256 fromCommission = MathUtils.min(rewardCommissions, amount);
-            amount -= fromCommission;
-
-            if (orchestratorPoolV2.contains(msg.sender)) {
-                if (_amount == delegatorStake) {
-                    _resignOrchestrator(msg.sender);
-                } else {
-                    _decreaseOrchTotalStake(msg.sender, delegatorStake, _amount, _newPosPrev, _newPosNext);
-                }
-            }
-
-            orch.rewardCommissions -= fromCommission;
-        }
-
-        if (amount > 0) {
-            Delegations.Pool storage pool = orchestrators[_delegate].delegationPool;
-            pool.unstake(msg.sender, amount);
-        }
-
-        // Create unbonding lock for _amount
-        uint256 id = lastUnbondingLockID;
-        lastUnbondingLockID++;
-
-        uint256 currentRound = roundsManager().currentRound();
-
-        unbondingLocks[id] = UnbondingLock({ orchestrator: _delegate, amount: _amount, withdrawRound: currentRound });
-
-        emit Unbond(_delegate, msg.sender, id, _amount, currentRound);
+    ) external {
+        uint256 lockID = _undelegate(_amount, _orchestrator, msg.sender, _newPosPrev, _newPosNext);
+        emit Undelegate(msg.sender, _orchestrator, _amount, lockID);
     }
 
     /**
-     * @notice Rebond tokens for an unbonding lock to a delegator's current 
-        delegate while a delegator is in the Bonded or Pending status
-     * @param _unbondingLockId ID of unbonding lock to rebond with
-     */
-    function rebond(uint256 _unbondingLockId) external {
-        rebondWithHint(_unbondingLockId, address(0), address(0));
-    }
-
-    /**
-     * @notice Rebond tokens for an unbonding lock to a delegator's current delegate while a delegator is in the Bonded or Pending status and updates
-     * the transcoder pool using an optional list hint if needed
-     * @dev If the delegate is in the transcoder pool, the caller can provide an optional hint for the delegate's insertion position in the
+     * @notice Redelegate LPT that was previously undelegated, but is still pending withdrawal, for the caller using an unstaking lock.
+     * @dev If the orchestrator being redelegated to is in the orchestrator pool, the caller can provide an optional hint for the delegate's insertion position in the
      * pool via the `_newPosPrev` and `_newPosNext` params. A linear search will be executed starting at the hint to find the correct position.
      * In the best case, the hint is the correct position so no search is executed. See SortedDoublyLL.sol details on list hints
-     * @param _unbondingLockId ID of unbonding lock to rebond with
-     * @param _newPosPrev Address of previous transcoder in pool if the delegate is in the pool
-     * @param _newPosNext Address of next transcoder in pool if the delegate is in the pool
+     * @param _unstakingLockID ID of unstaking lock to redelegate with
+     * @param _newPosPrev Address of previous orchestrator in pool if the orchestrator being redelegated to enters or is in the pool
+     * @param _newPosNext Address of next orchestrator in pool if the orchestrator being redelegated to enters or is in the pool
      */
-    function rebondWithHint(
-        uint256 _unbondingLockId,
+    function redelegate(
+        uint256 _unstakingLockID,
         address _newPosPrev,
         address _newPosNext
-    ) public whenSystemNotPaused currentRoundInitialized {
-        // Process rebond using unbonding lock
-        _processRebond(msg.sender, _unbondingLockId, _newPosPrev, _newPosNext);
+    ) external {
+        _redelegate(_unstakingLockID, msg.sender, _newPosPrev, _newPosNext);
     }
 
     /**
-     * @notice Rebond tokens for an unbonding lock to a delegate while a delegator is in the Unbonded status
-     * @param _to Address of delegate
-     * @param _unbondingLockId ID of unbonding lock to rebond with
+     * @notice Withdraws tokens for an unstaking lock that has existed through an undelegation period
+     * @param _unstakingLockId ID of unstaking lock to withdraw with
      */
-    function rebondFromUnbonded(address _to, uint256 _unbondingLockId) external {
-        rebondFromUnbondedWithHint(_to, _unbondingLockId, address(0), address(0));
-    }
+    function withdrawStake(uint256 _unstakingLockId) external whenSystemNotPaused currentRoundInitialized {
+        UnstakingLock storage lock = unstakingLocks[_unstakingLockId];
 
-    /**
-     * @notice Rebond tokens for an unbonding lock to a delegate while a delegator is in the Unbonded status and updates the transcoder pool using
-     * an optional list hint if needed
-     * @dev If the delegate joins the transcoder pool, the caller can provide an optional hint for the delegate's insertion position in the
-     * pool via the `_newPosPrev` and `_newPosNext` params. A linear search will be executed starting at the hint to find the correct position.
-     * In the best case, the hint is the correct position so no search is executed. See SortedDoublyLL.sol for details on list hints
-     * @param _delegate Address of delegate
-     * @param _unbondingLockId ID of unbonding lock to rebond with
-     * @param _newPosPrev Address of previous transcoder in pool if the delegate joins the pool
-     * @param _newPosNext Address of next transcoder in pool if the delegate joins the pool
-     */
-    function rebondFromUnbondedWithHint(
-        address _delegate,
-        uint256 _unbondingLockId,
-        address _newPosPrev,
-        address _newPosNext
-    ) public whenSystemNotPaused currentRoundInitialized {
-        require(stakeOf(_delegate, msg.sender) == 0, "CALLER_NOT_UNBONDED");
-
-        unbondingLocks[_unbondingLockId].orchestrator = _delegate;
-        // Process rebond using unbonding lock
-        _processRebond(msg.sender, _unbondingLockId, _newPosPrev, _newPosNext);
-    }
-
-    /**
-     * @notice Withdraws tokens for an unbonding lock that has existed through an unbonding period
-     * @param _unbondingLockId ID of unbonding lock to withdraw with
-     */
-    function withdrawStake(uint256 _unbondingLockId) external whenSystemNotPaused currentRoundInitialized {
-        UnbondingLock storage lock = unbondingLocks[_unbondingLockId];
-
-        require(isValidUnbondingLock(_unbondingLockId), "invalid unbonding lock ID");
+        require(isValidUnstakingLock(_unstakingLockId), "INVALID_UNSTAKING_LOCK_ID");
         require(
             lock.withdrawRound <= roundsManager().currentRound(),
             "withdraw round must be before or equal to the current round"
         );
+        require(msg.sender == lock.owner, "CALLER_NOT_LOCK_OWNER");
 
         uint256 amount = lock.amount;
         uint256 withdrawRound = lock.withdrawRound;
-        // Delete unbonding lock
-        delete unbondingLocks[_unbondingLockId];
+        // Delete unstaking lock
+        delete unstakingLocks[_unstakingLockId];
 
         // Tell Minter to transfer stake (LPT) to the delegator
         minter().trustedTransferTokens(msg.sender, amount);
-
-        emit WithdrawStake(msg.sender, _unbondingLockId, amount, withdrawRound);
+        emit WithdrawStake(msg.sender, _unstakingLockId, amount, withdrawRound);
     }
 
     /**
      * @notice Withdraw fees for an address
-     * @param _delegate Address of the delegate to claim fees from
+     * @param _orchestrator Address of the orchestrator to claim fees from
      * @dev Calculates amount of fees to claim using `feesOf`
      * @dev Updates Delegation.feeCheckpoint for the address to the current total amount of fees in the delegation pool
      * @dev If the claimer is an orchestator, reset its commission
      * @dev Transfers funds
      */
-    function withdrawFees(address _delegate) external whenSystemNotPaused currentRoundInitialized {
-        _claimFees(_delegate, payable(msg.sender));
+    function withdrawFees(address _orchestrator) external whenSystemNotPaused currentRoundInitialized {
+        _claimFees(_orchestrator, payable(msg.sender));
     }
 
     /**
@@ -407,32 +377,22 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
      */
 
     /**
-     * @notice Sets commission rates as a transcoder and if the caller is not in the transcoder pool tries to add it
+     * @notice Sets commission rates as a orchestrator and if the caller is not in the orchestrator pool tries to add it
      * @dev Percentages are represented as numerators of fractions over MathUtils.PERC_DIVISOR
+     * @dev caller can provide an optional hint for the insertion position in the pool via the `_newPosPrev` and `_newPosNext` params. A linear search will
+        be executed starting at the hint to find the correct position - in the best case, the hint is the correct position so no search is executed.
+        See SortedDoublyLL.sol for details on list hints
      * @param _rewardShare % of rewards paid to delegators by an orchestrator
-     * @param _feeShare % of fees paid to delegators by a transcoder
+     * @param _feeShare % of fees paid to delegators by a orchestrator
+     * @param _newPosPrev Address of previous orchestrator in pool if the caller joins the pool
+     * @param _newPosNext Address of next orchestrator in pool if the caller joins the pool
      */
-    function transcoder(uint256 _rewardShare, uint256 _feeShare) external {
-        transcoderWithHint(_rewardShare, _feeShare, address(0), address(0));
-    }
-
-    /**
-     * @notice Sets commission rates as a transcoder and if the caller is not in the transcoder pool tries to add it using an optional list hint
-     * @dev Percentages are represented as numerators of fractions over MathUtils.PERC_DIVISOR. If the caller is going to be added to the pool, the
-     * caller can provide an optional hint for the insertion position in the pool via the `_newPosPrev` and `_newPosNext` params. A linear search will
-     * be executed starting at the hint to find the correct position - in the best case, the hint is the correct position so no search is executed.
-     * See SortedDoublyLL.sol for details on list hints
-     * @param _rewardShare % of reward paid to delegators by an orchestrator
-     * @param _feeShare % of fees paid to delegators by a transcoder
-     * @param _newPosPrev Address of previous transcoder in pool if the caller joins the pool
-     * @param _newPosNext Address of next transcoder in pool if the caller joins the pool
-     */
-    function transcoderWithHint(
+    function orchestrator(
         uint256 _rewardShare,
         uint256 _feeShare,
         address _newPosPrev,
         address _newPosNext
-    ) public whenSystemNotPaused currentRoundInitialized {
+    ) external whenSystemNotPaused currentRoundInitialized {
         require(!roundsManager().currentRoundLocked(), "CURRENT_ROUND_LOCKED");
         require(MathUtils.validPerc(_rewardShare), "REWARDSHARE_INVALID_PERC");
         require(MathUtils.validPerc(_feeShare), "FEESHARE_INVALID_PERC");
@@ -441,7 +401,8 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
         Orchestrator storage o = orchestrators[msg.sender];
         uint256 currentRound = roundsManager().currentRound();
 
-        require(!isActiveTranscoder(msg.sender) || o.lastRewardRound == currentRound, "COMMISSION_RATES_LOCKED");
+        // caller can't be active or must have already called reward for the current round
+        require(!isActiveOrchestrator(msg.sender) || o.lastRewardRound == currentRound, "COMMISSION_RATES_LOCKED");
 
         o.rewardShare = _rewardShare;
         o.feeShare = _feeShare;
@@ -456,46 +417,35 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
             );
         }
 
-        emit TranscoderUpdate(msg.sender, _rewardShare, _feeShare);
+        emit OrchestratorUpdate(msg.sender, _rewardShare, _feeShare);
     }
 
     /**
-     * @notice Mint token rewards for an active transcoder and its delegators
-     */
-    function reward() external {
-        rewardWithHint(address(0), address(0));
-    }
-
-    /**
-     * @notice Mint token rewards for an active transcoder and its delegators and update the transcoder pool using an optional list hint if needed
-     * @dev If the caller is in the transcoder pool, the caller can provide an optional hint for its insertion position in the
+     * @notice Mint token rewards for an active orchestrator and its delegators and update the orchestrator pool using an optional list hint if needed
+     * @dev If the caller is in the orchestrator pool, the caller can provide an optional hint for its insertion position in the
      * pool via the `_newPosPrev` and `_newPosNext` params. A linear search will be executed starting at the hint to find the correct position.
      * In the best case, the hint is the correct position so no search is executed. See SortedDoublyLL.sol for details on list hints
-     * @param _newPosPrev Address of previous transcoder in pool if the caller is in the pool
-     * @param _newPosNext Address of next transcoder in pool if the caller is in the pool
+     * @param _newPosPrev Address of previous orchestrator in pool if the caller is in the pool
+     * @param _newPosNext Address of next orchestrator in pool if the caller is in the pool
      */
-    function rewardWithHint(address _newPosPrev, address _newPosNext)
-        public
-        whenSystemNotPaused
-        currentRoundInitialized
-    {
+    function reward(address _newPosPrev, address _newPosNext) public whenSystemNotPaused currentRoundInitialized {
         uint256 currentRound = roundsManager().currentRound();
 
-        require(isActiveTranscoder(msg.sender), "caller must be an active transcoder");
+        require(isActiveOrchestrator(msg.sender), "ORCHESTRATOR_NOT_ACTIVE");
 
         Orchestrator storage o = orchestrators[msg.sender];
 
-        require(o.lastRewardRound != currentRound, "caller has already called reward for the current round");
+        require(o.lastRewardRound != currentRound, "ALREADY_CALLED_REWARD_FOR_CURRENT_ROUND");
 
-        // Create reward based on active transcoder's stake relative to the total active stake
-        // rewardTokens = (current mintable tokens for the round * active transcoder stake) / total active stake
+        // Create reward based on active orchestrator's stake relative to the total active stake
+        // rewardTokens = (current mintable tokens for the round * active orchestrator stake) / total active stake
         uint256 totalStake = o.delegationPool.poolTotalStake();
         uint256 rewardTokens = minter().createReward(totalStake, currentRoundTotalActiveStake);
 
         _updateOrchestratorWithRewards(msg.sender, rewardTokens);
         _increaseOrchTotalStake(msg.sender, totalStake, rewardTokens, _newPosPrev, _newPosNext);
 
-        // Set last round that transcoder called reward
+        // Set last round that orchestrator called reward
         o.lastRewardRound = currentRound;
 
         emit Reward(msg.sender, rewardTokens);
@@ -516,11 +466,12 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
      * @dev Reverts if system is paused
      * @dev Reverts if caller is not TicketBroker
      */
-    function updateTranscoderWithFees(
-        address _orchestrator,
-        uint256 _fees,
-        uint256 /*_round*/
-    ) external override whenSystemNotPaused onlyTicketBroker {
+    function updateOrchestratorWithFees(address _orchestrator, uint256 _fees)
+        external
+        override
+        whenSystemNotPaused
+        onlyTicketBroker
+    {
         _updateOrchestratorWithFees(_orchestrator, _fees);
     }
 
@@ -537,17 +488,21 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
      */
 
     /**
-     * @notice Return whether an unbonding lock for a delegator is valid
-     * @param _unbondingLockId ID of unbonding lock
-     * @return true if unbondingLock for ID has a non-zero withdraw round
+     * @notice Return whether an unstaking lock for a delegator is valid
+     * @param _unstakingLockId ID of unstaking lock
+     * @return true if unstakingLock for ID has a non-zero withdraw round
      */
-    function isValidUnbondingLock(uint256 _unbondingLockId) public view returns (bool) {
-        // A unbonding lock is only valid if it has a non-zero withdraw round (the default value is zero)
-        return unbondingLocks[_unbondingLockId].withdrawRound > 0;
+    function isValidUnstakingLock(uint256 _unstakingLockId) public view returns (bool) {
+        // A unstaking lock is only valid if it has a non-zero withdraw round (the default value is zero)
+        return unstakingLocks[_unstakingLockId].withdrawRound > 0;
     }
 
-    function getDelegation(address _delegate, address _delegator) public view returns (uint256 stake, uint256 fees) {
-        (stake, fees) = orchestrators[_delegate].delegationPool.stakeAndFeesOf(_delegator);
+    function getDelegation(address _orchestrator, address _delegator)
+        public
+        view
+        returns (uint256 stake, uint256 fees)
+    {
+        (stake, fees) = orchestrators[_orchestrator].delegationPool.stakeAndFeesOf(_delegator);
     }
 
     /**
@@ -558,12 +513,9 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
         so for multi-delegation we can do calculations off chain
         and repurpose this to 'orchestratorStake(address _orchestrator)'
      */
-    function stakeOf(address _delegate, address _delegator) public view returns (uint256 stake) {
-        Orchestrator storage orch = orchestrators[_delegate];
-        stake = orch.delegationPool.stakeOf(_delegator);
-        if (_delegate == _delegator) {
-            stake += orch.rewardCommissions;
-        }
+    function getDelegatedStake(address _orchestrator, address _delegator) public view returns (uint256 delegatedStake) {
+        Orchestrator storage orch = orchestrators[_orchestrator];
+        delegatedStake = orch.delegationPool.stakeOf(_delegator);
     }
 
     /**
@@ -576,93 +528,236 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
         so for multi-delegation we can do calculations off chain
         and repurpose this to 'orchestratorFees(address _orchestrator)'
      */
-    function feesOf(address _delegate, address _delegator) public view returns (uint256 fees) {
-        Orchestrator storage orch = orchestrators[_delegate];
+    function feesOf(address _orchestrator, address _delegator) public view returns (uint256 fees) {
+        Orchestrator storage orch = orchestrators[_orchestrator];
         fees = orch.delegationPool.feesOf(_delegator);
-        if (_delegate == _delegator) {
+        if (_orchestrator == _delegator) {
             fees += orch.feeCommissions;
         }
     }
 
     /**
-     * @notice Returns total bonded stake for a transcoder
-     * @param _orchestrator Address of transcoder
-     * @return total bonded stake for a delegator
+     * @notice Returns total stake for a orchestrator
+     * @param _orchestrator Address of orchestrator
+     * @return total stake for an orchestrator
      */
     function orchestratorTotalStake(address _orchestrator) public view returns (uint256) {
         return orchestrators[_orchestrator].delegationPool.poolTotalStake();
     }
 
     /**
-     * @notice Return whether a transcoder is registered
-     * @param _orchestrator Transcoder address
-     * @return true if transcoder is self-bonded
+     * @notice Return whether a orchestrator is registered
+     * @param _orchestrator orchestrator address
+     * @return true if orchestrator is self-delegated
      */
     function isRegisteredOrchestrator(address _orchestrator) public view returns (bool) {
         return orchestrators[_orchestrator].delegationPool.stakeOf(_orchestrator) > 0;
     }
 
     /**
-     * @notice Return whether a transcoder is active for the current round
-     * @param _orchestrator Transcoder address
-     * @return true if transcoder is active
+     * @notice Return whether a orchestrator is active for the current round
+     * @param _orchestrator orchestrator address
+     * @return true if orchestrator is active
      */
-    function isActiveTranscoder(address _orchestrator) public view override returns (bool) {
+    function isActiveOrchestrator(address _orchestrator) public view override returns (bool) {
         Orchestrator storage o = orchestrators[_orchestrator];
         uint256 currentRound = roundsManager().currentRound();
         return o.activationRound <= currentRound && currentRound < o.deactivationRound;
     }
 
     /**
-     * @notice Computes transcoder status
-     * @param _orchestrator Address of transcoder
-     * @return active, registered or not registered transcoder status
+     * @notice Computes orchestrator status
+     * @param _orchestrator Address of orchestrator
+     * @return active, registered or not registered orchestrator status
      */
     function orchestratorStatus(address _orchestrator) public view returns (OrchestratorStatus) {
-        if (isActiveTranscoder(_orchestrator)) return OrchestratorStatus.Active;
+        if (isActiveOrchestrator(_orchestrator)) return OrchestratorStatus.Active;
         if (isRegisteredOrchestrator(_orchestrator)) return OrchestratorStatus.Registered;
         return OrchestratorStatus.NotRegistered;
     }
 
     /**
-     * @notice Returns max size of transcoder pool
-     * @return transcoder pool max size
+     * @notice Return orchestrator information
+     * @param _orchestrator Address of orchestrator
+     * @return lastRewardRound Orchestrator's last reward round
+     * @return rewardShare Orchestrator's reward share
+     * @return feeShare Orchestrator's fee share
+     * @return activationRound Round in which orchestrator became active
+     * @return deactivationRound Round in which orchestrator will no longer be active
      */
-    function getTranscoderPoolMaxSize() public view returns (uint256) {
+    function getOrchestrator(address _orchestrator)
+        public
+        view
+        returns (
+            uint256 lastRewardRound,
+            uint256 rewardShare,
+            uint256 feeShare,
+            uint256 activationRound,
+            uint256 deactivationRound
+        )
+    {
+        Orchestrator storage o = orchestrators[_orchestrator];
+
+        lastRewardRound = o.lastRewardRound;
+        rewardShare = o.rewardShare;
+        feeShare = o.feeShare;
+        activationRound = o.activationRound;
+        deactivationRound = o.deactivationRound;
+        lastRewardRound = o.lastRewardRound;
+    }
+
+    /**
+     * @notice Returns max size of orchestrator pool
+     * @return orchestrator pool max size
+     */
+    function getOrchestratorPoolMaxSize() public view returns (uint256) {
         return orchestratorPoolV2.getMaxSize();
     }
 
     /**
-     * @notice Returns size of transcoder pool
-     * @return transcoder pool current size
+     * @notice Returns size of orchestrator pool
+     * @return orchestrator pool current size
      */
-    function getTranscoderPoolSize() public view override returns (uint256) {
+    function getOrchestratorPoolSize() public view override returns (uint256) {
         return orchestratorPoolV2.getSize();
     }
 
     /**
-     * @notice Returns transcoder with most stake in pool
-     * @return address for transcoder with highest stake in transcoder pool
+     * @notice Returns orchestrator with most stake in pool
+     * @return address for orchestrator with highest stake in orchestrator pool
      */
-    function getFirstTranscoderInPool() public view returns (address) {
+    function getFirstOrchestratorInPool() public view returns (address) {
         return orchestratorPoolV2.getFirst();
     }
 
     /**
-     * @notice Returns next transcoder in pool for a given transcoder
-     * @param _orchestrator Address of a transcoder in the pool
-     * @return address for the transcoder after '_transcoder' in transcoder pool
+     * @notice Returns next orchestrator in pool for a given orchestrator
+     * @param _orchestrator Address of a orchestrator in the pool
+     * @return address for the orchestrator after '_orchestrator' in orchestrator pool
      */
-    function getNextTranscoderInPool(address _orchestrator) public view returns (address) {
+    function getNextOrchestratorInPool(address _orchestrator) public view returns (address) {
         return orchestratorPoolV2.getNext(_orchestrator);
     }
 
     /**
-     * @notice Return total bonded tokens
+     * @notice Return total staked tokens
      * @return total active stake for the current round
      */
-    function getTotalBonded() public view override returns (uint256) {
+    function getTotalStaked() public view override returns (uint256) {
         return currentRoundTotalActiveStake;
+    }
+
+    /**
+     * @notice Delegate stake towards a specific address and updates the orchestrator pool using optional list hints if needed
+     * @dev If the caller is decreasing the stake of its old delegate in the orchestrator pool, the caller can provide an optional hint
+     * for the insertion position of the old delegate via the `_oldDelegateNewPosPrev` and `_oldDelegateNewPosNext` params.
+     * If the caller is delegating to a delegate that is in the orchestrator pool, the caller can provide an optional hint for the
+     * insertion position of the delegate via the `_newPosPrev` and `_newPosNext` params.
+     * In both cases, a linear search will be executed starting at the hint to find the correct position. In the best case, the hint
+     * is the correct position so no search is executed. See SortedDoublyLL.sol for details on list hints
+     * @param _amount The amount of tokens to stake.
+     * @param _orchestrator The address of the orchestrator to stake towards
+     * @param _for The address which will own the stake
+     * @param _newPosPrev The address of the previous orchestrator in the pool for the current delegate
+     * @param _newPosNext The address of the next orchestrator in the pool for the current delegate
+     */
+    function _delegate(
+        uint256 _amount,
+        address _orchestrator,
+        address _for,
+        address _newPosPrev,
+        address _newPosNext
+    ) internal whenSystemNotPaused currentRoundInitialized autoClaimFees(_orchestrator, _for) {
+        // cannot delegate zero amount
+        require(_amount > 0, "ZERO_DELEGATION_AMOUNT");
+
+        // Delegate stake to _orchestrator for account "_for"
+        Delegations.Pool storage _pool = orchestrators[_orchestrator].delegationPool;
+        uint256 oldTotalStake = _pool.poolTotalStake();
+        _pool.stake(_for, _amount);
+
+        _increaseOrchTotalStake(_orchestrator, oldTotalStake, _amount, _newPosPrev, _newPosNext);
+
+        // Transfer the LPT to the Minter
+        livepeerToken().transferFrom(_for, address(minter()), _amount);
+    }
+
+    function _undelegate(
+        uint256 _amount,
+        address _orchestrator,
+        address _for,
+        address _newPosPrev,
+        address _newPosNext
+    ) internal whenSystemNotPaused currentRoundInitialized autoClaimFees(_orchestrator, _for) returns (uint256 id) {
+        require(_amount > 0, "ZERO_UNSTAKE_AMOUNT");
+
+        uint256 orchStake = orchestratorTotalStake(_orchestrator);
+        uint256 delegatorStake = getDelegatedStake(_orchestrator, _for);
+
+        require(delegatorStake > 0, "CALLER_NOT_STAKED");
+        require(_amount <= delegatorStake, "AMOUNT_EXCEEDS_STAKE");
+
+        // If the orchestrator is in the orchestrator pool, update the pool
+        if (orchestratorPoolV2.contains(_orchestrator)) {
+            // If the caller is the orchestrator itself and the amount to undelegate
+            // equals the self-staked amount, resign the orchestrator
+            if (_orchestrator == _for && _amount == delegatorStake) {
+                _resignOrchestrator(_orchestrator);
+            } else {
+                // Otherwise decrease the orchestrator's stake and update its position in the orchestrator pool
+                _decreaseOrchTotalStake(_orchestrator, orchStake, _amount, _newPosPrev, _newPosNext);
+            }
+        }
+
+        Delegations.Pool storage pool = orchestrators[_orchestrator].delegationPool;
+        pool.unstake(_for, _amount);
+
+        // Create unstaking lock for _amount
+        id = lastUnstakingLockID;
+        lastUnstakingLockID++;
+
+        uint256 currentRound = roundsManager().currentRound();
+
+        unstakingLocks[id] = UnstakingLock({
+            owner: _for,
+            orchestrator: _orchestrator,
+            amount: _amount,
+            withdrawRound: currentRound + unstakingPeriod
+        });
+    }
+
+    function _redelegate(
+        uint256 _unstakingLockID,
+        address _for,
+        address _newPosPrev,
+        address _newPosNext
+    ) internal whenSystemNotPaused currentRoundInitialized {
+        UnstakingLock storage lock = unstakingLocks[_unstakingLockID];
+
+        require(isValidUnstakingLock(_unstakingLockID), "INVALID_UNSTAKING_LOCK_ID");
+        require(msg.sender == lock.owner, "CALLER_NOT_LOCK_OWNER");
+
+        address orchestrator = lock.orchestrator;
+        uint256 amount = lock.amount;
+
+        // Claim outstanding fees and checkpoint fee factor
+        _claimFees(orchestrator, payable(_for));
+
+        uint256 oldStake = orchestratorTotalStake(orchestrator);
+
+        // Increase delegator's staked amount
+        orchestrators[orchestrator].delegationPool.stake(_for, amount);
+
+        // Delete lock
+        delete unstakingLocks[_unstakingLockID];
+
+        _increaseOrchTotalStake(orchestrator, oldStake, amount, _newPosPrev, _newPosNext);
+
+        if (_for == orchestrator) {
+            emit Stake(orchestrator, amount);
+        } else {
+            emit Delegate(_for, orchestrator, amount);
+        }
     }
 
     function _updateOrchestratorWithFees(address _orchestrator, uint256 _fees) internal {
@@ -687,7 +782,8 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
 
         uint256 rewardShare = MathUtils.percOf(_rewards, orch.rewardShare);
 
-        orch.rewardCommissions = _rewards - rewardShare;
+        uint256 rewardCut = _rewards - rewardShare;
+        orch.delegationPool.stake(_orchestrator, rewardCut);
         orch.delegationPool.addRewards(rewardShare);
     }
 
@@ -724,25 +820,25 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
     }
 
     /**
-     * @dev Remove a transcoder from the pool and deactivate it
+     * @dev Remove a orchestrator from the pool and deactivate it
      */
     function _resignOrchestrator(address _orchestrator) internal {
-        // Not zeroing 'Transcoder.lastActiveStakeUpdateRound' saves gas (5k when transcoder is evicted and 20k when transcoder is reinserted)
+        // Not zeroing 'Orchestrator.lastActiveStakeUpdateRound' saves gas (5k when orchestrator is evicted and 20k when orchestrator is reinserted)
         // There should be no side-effects as long as the value is properly updated on stake updates
         // Not zeroing the stake on the current round's 'EarningsPool' saves gas and should have no side effects as long as
-        // 'EarningsPool.setStake()' is called whenever a transcoder becomes active again.
+        // 'EarningsPool.setStake()' is called whenever a orchestrator becomes active again.
         orchestratorPoolV2.remove(_orchestrator);
         nextRoundTotalActiveStake -= orchestratorTotalStake(_orchestrator);
         uint256 deactivationRound = roundsManager().currentRound() + 1;
         orchestrators[_orchestrator].deactivationRound = deactivationRound;
-        emit TranscoderDeactivated(_orchestrator, deactivationRound);
+        emit OrchestratorDeactivated(_orchestrator, deactivationRound);
     }
 
     /**
-     * @dev Tries to add a transcoder to active transcoder pool, evicts the active transcoder with the lowest stake if the pool is full
-     * @param _orchestrator The transcoder to insert into the transcoder pool
-     * @param _totalStake The total stake for '_transcoder'
-     * @param _activationRound The round in which the transcoder should become active
+     * @dev Tries to add a orchestrator to active orchestrator pool, evicts the active orchestrator with the lowest stake if the pool is full
+     * @param _orchestrator The orchestrator to insert into the orchestrator pool
+     * @param _totalStake The total stake for '_orchestrator'
+     * @param _activationRound The round in which the orchestrator should become active
      */
     function _tryToJoinActiveSet(
         address _orchestrator,
@@ -757,22 +853,22 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
             address lastOrchestrator = orchestratorPoolV2.getLast();
             uint256 lastStake = orchestrators[lastOrchestrator].delegationPool.poolTotalStake();
 
-            // If the pool is full and the transcoder has less stake than the least stake transcoder in the pool
-            // then the transcoder is unable to join the active set for the next round
+            // If the pool is full and the orchestrator has less stake than the least stake orchestrator in the pool
+            // then the orchestrator is unable to join the active set for the next round
             if (_totalStake <= lastStake) {
                 return;
             }
 
-            // Evict the least stake transcoder from the active set for the next round
-            // Not zeroing 'Transcoder.lastActiveStakeUpdateRound' saves gas (5k when transcoder is evicted and 20k when transcoder is reinserted)
+            // Evict the least stake orchestrator from the active set for the next round
+            // Not zeroing 'Orchestrator.lastActiveStakeUpdateRound' saves gas (5k when orchestrator is evicted and 20k when orchestrator is reinserted)
             // There should be no side-effects as long as the value is properly updated on stake updates
             // Not zeroing the stake on the current round's 'EarningsPool' saves gas and should have no side effects as long as
-            // 'EarningsPool.setStake()' is called whenever a transcoder becomes active again.
+            // 'EarningsPool.setStake()' is called whenever a orchestrator becomes active again.
             orchestratorPoolV2.remove(lastOrchestrator);
             orchestrators[lastOrchestrator].deactivationRound = _activationRound;
             pendingNextRoundTotalActiveStake = pendingNextRoundTotalActiveStake - lastStake;
 
-            emit TranscoderDeactivated(lastOrchestrator, _activationRound);
+            emit OrchestratorDeactivated(lastOrchestrator, _activationRound);
         }
 
         orchestratorPoolV2.insert(_orchestrator, _totalStake, _newPosPrev, _newPosNext);
@@ -781,44 +877,7 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
         o.activationRound = _activationRound;
         o.deactivationRound = MAX_FUTURE_ROUND;
         nextRoundTotalActiveStake = pendingNextRoundTotalActiveStake;
-        emit TranscoderActivated(_orchestrator, _activationRound);
-    }
-
-    /**
-     * @dev Update the state of a delegator and its delegate by processing a rebond using an unbonding lock and update the transcoder pool with an optional
-     * list hint if needed. See SortedDoublyLL.sol for details on list hints
-     * @param _delegator Address of delegator
-     * @param _unbondingLockId ID of unbonding lock to rebond with
-     * @param _newPosPrev Address of previous transcoder in pool if the delegate is already in or joins the pool
-     * @param _newPosNext Address of next transcoder in pool if the delegate is already in or joins the pool
-     */
-    function _processRebond(
-        address _delegator,
-        uint256 _unbondingLockId,
-        address _newPosPrev,
-        address _newPosNext
-    ) internal {
-        UnbondingLock storage lock = unbondingLocks[_unbondingLockId];
-
-        require(isValidUnbondingLock(_unbondingLockId), "invalid unbonding lock ID");
-
-        uint256 amount = lock.amount;
-        address delegate = lock.orchestrator;
-
-        require(amount > 0, "ZERO_AMOUNT");
-
-        // Claim outstanding fees
-        _claimFees(delegate, payable(_delegator));
-
-        // Increase delegator's bonded amount
-        uint256 oldStake = stakeOf(delegate, _delegator);
-        orchestrators[delegate].delegationPool.stake(_delegator, amount);
-
-        // Delete lock
-        delete unbondingLocks[_unbondingLockId];
-
-        _increaseOrchTotalStake(delegate, oldStake, amount, _newPosPrev, _newPosNext);
-        emit Rebond(delegate, _delegator, _unbondingLockId, amount);
+        emit OrchestratorActivated(_orchestrator, _activationRound);
     }
 
     /**
@@ -829,10 +888,10 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
      * @dev Transfer funds
      * @dev NOTE: currently doesn't support multi-delegation, would have to add an orchestrator address param
      */
-    function _claimFees(address _delegate, address payable _for) internal {
-        Orchestrator storage orch = orchestrators[_delegate];
+    function _claimFees(address _orchestrator, address payable _for) internal {
+        Orchestrator storage orch = orchestrators[_orchestrator];
         uint256 fees = orch.delegationPool.claimFees(_for);
-        if (_for == _delegate) {
+        if (_for == _orchestrator) {
             fees += orch.feeCommissions;
             orch.feeCommissions = 0;
         }
@@ -864,18 +923,14 @@ contract StakingManager is ManagerProxyTarget, IStakingManager {
     }
 
     function _onlyTicketBroker() internal view {
-        require(msg.sender == controller.getContract(keccak256("TicketBroker")), "caller must be TicketBroker");
+        require(msg.sender == controller.getContract(keccak256("TicketBroker")), "ONLY_TICKETBROKER");
     }
 
     function _onlyRoundsManager() internal view {
-        require(msg.sender == controller.getContract(keccak256("RoundsManager")), "caller must be RoundsManager");
-    }
-
-    function _onlyVerifier() internal view {
-        require(msg.sender == controller.getContract(keccak256("Verifier")), "caller must be Verifier");
+        require(msg.sender == controller.getContract(keccak256("RoundsManager")), "ONLY_ROUNDSMANAGER");
     }
 
     function _currentRoundInitialized() internal view {
-        require(roundsManager().currentRoundInitialized(), "current round is not initialized");
+        require(roundsManager().currentRoundInitialized(), "CURRENT_ROUND_NOT_INITIALIZED");
     }
 }

--- a/test/unit/StakingManager.test.ts
+++ b/test/unit/StakingManager.test.ts
@@ -6,6 +6,7 @@ import {functionSig} from "../../utils/helpers"
 import chai from "chai"
 import {solidity} from "ethereum-waffle"
 import {constants} from "../../utils/constants"
+import {BigNumberish} from "@ethersproject/bignumber"
 chai.use(solidity)
 const {expect} = chai
 
@@ -14,8 +15,8 @@ describe("StakingManager", () => {
     let stakingManager: StakingManager
     let lpt: LivepeerToken
 
-    const NUM_ACTIVE_TRANSCODERS = 2
-    const UNBONDING_PERIOD = 2
+    const UNSTAKING_PERIOD = 2
+    const NUM_ACTIVE_ORCHESTRATORS = 3
 
     let signers: SignerWithAddress[]
 
@@ -27,20 +28,18 @@ describe("StakingManager", () => {
         const llFac = await ethers.getContractFactory("SortedDoublyLL")
         const ll = await llFac.deploy()
 
-        const stakingManagerFactory = new StakingManager__factory(
-            {
-                "contracts/utils/SortedDoublyLL.sol:SortedDoublyLL": ll.address
-            },
-            signers[0]
-        )
-
+        const stakingManagerFactory = await ethers.getContractFactory<StakingManager__factory>("StakingManager", {
+            libraries: {
+                SortedDoublyLL: ll.address
+            }
+        })
         stakingManager = await fixture.deployAndRegister(stakingManagerFactory, "StakingManager", fixture?.controller?.address)
 
         const lptFactory = new LivepeerToken__factory(signers[0])
         lpt = await fixture.deployAndRegister(lptFactory, "LivepeerToken")
 
-        await stakingManager.setUnbondingPeriod(UNBONDING_PERIOD)
-        await stakingManager.setNumActiveTranscoders(NUM_ACTIVE_TRANSCODERS)
+        await stakingManager.setUnstakingPeriod(UNSTAKING_PERIOD)
+        await stakingManager.setNumActiveOrchestrators(NUM_ACTIVE_ORCHESTRATORS)
     })
 
     beforeEach(async () => {
@@ -51,82 +50,632 @@ describe("StakingManager", () => {
         await fixture.tearDown()
     })
 
-    describe("bond", () => {
+    describe("StakingManager", () => {
         let orchestrator0: SignerWithAddress
         let orchestrator1: SignerWithAddress
+        let orchestrator2: SignerWithAddress
         let delegator0: SignerWithAddress
         let delegator1: SignerWithAddress
+        let thirdParty: SignerWithAddress
+        let notControllerOwner: SignerWithAddress
+        let controllerOwner: SignerWithAddress
+
         const currentRound = 100
+        const stakeAmount = 10000
+        const zeroAmount = 0
 
         before(async () => {
+            controllerOwner = signers[0]
+            notControllerOwner = signers[7]
+
             orchestrator0 = signers[1]
             orchestrator1 = signers[2]
-            delegator0 = signers[3]
-            delegator1 = signers[4]
+            orchestrator2 = signers[3]
 
-            await lpt.mint(orchestrator0.address, 1000000)
-            await lpt.mint(orchestrator1.address, 1000000)
-            await lpt.mint(delegator0.address, 1000000)
-            await lpt.mint(delegator1.address, 1000000)
+            delegator0 = signers[4]
+            delegator1 = signers[5]
+
+            // migrator contract
+            thirdParty = signers[6]
+
+            const lptMintAmount = 1000000
+            await lpt.mint(orchestrator0.address, lptMintAmount)
+            await lpt.mint(orchestrator1.address, lptMintAmount)
+            await lpt.mint(orchestrator2.address, lptMintAmount)
+            await lpt.mint(delegator0.address, lptMintAmount)
+            await lpt.mint(delegator1.address, lptMintAmount)
+            await lpt.mint(thirdParty.address, lptMintAmount)
 
             await lpt.connect(orchestrator0).approve(stakingManager.address, ethers.constants.MaxUint256)
             await lpt.connect(orchestrator1).approve(stakingManager.address, ethers.constants.MaxUint256)
+            await lpt.connect(orchestrator2).approve(stakingManager.address, ethers.constants.MaxUint256)
             await lpt.connect(delegator0).approve(stakingManager.address, ethers.constants.MaxUint256)
             await lpt.connect(delegator1).approve(stakingManager.address, ethers.constants.MaxUint256)
+            await lpt.connect(thirdParty).approve(stakingManager.address, ethers.constants.MaxUint256)
         })
 
-        it("should fail if current round is not initialized", async () => {
-            await fixture?.roundsManager?.setMockBool(functionSig("currentRoundInitialized()"), false)
+        describe("Controller", () => {
+            describe("setUnstakingPeriod", () => {
+                it("should fail if caller is not Controller owner", async () => {
+                    const tx = stakingManager.connect(notControllerOwner).setUnstakingPeriod(5)
 
-            await expect(stakingManager.connect(delegator0).bond(1000, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS)).to.be.revertedWith("current round is not initialized")
+                    await expect(tx).to.be.revertedWith("caller must be Controller owner")
+                })
+
+                it("should set unstakingPeriod", async () => {
+                    const tx = stakingManager.connect(controllerOwner).setUnstakingPeriod(5)
+
+                    await expect(tx).to.emit(stakingManager, "ParameterUpdate").withArgs("unstakingPeriod")
+                    expect(await stakingManager.unstakingPeriod()).to.equal(5, "wrong unstakingPeriod")
+                })
+            })
+
+            describe("setNumActiveTranscoders", () => {
+                it("should fail if caller is not Controller owner", async () => {
+                    const tx = stakingManager.connect(notControllerOwner).setNumActiveOrchestrators(7)
+
+                    await expect(tx).to.be.revertedWith("caller must be Controller owner")
+                })
+
+                it("should set numActiveTranscoders", async () => {
+                    const tx = stakingManager.connect(controllerOwner).setNumActiveOrchestrators(4)
+
+                    await expect(tx).to.emit(stakingManager, "ParameterUpdate").withArgs("numActiveOrchestrators")
+                    expect(await stakingManager.getOrchestratorPoolMaxSize()).to.equal(4, "wrong numActiveTranscoders")
+                })
+            })
         })
 
-        describe("staking", () => {
+        describe("Orchestrator", () => {
             before(async () => {
                 await fixture?.roundsManager?.setMockBool(functionSig("currentRoundInitialized()"), true)
                 await fixture?.roundsManager?.setMockBool(functionSig("currentRoundLocked()"), false)
                 await fixture?.roundsManager?.setMockUint256(functionSig("currentRound()"), currentRound - 1)
 
-                await stakingManager.connect(orchestrator0).bond(1000, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
-                await stakingManager.connect(orchestrator1).bond(1000, orchestrator1.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                await stakingManager.connect(orchestrator0).stake(stakeAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                await stakingManager.connect(orchestrator0).orchestrator(5, 10, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
 
-                await stakingManager.connect(orchestrator0).transcoder(5, 10)
-                await stakingManager.connect(orchestrator1).transcoder(5, 10)
+                await stakingManager.connect(orchestrator1).stake(stakeAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                await stakingManager.connect(orchestrator1).orchestrator(5, 10, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
 
                 await fixture?.roundsManager?.setMockUint256(functionSig("currentRound()"), currentRound)
+                await fixture?.roundsManager?.execute(stakingManager.address, functionSig("setCurrentRoundTotalActiveStake()"))
             })
 
-            describe("caller is unbonded", () => {
-                it("should fail if orchestrator delegates to another orchestrator", async () => {
-                    await expect(stakingManager.connect(orchestrator0).bond(1000, orchestrator1.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS)).to.be.revertedWith("ORCHESTRATOR_CAN_NOT_DELEGATE")
+            describe("orchestrator data", async () => {
+                it("should get orchestrator max pool size", async () => {
+                    const maxPoolSize = await stakingManager.getOrchestratorPoolMaxSize()
+
+                    expect(maxPoolSize).to.equal(ethers.BigNumber.from(NUM_ACTIVE_ORCHESTRATORS))
+                })
+
+                it("should get orchestrator pool size", async () => {
+                    const poolSize = await stakingManager.getOrchestratorPoolSize()
+
+                    expect(poolSize).to.equal(ethers.BigNumber.from(2))
+                })
+
+                it("should get first orchestrator in pool", async () => {
+                    const orchestrator = await stakingManager.getFirstOrchestratorInPool()
+
+                    // should return the orchestrator with max stake
+                    // or if all orchestrators have equal stake, return the latest
+                    expect(orchestrator).to.equal(orchestrator1.address)
+                })
+
+                it("should get next orchestrator in pool", async () => {
+                    const orchestrator = await stakingManager.getNextOrchestratorInPool(orchestrator1.address)
+
+                    expect(orchestrator).to.equal(orchestrator0.address)
+                })
+
+                it("should get total stake for the round", async () => {
+                    const stake0 = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+                    const stake1 = await stakingManager.orchestratorTotalStake(orchestrator1.address)
+                    const total = stake0.add(stake1)
+
+                    const roundTotalStake = await stakingManager.getTotalStaked()
+
+                    expect(roundTotalStake).to.equal(total)
+                })
+            })
+
+            // Todo - when orchestrator pool is full
+
+            describe("parameter updates", async () => {
+                it("should fail if current round is not initialized", async () => {
+                    await fixture?.roundsManager?.setMockBool(functionSig("currentRoundInitialized()"), false)
+                    const tx = stakingManager.connect(orchestrator0).orchestrator(5, 10, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("CURRENT_ROUND_NOT_INITIALIZED")
+                })
+
+                it("should fail if the current round is locked", async () => {
+                    await fixture?.roundsManager?.setMockBool(functionSig("currentRoundLocked()"), true)
+                    const tx = stakingManager.connect(orchestrator0).orchestrator(5, 10, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("CURRENT_ROUND_LOCKED")
+                })
+
+                it("should fail if rewardCut is not a valid percentage <= 100%", async () => {
+                    await fixture?.roundsManager?.setMockUint256(functionSig("currentRound()"), currentRound + 1)
+                    const tx = stakingManager.connect(orchestrator0).orchestrator(constants.PERC_DIVISOR_PRECISE.add(1), 10, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("REWARDSHARE_INVALID_PERC")
+                })
+
+                it("should fail if feeShare is not a valid percentage <= 100%", async () => {
+                    await fixture?.roundsManager?.setMockUint256(functionSig("currentRound()"), currentRound + 1)
+                    const tx = stakingManager.connect(orchestrator0).orchestrator(5, constants.PERC_DIVISOR_PRECISE.add(1), constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("FEESHARE_INVALID_PERC")
+                })
+
+                it("should fail if caller is not delegated to self with a non-zero bonded amount", async () => {
+                    await fixture?.roundsManager?.setMockUint256(functionSig("currentRound()"), currentRound + 1)
+                    const tx = stakingManager.connect(orchestrator2).orchestrator(5, 10, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("ORCHESTRATOR_NOT_REGISTERED")
+                })
+
+                it("should fail to changes its commission if active and not called reward", async () => {
+                    const tx = stakingManager.connect(orchestrator0).orchestrator(6, 11, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                    expect(tx).to.be.revertedWith("COMMISSION_RATES_LOCKED")
+                })
+
+                it("should make changes to its commission rates after calling reward", async () => {
+                    await stakingManager.connect(orchestrator0).reward(constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                    await stakingManager.connect(orchestrator0).orchestrator(6, 11, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    const oInfo = await stakingManager.getOrchestrator(orchestrator0.address)
+
+                    expect(oInfo.rewardShare).to.equal(6)
+                    expect(oInfo.feeShare).to.equal(11)
+                })
+            })
+
+            describe("stake", async () => {
+                it("should fail if current round is not initialized", async () => {
+                    await fixture?.roundsManager?.setMockBool(functionSig("currentRoundInitialized()"), false)
+                    const tx = stakingManager.connect(orchestrator0).stake(stakeAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("CURRENT_ROUND_NOT_INITIALIZED")
+                })
+
+                it("should increases stake for itself", async () => {
+                    const currentStake = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+                    await stakingManager.connect(orchestrator0).stake(stakeAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                    const newStake = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+
+                    expect(newStake).to.equal(currentStake.add(stakeAmount))
                 })
 
                 it("should fail if provided amount = 0", async () => {
-                    await expect(stakingManager.connect(delegator0).bond(ethers.BigNumber.from(0), orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS)).to.be.revertedWith(
-                        "ZERO_DELEGATION_AMOUNT"
-                    )
+                    const tx = stakingManager.connect(orchestrator0).stake(zeroAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("ZERO_DELEGATION_AMOUNT")
                 })
 
-                it("delegator stakes funds to orchestrator for itself", async () => {
-                    const startDelegatedAmount = await stakingManager.orchestratorTotalStake(orchestrator0.address)
-                    await stakingManager.connect(delegator0).bond(1000, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                it("should fail if insufficient available balance", async () => {
+                    const balance = await lpt.balanceOf(orchestrator0.address)
+                    const tx = stakingManager.connect(orchestrator0).stake(balance.add(1000), constants.NULL_ADDRESS, constants.NULL_ADDRESS)
 
-                    expect(await stakingManager.orchestratorTotalStake(orchestrator0.address)).to.equal(startDelegatedAmount.add(1000), "wrong change in delegatedAmount")
-                    expect(await stakingManager.stakeOf(orchestrator0.address, delegator0.address)).to.equal(ethers.BigNumber.from(1000), "wrong bondedAmount")
+                    await expect(tx).to.be.revertedWith("ERC20: transfer amount exceeds balance")
                 })
 
-                it("should fire a Bond event when bonding", async () => {
-                    const txRes = stakingManager.connect(delegator0).bond(1000, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
-                    await expect(txRes).to.emit(stakingManager, "Bond").withArgs(orchestrator0.address, delegator0.address, 1000, 1000)
+                it("should fire a Stake event when staking", async () => {
+                    const tx = await stakingManager.connect(orchestrator0).stake(stakeAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    expect(tx).to.emit(stakingManager, "Stake").withArgs(orchestrator0.address, stakeAmount)
                 })
 
-                it("delegator stakes funds to orchestrator on behalf of second delegator", async () => {
-                    const startDelegatedAmount = await stakingManager.orchestratorTotalStake(orchestrator0.address)
-                    await stakingManager.connect(delegator0).bondFor(1000, orchestrator0.address, delegator1.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                it("should fail if orchestrator tries to delegate to itself", async () => {
+                    const tx = stakingManager.connect(orchestrator0).delegate(stakeAmount, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
 
-                    expect(await stakingManager.orchestratorTotalStake(orchestrator0.address)).to.equal(startDelegatedAmount.add(1000), "wrong change in delegatedAmount")
-                    expect(await stakingManager.stakeOf(orchestrator0.address, delegator0.address)).to.equal(ethers.BigNumber.from(0), "wrong bondedAmount for proxy delegator")
-                    expect(await stakingManager.stakeOf(orchestrator0.address, delegator1.address)).to.equal(ethers.BigNumber.from(1000), "wrong bondedAmount for stake owner")
+                    await expect(tx).to.be.revertedWith("CANNOT_SELF_DELEGATE")
+                })
+            })
+
+            describe("unstake", async () => {
+                it("should fail if provided amount = 0", async () => {
+                    const tx = stakingManager.connect(orchestrator0).unstake(zeroAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("ZERO_UNSTAKE_AMOUNT")
+                })
+
+                it("should fail requested amount exceeds staked amount", async () => {
+                    const excessAmount = stakeAmount + 1000
+                    const tx = stakingManager.connect(orchestrator0).unstake(excessAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("AMOUNT_EXCEEDS_STAKE")
+                })
+
+                it("should unstake partially", async () => {
+                    await stakingManager.connect(orchestrator0).reward(constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    const partialAmount = stakeAmount - 1000
+                    const currentStake = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+                    await stakingManager.connect(orchestrator0).unstake(partialAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                    const newStake = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+
+                    expect(newStake).to.equal(currentStake.sub(partialAmount))
+                })
+
+                it("should fire a Unstake event when unstaking", async () => {
+                    const partialAmount = stakeAmount - 1000
+                    const tx = stakingManager.connect(orchestrator0).unstake(partialAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.emit(stakingManager, "Unstake").withArgs(orchestrator0.address, partialAmount, 0)
+                })
+
+                it("should unstake fully", async () => {
+                    const fullAmount = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+                    const tx = stakingManager.connect(orchestrator0).unstake(fullAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx)
+                        .to.emit(stakingManager, "OrchestratorDeactivated")
+                        .withArgs(orchestrator0.address, currentRound + 1)
+                })
+
+                it("should fail if no stakes", async () => {
+                    const fullAmount = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+                    await stakingManager.connect(orchestrator0).unstake(fullAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    const tx = stakingManager.connect(orchestrator0).unstake(fullAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("CALLER_NOT_STAKED")
+                })
+            })
+
+            describe("restake", async () => {
+                let unstakingLockID: BigNumberish
+                const unstakeAmount = stakeAmount / 2
+
+                beforeEach(async () => {
+                    await stakingManager.connect(orchestrator0).stake(stakeAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                    const tx = await stakingManager.connect(orchestrator0).unstake(unstakeAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    const events = await stakingManager.queryFilter(stakingManager.filters.Unstake(), tx.blockHash)
+                    unstakingLockID = events[0].args.lockID
+                })
+
+                it("should fail for invalid unstakingLockID", async () => {
+                    const unstakingLockID = 1234
+                    const tx = stakingManager.connect(orchestrator0).restake(unstakingLockID, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("INVALID_UNSTAKING_LOCK_ID")
+                })
+
+                it("should fail if not lock owner", async () => {
+                    const tx = stakingManager.connect(orchestrator1).restake(unstakingLockID, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("CALLER_NOT_LOCK_OWNER")
+                })
+
+                it("should restake to itself", async () => {
+                    const prevStake = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+                    await stakingManager.connect(orchestrator0).restake(unstakingLockID, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                    const newStake = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+
+                    expect(prevStake).to.gte(ethers.BigNumber.from(unstakeAmount).sub(1))
+                    expect(newStake).to.gte(ethers.BigNumber.from(stakeAmount).sub(1))
+                })
+            })
+
+            describe("withdraw", async () => {
+                describe("withdraw stake", async () => {
+                    let unstakingLockID: BigNumberish
+                    const withdrawAmount = stakeAmount / 2
+
+                    beforeEach(async () => {
+                        await fixture?.roundsManager?.setMockUint256(functionSig("currentRound()"), currentRound + 1)
+                        const tx = await stakingManager.connect(orchestrator0).unstake(withdrawAmount, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                        const events = await stakingManager.queryFilter(stakingManager.filters.Unstake(), tx.blockHash)
+                        unstakingLockID = events[0].args.lockID
+                    })
+
+                    it("should fail if system is paused", async () => {
+                        await fixture?.controller?.pause()
+                        const tx = stakingManager.connect(orchestrator0).withdrawStake(unstakingLockID)
+
+                        await expect(tx).to.be.revertedWith("system is paused")
+                    })
+
+                    it("should fail if current round is not initialized", async () => {
+                        await fixture?.roundsManager?.setMockBool(functionSig("currentRoundInitialized()"), false)
+                        const tx = stakingManager.connect(orchestrator0).withdrawStake(unstakingLockID)
+
+                        await expect(tx).to.be.revertedWith("CURRENT_ROUND_NOT_INITIALIZED")
+                    })
+
+                    it("should fail for invalid unstakingLockID", async () => {
+                        const unstakingLockID = 1234
+                        const tx = stakingManager.connect(orchestrator0).withdrawStake(unstakingLockID)
+
+                        await expect(tx).to.be.revertedWith("INVALID_UNSTAKING_LOCK_ID")
+                    })
+
+                    it("should fail if unbonding lock withdraw round is in the future", async () => {
+                        const tx = stakingManager.connect(orchestrator0).withdrawStake(unstakingLockID)
+
+                        await expect(tx).revertedWith("withdraw round must be before or equal to the current round")
+                    })
+
+                    it("should fail if not lock owner", async () => {
+                        const unstakingPeriod = await stakingManager.unstakingPeriod()
+                        await fixture?.roundsManager?.setMockUint256(functionSig("currentRound()"), currentRound + 1 + unstakingPeriod.toNumber())
+
+                        const tx = stakingManager.connect(orchestrator1).withdrawStake(unstakingLockID)
+
+                        await expect(tx).to.be.revertedWith("CALLER_NOT_LOCK_OWNER")
+                    })
+
+                    it("should withdraw stake", async () => {
+                        const unstakingPeriod = await stakingManager.unstakingPeriod()
+                        await fixture?.roundsManager?.setMockUint256(functionSig("currentRound()"), currentRound + 1 + unstakingPeriod.toNumber())
+
+                        const prevLock = await stakingManager.unstakingLocks(unstakingLockID)
+                        await stakingManager.connect(orchestrator0).withdrawStake(unstakingLockID)
+                        const newLock = await stakingManager.unstakingLocks(unstakingLockID)
+
+                        expect(prevLock.amount).to.eq(withdrawAmount)
+                        expect(newLock.amount).to.eq(0)
+                    })
+
+                    it("should fire a WithdrawStake event when withdrawing stake", async () => {
+                        const unstakingPeriod = await stakingManager.unstakingPeriod()
+                        await fixture?.roundsManager?.setMockUint256(functionSig("currentRound()"), currentRound + 1 + unstakingPeriod.toNumber())
+
+                        const tx = stakingManager.connect(orchestrator0).withdrawStake(unstakingLockID)
+
+                        await expect(tx)
+                            .to.emit(stakingManager, "WithdrawStake")
+                            .withArgs(orchestrator0.address, unstakingLockID, withdrawAmount, currentRound + 1 + unstakingPeriod.toNumber())
+                    })
+                })
+
+                describe("withdraw fees", async () => {
+                    // TODO
+                })
+            })
+
+            describe("third party", async () => {
+                it("stakeFor", async () => {
+                    const currentStake = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+                    await stakingManager.connect(thirdParty).stakeFor(stakeAmount, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                    const newStake = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+
+                    expect(newStake).to.equal(currentStake.add(stakeAmount))
+                })
+
+                it("should fail to call delegateFor to orchestrator on behalf of same orchestrator", async () => {
+                    const tx = stakingManager.connect(thirdParty).delegateFor(stakeAmount, orchestrator0.address, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("CANNOT_SELF_DELEGATE")
+                })
+            })
+        })
+
+        describe("Delegator", () => {
+            describe("delegate", () => {
+                it("should fail if current round is not initialized", async () => {
+                    await fixture?.roundsManager?.setMockBool(functionSig("currentRoundInitialized()"), false)
+                    const tx = stakingManager.connect(delegator0).delegate(stakeAmount, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("CURRENT_ROUND_NOT_INITIALIZED")
+                })
+
+                it("should fail if provided amount = 0", async () => {
+                    const tx = stakingManager.connect(delegator0).delegate(zeroAmount, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("ZERO_DELEGATION_AMOUNT")
+                })
+
+                it("should fail if delegating to self", async () => {
+                    const tx = stakingManager.connect(delegator0).delegate(stakeAmount, delegator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("CANNOT_SELF_DELEGATE")
+                })
+
+                it("should delegate towards an orchestrator", async () => {
+                    const currentStake = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+                    await stakingManager.connect(delegator0).delegate(stakeAmount, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                    const newStake = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+
+                    expect(newStake).to.gte(currentStake.add(stakeAmount).sub(1))
+                    expect(await stakingManager.getDelegatedStake(orchestrator0.address, delegator0.address)).to.be.gte(ethers.BigNumber.from(stakeAmount).sub(1))
+                })
+
+                it("should fire a Delegate event when delegating", async () => {
+                    const tx = await stakingManager.connect(delegator0).delegate(stakeAmount, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    expect(tx).to.emit(stakingManager, "Delegate").withArgs(delegator0.address, orchestrator0.address, stakeAmount)
+                })
+            })
+
+            describe("changeDelegation", () => {
+                const changeAmount = 4000
+
+                beforeEach(async () => {
+                    await stakingManager.connect(delegator0).delegate(stakeAmount, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                })
+
+                it("should fail if change delegation amount = 0", async () => {
+                    const tx = stakingManager.connect(delegator0).changeDelegation(zeroAmount, orchestrator0.address, orchestrator1.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("ZERO_CHANGE_DELEGATION_AMOUNT")
+                })
+
+                it("should fail if delegator changes delegation for self", async () => {
+                    const tx = stakingManager.connect(delegator0).changeDelegation(changeAmount, delegator0.address, orchestrator1.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("CANNOT_CHANGE_DELEGATION_FOR_SELF")
+                })
+
+                it("should fail if orchestrator changes delegation for self", async () => {
+                    const tx = stakingManager.connect(orchestrator0).changeDelegation(changeAmount, orchestrator0.address, orchestrator1.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("CANNOT_CHANGE_DELEGATION_FOR_SELF")
+                })
+
+                it("should change delegation to another orchestrator", async () => {
+                    const currentStake0 = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+                    const currentStake1 = await stakingManager.orchestratorTotalStake(orchestrator1.address)
+
+                    const delegatorShare0 = await stakingManager.getDelegatedStake(orchestrator0.address, delegator0.address)
+                    const delegatorShare1 = await stakingManager.getDelegatedStake(orchestrator1.address, delegator0.address)
+
+                    await stakingManager.connect(delegator0).changeDelegation(changeAmount, orchestrator0.address, orchestrator1.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    const newStake0 = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+                    const newStake1 = await stakingManager.orchestratorTotalStake(orchestrator1.address)
+
+                    expect(newStake0).to.equal(currentStake0.sub(changeAmount))
+                    expect(newStake1).to.equal(currentStake1.add(changeAmount))
+                    expect(await stakingManager.getDelegatedStake(orchestrator0.address, delegator0.address)).to.be.gte(delegatorShare0.sub(changeAmount).sub(1))
+                    expect(await stakingManager.getDelegatedStake(orchestrator1.address, delegator0.address)).to.be.gte(delegatorShare1.add(changeAmount).sub(1))
+                })
+            })
+
+            describe("undelegate", () => {
+                beforeEach(async () => {
+                    await stakingManager.connect(delegator0).delegate(stakeAmount, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                })
+
+                it("should undelegate amount from an orchestrator", async () => {
+                    const currentStake = await stakingManager.getDelegatedStake(orchestrator0.address, delegator0.address)
+                    await stakingManager.connect(delegator0).undelegate(stakeAmount, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                    const newStake = await stakingManager.getDelegatedStake(orchestrator0.address, delegator0.address)
+
+                    expect(newStake).to.gte(currentStake.sub(stakeAmount).sub(1))
+                })
+
+                it("should fire an Undelegate event when undelegating", async () => {
+                    const tx = stakingManager.connect(delegator0).undelegate(stakeAmount, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.emit(stakingManager, "Undelegate").withArgs(delegator0.address, orchestrator0.address, stakeAmount, 0)
+                })
+            })
+
+            describe("redelegate", () => {
+                let unstakingLockID: BigNumberish
+                const undelegateAmount = stakeAmount / 2
+
+                beforeEach(async () => {
+                    await stakingManager.connect(delegator0).delegate(stakeAmount, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                    const tx = await stakingManager.connect(delegator0).undelegate(undelegateAmount, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    const events = await stakingManager.queryFilter(stakingManager.filters.Undelegate(), tx.blockHash)
+                    unstakingLockID = events[0].args.lockID
+                })
+
+                it("should fail for invalid unstakingLockID", async () => {
+                    const unstakingLockID = 1234
+                    const tx = stakingManager.connect(delegator0).redelegate(unstakingLockID, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("INVALID_UNSTAKING_LOCK_ID")
+                })
+
+                it("should fail if not lock owner", async () => {
+                    const tx = stakingManager.connect(delegator1).redelegate(unstakingLockID, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await expect(tx).to.be.revertedWith("CALLER_NOT_LOCK_OWNER")
+                })
+
+                it("should redelegate amount to an orchestrator", async () => {
+                    const prevStake = await stakingManager.getDelegatedStake(orchestrator0.address, delegator0.address)
+                    await stakingManager.connect(delegator0).redelegate(unstakingLockID, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                    const newStake = await stakingManager.getDelegatedStake(orchestrator0.address, delegator0.address)
+
+                    expect(prevStake).to.gte(ethers.BigNumber.from(undelegateAmount).sub(1))
+                    expect(newStake).to.gte(ethers.BigNumber.from(stakeAmount).sub(1))
+                })
+            })
+
+            describe("withdraw", async () => {
+                let unstakingLockID: BigNumberish
+                const withdrawAmount = stakeAmount / 2
+
+                beforeEach(async () => {
+                    await stakingManager.connect(delegator0).delegate(stakeAmount, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    await fixture?.roundsManager?.setMockUint256(functionSig("currentRound()"), currentRound + 1)
+                    const tx = await stakingManager.connect(delegator0).undelegate(withdrawAmount, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+
+                    const events = await stakingManager.queryFilter(stakingManager.filters.Undelegate(), tx.blockHash)
+                    unstakingLockID = events[0].args.lockID
+                })
+
+                it("should fail if system is paused", async () => {
+                    await fixture?.controller?.pause()
+                    const tx = stakingManager.connect(delegator0).withdrawStake(unstakingLockID)
+
+                    await expect(tx).to.be.revertedWith("system is paused")
+                })
+
+                it("should fail if current round is not initialized", async () => {
+                    await fixture?.roundsManager?.setMockBool(functionSig("currentRoundInitialized()"), false)
+                    const tx = stakingManager.connect(delegator0).withdrawStake(unstakingLockID)
+
+                    await expect(tx).to.be.revertedWith("CURRENT_ROUND_NOT_INITIALIZED")
+                })
+
+                it("should fail for invalid unstakingLockID", async () => {
+                    const unstakingLockID = 1234
+                    const tx = stakingManager.connect(delegator0).withdrawStake(unstakingLockID)
+
+                    await expect(tx).to.be.revertedWith("INVALID_UNSTAKING_LOCK_ID")
+                })
+
+                it("should fail if unbonding lock withdraw round is in the future", async () => {
+                    const tx = stakingManager.connect(delegator1).withdrawStake(unstakingLockID)
+
+                    await expect(tx).revertedWith("withdraw round must be before or equal to the current round")
+                })
+
+                it("should fail if not lock owner", async () => {
+                    const unstakingPeriod = await stakingManager.unstakingPeriod()
+                    await fixture?.roundsManager?.setMockUint256(functionSig("currentRound()"), currentRound + 1 + unstakingPeriod.toNumber())
+
+                    const tx = stakingManager.connect(delegator1).withdrawStake(unstakingLockID)
+
+                    await expect(tx).to.be.revertedWith("CALLER_NOT_LOCK_OWNER")
+                })
+
+                it("should withdraw stake", async () => {
+                    const unstakingPeriod = await stakingManager.unstakingPeriod()
+                    await fixture?.roundsManager?.setMockUint256(functionSig("currentRound()"), currentRound + 1 + unstakingPeriod.toNumber())
+
+                    const prevLock = await stakingManager.unstakingLocks(unstakingLockID)
+                    await stakingManager.connect(delegator0).withdrawStake(unstakingLockID)
+                    const newLock = await stakingManager.unstakingLocks(unstakingLockID)
+
+                    expect(prevLock.amount).to.eq(withdrawAmount)
+                    expect(newLock.amount).to.eq(0)
+                })
+
+                it("should fire a WithdrawStake event when withdrawing stake", async () => {
+                    const unstakingPeriod = await stakingManager.unstakingPeriod()
+                    await fixture?.roundsManager?.setMockUint256(functionSig("currentRound()"), currentRound + 1 + unstakingPeriod.toNumber())
+
+                    const tx = stakingManager.connect(delegator0).withdrawStake(unstakingLockID)
+
+                    await expect(tx)
+                        .to.emit(stakingManager, "WithdrawStake")
+                        .withArgs(delegator0.address, unstakingLockID, withdrawAmount, currentRound + 1 + unstakingPeriod.toNumber())
+                })
+            })
+
+            describe("third party", async () => {
+                it("should delegate on behalf of delegator", async () => {
+                    const currentStake = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+                    await stakingManager.connect(thirdParty).delegateFor(stakeAmount, orchestrator0.address, delegator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                    const newStake = await stakingManager.orchestratorTotalStake(orchestrator0.address)
+
+                    expect(newStake).to.equal(currentStake.add(stakeAmount))
+                    expect(await stakingManager.getDelegatedStake(orchestrator0.address, delegator0.address)).to.be.gte(ethers.BigNumber.from(stakeAmount).sub(1))
+                    expect(await stakingManager.getDelegatedStake(orchestrator0.address, thirdParty.address)).to.be.gte(ethers.BigNumber.from(0).sub(1))
                 })
             })
         })


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Contains API changes which separates functions of orchestrators and delegators. Orchestrator functions include stake, restake, unstake etc whereas delegators can call delegate, undelegate, redelegate etc. This makes the usage of the API more intuitive for the respective users.

splitting /pull/474 into 2 parts
1. updating stakingManager contracts API
2. removing bondingManager and rewriting tests
 
**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- created+renamed functions for orchestrators
- created+renamed functions for delegators
- added test cases for the stakingManager functions 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
ran yarn test

**Does this pull request close any open issues?**
<!-- Fixes # -->
closes #471 #470 #454 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
