### PR TITLE
changed events testing pattern

### DIFF
--- a/test/integration/GovernorUpdate.js
+++ b/test/integration/GovernorUpdate.js
@@ -64,10 +64,12 @@ describe("Governor update", () => {
             }
             await governor.stage(update, 0)
 
-            const tx = await governor.execute(update)
-            assert.equal((await bondingManager.getTranscoderPoolMaxSize()).toNumber(), 30)
+            const tx = governor.execute(update)
+            await expect(tx)
+                .to.emit(governor, "UpdateExecuted")
+                .withArgs([...update])
 
-            expect(tx).to.emit(governor, "UpdateExecuted").withArgs([...update])
+            assert.equal((await bondingManager.getTranscoderPoolMaxSize()).toNumber(), 30)
         })
     })
 
@@ -104,7 +106,6 @@ describe("Governor update", () => {
             unpauseData = controller.interface.encodeFunctionData("unpause", [])
             unpauseTarget = controller.address
         })
-
 
         it("step 1 'pause' fails: the protocol is already paused", async () => {
             // pause twice
@@ -169,7 +170,6 @@ describe("Governor update", () => {
 
         it("step 3 'setContractInfo' fails: wrong target", async () => {
             migrateData = minter.interface.encodeFunctionData("migrateToNewMinter", [newMinter.address])
-
 
             const update = {
                 target: [pauseTarget, migrateTarget, migrateTarget, unpauseTarget],

--- a/test/integration/PoolUpdatesWithHints.js
+++ b/test/integration/PoolUpdatesWithHints.js
@@ -157,7 +157,7 @@ describe("PoolUpdatesWithHints", () => {
         // Get gas cost of transcoder()
         let tx = await bondingManager.connect(newTranscoder).transcoder(0, 0)
         const txResNoHint = await tx.wait()
-        expect(tx).to.emit(bondingManager, "TranscoderDeactivated").withArgs(transcoders[size - 1].address, dr)
+        await expect(tx.hash).to.emit(bondingManager, "TranscoderDeactivated").withArgs(transcoders[size - 1].address, dr)
 
         assert.equal(await transcoderAtPoolPos(size - 1), newTranscoder.address)
 

--- a/test/integration/PoolUpdatesWithHints.js
+++ b/test/integration/PoolUpdatesWithHints.js
@@ -156,16 +156,16 @@ describe("PoolUpdatesWithHints", () => {
 
         // Get gas cost of transcoder()
         let tx = await bondingManager.connect(newTranscoder).transcoder(0, 0)
+        const txResNoHint = await tx.wait()
         expect(tx).to.emit(bondingManager, "TranscoderDeactivated").withArgs(transcoders[size - 1].address, dr)
 
-        const txResNoHint = await tx.wait()
         assert.equal(await transcoderAtPoolPos(size - 1), newTranscoder.address)
 
         await rpc.revert(testSnapshotId)
 
         // Get gas cost of transcoderWithHint()
         tx = await bondingManager.connect(newTranscoder).transcoderWithHint(0, 0, transcoders[size - 3].address, ethers.constants.AddressZero)
-        expect(tx).to.emit(bondingManager, "TranscoderDeactivated").withArgs(transcoders[size - 1].address, dr)
+        await expect(tx.hash).to.emit(bondingManager, "TranscoderDeactivated").withArgs(transcoders[size - 1].address, dr)
 
         const txResHint = await tx.wait()
         assert.equal(await transcoderAtPoolPos(size - 1), newTranscoder.address)

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -152,9 +152,9 @@ describe("BondingManager", () => {
             describe("transcoder pool is not full", () => {
                 it("should add new transcoder to the pool", async () => {
                     await bondingManager.bond(1000, signers[0].address)
-                    const txRes = await bondingManager.transcoder(5, 10)
+                    const txRes = bondingManager.transcoder(5, 10)
 
-                    expect(txRes).to.emit(bondingManager, "TranscoderUpdate").withArgs(signers[0].address, 5, 10)
+                    await expect(txRes).to.emit(bondingManager, "TranscoderUpdate").withArgs(signers[0].address, 5, 10)
 
                     assert.equal(await bondingManager.nextRoundTotalActiveStake(), 1000, "wrong next total stake")
                     assert.equal(await bondingManager.getTranscoderPoolSize(), 1, "wrong transcoder pool size")
@@ -222,8 +222,8 @@ describe("BondingManager", () => {
 
                         // Caller bonds 6000 which is more than transcoder with least delegated stake
                         await bondingManager.connect(newTranscoder).bond(6000, newTranscoder.address)
-                        const txRes = await bondingManager.connect(newTranscoder).transcoder(5, 10)
-                        expect(txRes).to.emit(bondingManager, "TranscoderUpdate").withArgs(newTranscoder.address, 5, 10)
+                        const txRes = bondingManager.connect(newTranscoder).transcoder(5, 10)
+                        await expect(txRes).to.emit(bondingManager, "TranscoderUpdate").withArgs(newTranscoder.address, 5, 10)
                         await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
 
                         // Subtract evicted transcoder's delegated stake and add new transcoder's delegated stake
@@ -266,8 +266,8 @@ describe("BondingManager", () => {
                         // Caller bonds 600 - less than transcoder with least delegated stake
                         await bondingManager.connect(newTranscoder).bond(600, newTranscoder.address)
                         await bondingManager.connect(newTranscoder).transcoder(5, 10)
-                        const txRes = await bondingManager.connect(newTranscoder).transcoder(5, 10)
-                        expect(txRes).to.emit(bondingManager, "TranscoderUpdate").withArgs(newTranscoder.address, 5, 10)
+                        const txRes = bondingManager.connect(newTranscoder).transcoder(5, 10)
+                        await expect(txRes).to.emit(bondingManager, "TranscoderUpdate").withArgs(newTranscoder.address, 5, 10)
                         await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
 
                         assert.isFalse(
@@ -293,8 +293,8 @@ describe("BondingManager", () => {
 
                         // Caller bonds 2000 - same as transcoder with least delegated stake
                         await bondingManager.connect(newTranscoder).bond(2000, newTranscoder.address)
-                        const txRes = await bondingManager.connect(newTranscoder).transcoder(5, 10)
-                        expect(txRes).to.emit(bondingManager, "TranscoderUpdate").withArgs(newTranscoder.address, 5, 10)
+                        const txRes = bondingManager.connect(newTranscoder).transcoder(5, 10)
+                        await expect(txRes).to.emit(bondingManager, "TranscoderUpdate").withArgs(newTranscoder.address, 5, 10)
                         await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1)
                         assert.isFalse(
                             await bondingManager.isActiveTranscoder(newTranscoder.address),
@@ -453,8 +453,8 @@ describe("BondingManager", () => {
 
             describe("evicts a transcoder from the pool", () => {
                 it("last transcoder gets evicted and new transcoder gets inserted", async () => {
-                    const txRes = await bondingManager.connect(delegator).bond(2000, transcoder2.address)
-                    expect(txRes)
+                    const txRes = bondingManager.connect(delegator).bond(2000, transcoder2.address)
+                    await expect(txRes)
                         .to.emit(bondingManager, "TranscoderDeactivated")
                         .withArgs(transcoder0.address, currentRound + 2)
                     await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 2)
@@ -475,8 +475,8 @@ describe("BondingManager", () => {
                 })
 
                 it("fires a TranscoderActivated event for the new transcoder", async () => {
-                    const txRes = await bondingManager.connect(delegator).bond(2000, transcoder2.address)
-                    expect(txRes)
+                    const txRes = bondingManager.connect(delegator).bond(2000, transcoder2.address)
+                    await expect(txRes)
                         .to.emit(bondingManager, "TranscoderActivated")
                         .withArgs(transcoder2.address, currentRound + 2)
                 })
@@ -539,25 +539,25 @@ describe("BondingManager", () => {
             })
 
             it("should fire a Bond event when bonding from unbonded", async () => {
-                const txRes = await bondingManager.connect(delegator).bond(1000, transcoder0.address)
-                expect(txRes)
+                const txRes = bondingManager.connect(delegator).bond(1000, transcoder0.address)
+                await expect(txRes)
                     .to.emit(bondingManager, "Bond")
                     .withArgs(transcoder0.address, constants.NULL_ADDRESS, delegator.address, 1000, 1000)
             })
 
             it("fires an EarningsClaimed event when bonding from unbonded", async () => {
-                const txResult = await bondingManager.connect(delegator).bond(1000, transcoder0.address)
+                const txResult = bondingManager.connect(delegator).bond(1000, transcoder0.address)
 
-                expect(txResult)
+                await expect(txResult)
                     .to.emit(bondingManager, "EarningsClaimed")
                     .withArgs(constants.NULL_ADDRESS, delegator.address, 0, 0, 1, currentRound)
             })
 
             it("it doesn't fire an EarningsClaimed event when bonding twice in the same round", async () => {
                 await bondingManager.connect(delegator).bond(1000, transcoder0.address)
-                const txResult = await bondingManager.connect(delegator).bond(1000, transcoder0.address)
+                const txResult = bondingManager.connect(delegator).bond(1000, transcoder0.address)
 
-                expect(txResult).to.not.emit(bondingManager, "EarningsClaimed").withArgs(delegator.address)
+                await expect(txResult).to.not.emit(bondingManager, "EarningsClaimed").withArgs(delegator.address)
             })
 
             describe("delegate is a registered transcoder", () => {
@@ -764,9 +764,9 @@ describe("BondingManager", () => {
                         assert.equal(endBondedAmount.sub(startBondedAmount), 0, "bondedAmount change should be 0")
                     })
                     it("should fire a Bond event when changing delegates", async () => {
-                        const txRes = await bondingManager.connect(delegator).bond(0, transcoder1.address)
+                        const txRes = bondingManager.connect(delegator).bond(0, transcoder1.address)
 
-                        expect(txRes)
+                        await expect(txRes)
                             .to.emit(bondingManager, "Bond")
                             .withArgs(transcoder1.address, transcoder0.address, delegator.address, 0, 2000)
                     })
@@ -853,9 +853,9 @@ describe("BondingManager", () => {
                         assert.equal(endTotalStake.sub(startTotalStake), 1000, "wrong change in total next round stake")
                     })
                     it("should fire a Bond event when increasing bonded stake and changing delegates", async () => {
-                        const txRes = await bondingManager.connect(delegator).bond(1000, transcoder1.address)
+                        const txRes = bondingManager.connect(delegator).bond(1000, transcoder1.address)
 
-                        expect(txRes)
+                        await expect(txRes)
                             .to.emit(bondingManager, "Bond")
                             .withArgs(transcoder1.address, transcoder0.address, delegator.address, 1000, 3000)
                     })
@@ -976,8 +976,8 @@ describe("BondingManager", () => {
                     })
                 })
                 it("should fire a Bond event when increasing bonded amount", async () => {
-                    const txRes = await bondingManager.connect(delegator).bond(1000, transcoder0.address)
-                    expect(txRes)
+                    const txRes = bondingManager.connect(delegator).bond(1000, transcoder0.address)
+                    await expect(txRes)
                         .to.emit(bondingManager, "Bond")
                         .withArgs(transcoder0.address, transcoder0.address, delegator.address, 1000, 3000)
                 })
@@ -1147,9 +1147,9 @@ describe("BondingManager", () => {
                 const unbondingLockID = (await bondingManager.getDelegator(delegator.address))[6]
                 const unbondingPeriod = (await bondingManager.unbondingPeriod.call()).toNumber()
 
-                const txRes = await bondingManager.connect(delegator).unbond(500)
+                const txRes = bondingManager.connect(delegator).unbond(500)
 
-                expect(txRes)
+                await expect(txRes)
                     .to.emit(bondingManager, "Unbond")
                     .withArgs(
                         transcoder.address,
@@ -1258,8 +1258,8 @@ describe("BondingManager", () => {
                 const unbondingLockID = (await bondingManager.getDelegator(delegator.address))[6]
                 const unbondingPeriod = (await bondingManager.unbondingPeriod.call()).toNumber()
 
-                const txRes = await bondingManager.connect(delegator).unbond(1000)
-                expect(txRes)
+                const txRes = bondingManager.connect(delegator).unbond(1000)
+                await expect(txRes)
                     .to.emit(bondingManager, "Unbond")
                     .withArgs(
                         transcoder.address,
@@ -1292,8 +1292,8 @@ describe("BondingManager", () => {
                 })
 
                 it("should fire a TranscoderDeactivated event", async () => {
-                    const txRes = await bondingManager.connect(transcoder).unbond(1000)
-                    expect(txRes)
+                    const txRes = bondingManager.connect(transcoder).unbond(1000)
+                    await expect(txRes)
                         .to.emit(bondingManager, "TranscoderDeactivated")
                         .withArgs(transcoder.address, currentRound + 2)
                 })
@@ -1416,8 +1416,8 @@ describe("BondingManager", () => {
                 await bondingManager.connect(transcoder2).bond(1800, transcoder2.address)
                 await bondingManager.connect(transcoder2).transcoder(5, 10)
 
-                const txRes = await bondingManager.connect(delegator).rebond(unbondingLockID)
-                expect(txRes)
+                const txRes = bondingManager.connect(delegator).rebond(unbondingLockID)
+                await expect(txRes)
                     .to.emit(bondingManager, "TranscoderDeactivated")
                     .withArgs(transcoder2.address, currentRound + 2)
 
@@ -1450,8 +1450,8 @@ describe("BondingManager", () => {
         })
 
         it("should create an Rebond event", async () => {
-            const txRes = await bondingManager.connect(delegator).rebond(unbondingLockID)
-            expect(txRes)
+            const txRes = bondingManager.connect(delegator).rebond(unbondingLockID)
+            await expect(txRes)
                 .to.emit(bondingManager, "Rebond")
                 .withArgs(transcoder.address, delegator.address, unbondingLockID, 500)
         })
@@ -1601,8 +1601,8 @@ describe("BondingManager", () => {
             // Delegator unbonds rest of tokens transitioning to the Unbonded state
             await bondingManager.connect(delegator).unbond(500)
 
-            const txRes = await bondingManager.connect(delegator).rebondFromUnbonded(transcoder.address, unbondingLockID)
-            expect(txRes)
+            const txRes = bondingManager.connect(delegator).rebondFromUnbonded(transcoder.address, unbondingLockID)
+            await expect(txRes)
                 .to.emit(bondingManager, "Rebond")
                 .withArgs(transcoder.address, delegator.address, unbondingLockID, 500)
         })
@@ -1676,8 +1676,8 @@ describe("BondingManager", () => {
             const unbondingPeriod = (await bondingManager.unbondingPeriod.call()).toNumber()
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + 1 + unbondingPeriod)
 
-            const txRes = await bondingManager.connect(delegator).withdrawStake(unbondingLockID)
-            expect(txRes)
+            const txRes = bondingManager.connect(delegator).withdrawStake(unbondingLockID)
+            await expect(txRes)
                 .to.emit(bondingManager, "WithdrawStake")
                 .withArgs(delegator.address, unbondingLockID, 500, currentRound + 1 + unbondingPeriod)
         })
@@ -1890,8 +1890,8 @@ describe("BondingManager", () => {
         })
 
         it("Should emit a Reward event", async () => {
-            const txRes = await bondingManager.connect(transcoder).reward()
-            expect(txRes).to.emit(bondingManager, "Reward").withArgs(transcoder.address, 1000)
+            const txRes = bondingManager.connect(transcoder).reward()
+            await expect(txRes).to.emit(bondingManager, "Reward").withArgs(transcoder.address, 1000)
         })
 
         describe("previous cumulative factors rescaling", () => {
@@ -2431,7 +2431,7 @@ describe("BondingManager", () => {
             })
 
             it("fires a TranscoderDeactivated event", async () => {
-                const txRes = await fixture.verifier.execute(
+                const txRes = fixture.verifier.execute(
                     bondingManager.address,
                     functionEncodedABI(
                         "slashTranscoder(address,address,uint256,uint256)",
@@ -2439,7 +2439,7 @@ describe("BondingManager", () => {
                         [transcoder.address, constants.NULL_ADDRESS, PERC_DIVISOR / 2, 0]
                     )
                 )
-                expect(txRes)
+                await expect(txRes)
                     .to.emit(bondingManager, "TranscoderDeactivated")
                     .withArgs(transcoder.address, currentRound + 2)
             })
@@ -2534,7 +2534,7 @@ describe("BondingManager", () => {
 
         describe("invoked with a finder", () => {
             it("slashes transcoder and rewards finder", async () => {
-                const txRes = await fixture.verifier.execute(
+                const txRes = fixture.verifier.execute(
                     bondingManager.address,
                     functionEncodedABI(
                         "slashTranscoder(address,address,uint256,uint256)",
@@ -2543,7 +2543,7 @@ describe("BondingManager", () => {
                     )
                 )
 
-                expect(txRes)
+                await expect(txRes)
                     .to.emit(bondingManager, "TranscoderSlashed")
                     .withArgs(transcoder.address, finder.address, 500, 250)
             })
@@ -2551,7 +2551,7 @@ describe("BondingManager", () => {
 
         describe("invoked without a finder", () => {
             it("slashes transcoder", async () => {
-                const txRes = await fixture.verifier.execute(
+                const txRes = fixture.verifier.execute(
                     bondingManager.address,
                     functionEncodedABI(
                         "slashTranscoder(address,address,uint256,uint256)",
@@ -2560,7 +2560,7 @@ describe("BondingManager", () => {
                     )
                 )
 
-                expect(txRes)
+                await expect(txRes)
                     .to.emit(bondingManager, "TranscoderSlashed")
                     .withArgs(transcoder.address, constants.NULL_ADDRESS, 500, 0)
             })
@@ -2578,7 +2578,7 @@ describe("BondingManager", () => {
             })
 
             it("fires a TranscoderSlashed event, but transcoder is not penalized because it does not have a bonded amount", async () => {
-                const txRes = await fixture.verifier.execute(
+                const txRes = fixture.verifier.execute(
                     bondingManager.address,
                     functionEncodedABI(
                         "slashTranscoder(address,address,uint256,uint256)",
@@ -2587,7 +2587,7 @@ describe("BondingManager", () => {
                     )
                 )
 
-                expect(txRes)
+                await expect(txRes)
                     .to.emit(bondingManager, "TranscoderSlashed")
                     .withArgs(transcoder.address, constants.NULL_ADDRESS, 0, 0)
             })
@@ -3160,8 +3160,8 @@ describe("BondingManager", () => {
 
         it("emits an EarningsClaimed event", async () => {
             const lastClaimRound = (await bondingManager.getDelegator(delegator.address)).lastClaimRound
-            const txRes = await bondingManager.claimSnapshotEarnings(1500, 1000, [], [])
-            expect(txRes)
+            const txRes = bondingManager.claimSnapshotEarnings(1500, 1000, [], [])
+            await expect(txRes)
                 .to.emit(bondingManager, "EarningsClaimed")
                 .withArgs(delegator.address, delegator.address, 500, 1000, lastClaimRound.toNumber() + 1, currentRound)
         })

--- a/test/unit/Governor.js
+++ b/test/unit/Governor.js
@@ -100,7 +100,7 @@ describe("Governor", () => {
                 "0"
             )
 
-            const tx = await governor.execute(
+            const tx = governor.execute(
                 {
                     target: [governor.address],
                     value: ["0"],
@@ -109,8 +109,8 @@ describe("Governor", () => {
                 }
             )
 
+            await expect(tx).to.emit(governor, "OwnershipTransferred").withArgs(signers[0].address, signers[1].address)
             assert.equal(await governor.owner(), signers[1].address)
-            expect(tx).to.emit(governor, "OwnershipTransferred").withArgs(signers[0].address, signers[1].address)
         })
     })
 
@@ -193,16 +193,16 @@ describe("Governor", () => {
             const updateHash = getUpdateHash(update)
             const blockNum = await fixture.rpc.getBlockNumberAsync()
 
-            const tx = await governor.stage(
+            const tx = governor.stage(
                 update,
                 "5"
             )
 
-            assert.equal((await governor.updates(updateHash)).toNumber(), blockNum + 5 + 1) // + 1 because stage() mines a block
 
-            expect(tx).to.emit(governor, "UpdateStaged").withArgs(
+            await expect(tx).to.emit(governor, "UpdateStaged").withArgs(
                 [...update], 5
             )
+            assert.equal((await governor.updates(updateHash)).toNumber(), blockNum + 5 + 1) // + 1 because stage() mines a block
         })
     })
 
@@ -273,17 +273,17 @@ describe("Governor", () => {
             const updateHash = getUpdateHash(update)
             const blockNum = await fixture.rpc.getBlockNumberAsync()
 
-            const tx = await governor.stage(
+            const tx = governor.stage(
                 update,
                 "5"
             )
 
-            assert.equal((await governor.updates(updateHash)).toNumber(), blockNum + 5 + 1) // + 1 because stage() mines a block
 
-            expect(tx).to.emit(governor, "UpdateStaged").withArgs(
+            await expect(tx).to.emit(governor, "UpdateStaged").withArgs(
                 [...update],
                 5
             )
+            assert.equal((await governor.updates(updateHash)).toNumber(), blockNum + 5 + 1) // + 1 because stage() mines a block
         })
     })
 
@@ -333,23 +333,23 @@ describe("Governor", () => {
             const updateHash = getUpdateHash(update)
             const blockNum = await fixture.rpc.getBlockNumberAsync()
 
-            let tx = await governor.stage(
+            let tx = governor.stage(
                 update,
                 "5"
             )
 
-            assert.equal((await governor.updates(updateHash)).toNumber(), blockNum + 5 + 1) // + 1 because stage() mines a block
-            expect(tx).to.emit(governor, "UpdateStaged").withArgs(
+            await expect(tx).to.emit(governor, "UpdateStaged").withArgs(
                 [...update], 5
             )
+            assert.equal((await governor.updates(updateHash)).toNumber(), blockNum + 5 + 1) // + 1 because stage() mines a block
 
-            tx = await governor.cancel(update)
+            tx = governor.cancel(update)
 
-            assert.equal((await governor.updates(updateHash)).toNumber(), 0)
 
-            expect(tx).to.emit(governor, "UpdateCancelled").withArgs(
+            await expect(tx).to.emit(governor, "UpdateCancelled").withArgs(
                 [...update]
             )
+            assert.equal((await governor.updates(updateHash)).toNumber(), 0)
         })
     })
 
@@ -406,23 +406,22 @@ describe("Governor", () => {
             const updateHash = getUpdateHash(update)
             const blockNum = await fixture.rpc.getBlockNumberAsync()
 
-            let tx = await governor.stage(
+            let tx = governor.stage(
                 update,
                 "5"
             )
 
-            assert.equal((await governor.updates(updateHash)).toNumber(), blockNum + 5 + 1) // + 1 because stage() mines a block
-            expect(tx).to.emit(governor, "UpdateStaged").withArgs(
+            await expect(tx).to.emit(governor, "UpdateStaged").withArgs(
                 [...update], 5
             )
+            assert.equal((await governor.updates(updateHash)).toNumber(), blockNum + 5 + 1) // + 1 because stage() mines a block
 
-            tx = await governor.cancel(update)
+            tx = governor.cancel(update)
 
-            assert.equal((await governor.updates(updateHash)).toNumber(), 0)
-
-            expect(tx).to.emit(governor, "UpdateCancelled").withArgs(
+            await expect(tx).to.emit(governor, "UpdateCancelled").withArgs(
                 [...update]
             )
+            assert.equal((await governor.updates(updateHash)).toNumber(), 0)
         })
     })
 
@@ -518,13 +517,13 @@ describe("Governor", () => {
 
             await fixture.rpc.wait(100)
 
-            const tx = await governor.connect(signers[0]).execute(update, {value: BigNumber.from("1000")})
+            const tx = governor.connect(signers[0]).execute(update, {value: BigNumber.from("1000")})
 
-            assert.equal((await governor.updates(updateHash)).toNumber(), 0)
 
-            expect(tx).to.emit(governor, "UpdateExecuted").withArgs(
+            await expect(tx).to.emit(governor, "UpdateExecuted").withArgs(
                 [...update]
             )
+            assert.equal((await governor.updates(updateHash)).toNumber(), 0)
 
             // check that ETH balance of target is updated
             assert.equal((await web3.eth.getBalance(update.target[0])).toString(), update.value[0])
@@ -633,12 +632,12 @@ describe("Governor", () => {
 
             await fixture.rpc.wait(100)
 
-            const tx = await governor.execute(update)
+            const tx = governor.execute(update)
 
-            assert.equal((await governor.updates(updateHash)), 0)
-            expect(tx).to.emit(governor, "UpdateExecuted").withArgs(
+            await expect(tx).to.emit(governor, "UpdateExecuted").withArgs(
                 [...update]
             )
+            assert.equal((await governor.updates(updateHash)), 0)
         })
     })
 })

--- a/test/unit/Poll.js
+++ b/test/unit/Poll.js
@@ -37,10 +37,10 @@ describe("Poll", () => {
 
     describe("vote", () => {
         it("emit \"Vote\" event when poll is active", async () => {
-            let tx = await poll.vote(0)
-            expect(tx).to.emit(poll, "Vote").withArgs(signers[0].address, 0)
-            tx = await poll.connect(signers[1]).vote(1)
-            expect(tx).to.emit(poll, "Vote").withArgs(signers[1].address, 1)
+            let tx = poll.vote(0)
+            await expect(tx).to.emit(poll, "Vote").withArgs(signers[0].address, 0)
+            tx = poll.connect(signers[1]).vote(1)
+            await expect(tx).to.emit(poll, "Vote").withArgs(signers[1].address, 1)
         })
 
         it("revert when poll is inactive", async () => {

--- a/test/unit/PollCreator.js
+++ b/test/unit/PollCreator.js
@@ -56,7 +56,7 @@ describe("PollCreator", () => {
             const end = start + POLL_PERIOD + 1 // + 1 because createPoll tx will mine a new block
             const tx = await pollCreator.createPoll(hash)
             const receipt = await tx.wait()
-            expect(tx).to.emit(pollCreator, "PollCreated").withArgs(
+            await expect(tx.hash).to.emit(pollCreator, "PollCreated").withArgs(
                 receipt.events[0].args[0], hash, end, QUORUM, QUOTA
             )
         })

--- a/test/unit/RoundsManager.js
+++ b/test/unit/RoundsManager.js
@@ -214,7 +214,7 @@ describe("RoundsManager", () => {
             const tx = await roundsManager.initializeRound()
 
             const currentRound = await roundsManager.currentRound()
-            expect(tx).to.emit(roundsManager, "NewRound").withArgs(currentRound, blockHash)
+            await expect(tx).to.emit(roundsManager, "NewRound").withArgs(currentRound.toString(), blockHash)
         })
 
         it("emits a NewRound event with indexed round", async () => {

--- a/test/unit/ServiceRegistry.js
+++ b/test/unit/ServiceRegistry.js
@@ -46,8 +46,8 @@ describe("ServiceRegistry", () => {
         })
 
         it("fires ServiceURIUpdate event", async () => {
-            const tx = await registry.setServiceURI("foo")
-            expect(tx).to.emit(registry, "ServiceURIUpdate").withArgs(
+            const tx = registry.setServiceURI("foo")
+            await expect(tx).to.emit(registry, "ServiceURIUpdate").withArgs(
                 signers[0].address, "foo"
             )
         })

--- a/test/unit/StakingManager.test.ts
+++ b/test/unit/StakingManager.test.ts
@@ -116,8 +116,8 @@ describe("StakingManager", () => {
                 })
 
                 it("should fire a Bond event when bonding", async () => {
-                    const txRes = await stakingManager.connect(delegator0).bond(1000, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
-                    expect(txRes).to.emit(stakingManager, "Bond").withArgs(orchestrator0.address, delegator0.address, 1000, 1000)
+                    const txRes = stakingManager.connect(delegator0).bond(1000, orchestrator0.address, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS, constants.NULL_ADDRESS)
+                    await expect(txRes).to.emit(stakingManager, "Bond").withArgs(orchestrator0.address, delegator0.address, 1000, 1000)
                 })
 
                 it("delegator stakes funds to orchestrator on behalf of second delegator", async () => {

--- a/test/unit/TicketBroker.js
+++ b/test/unit/TicketBroker.js
@@ -163,8 +163,8 @@ describe("TicketBroker", () => {
         })
 
         it("emits a DepositFunded event", async () => {
-            const tx = await broker.fundDeposit({value: 1000})
-            expect(tx).to.emit(broker, "DepositFunded").withArgs(
+            const tx = broker.fundDeposit({value: 1000})
+            await expect(tx).to.emit(broker, "DepositFunded").withArgs(
                 sender, "1000"
             )
         })
@@ -304,9 +304,9 @@ describe("TicketBroker", () => {
         })
 
         it("emits a ReserveFunded event", async () => {
-            const tx = await broker.fundReserve({value: 1000})
+            const tx = broker.fundReserve({value: 1000})
 
-            expect(tx).to.emit(broker, "ReserveFunded").withArgs(sender, "1000")
+            await expect(tx).to.emit(broker, "ReserveFunded").withArgs(sender, "1000")
         })
 
         it("emits a ReserveFunded event with indexed sender", async () => {
@@ -718,9 +718,9 @@ describe("TicketBroker", () => {
                     const senderSig = await signMsg(getTicketHash(ticket), sender)
 
                     // There are no registered recipients so the recipients should not be able to claim
-                    const tx = await broker.connect(signers[1]).redeemWinningTicket(ticket, senderSig, recipientRand)
-                    expect(tx).to.emit(broker, "WinningTicketRedeemed")
-                    expect(tx).to.not.emit(broker, "ReserveClaimed")
+                    const tx = broker.connect(signers[1]).redeemWinningTicket(ticket, senderSig, recipientRand)
+                    await expect(tx).to.emit(broker, "WinningTicketRedeemed")
+                    await expect(tx).to.not.emit(broker, "ReserveClaimed")
                     assert.equal((await broker.claimedReserve(sender, recipient)).toString(), "0")
                 })
 
@@ -737,9 +737,9 @@ describe("TicketBroker", () => {
                     const senderSig = await signMsg(getTicketHash(ticket), sender)
 
                     // Recipient is not registered so it should not be able to claim from the reserve
-                    const tx = await broker.connect(signers[1]).redeemWinningTicket(ticket, senderSig, recipientRand)
-                    expect(tx).to.emit(broker, "WinningTicketRedeemed")
-                    expect(tx).to.not.emit(broker, "ReserveClaimed")
+                    const tx = broker.connect(signers[1]).redeemWinningTicket(ticket, senderSig, recipientRand)
+                    await expect(tx).to.emit(broker, "WinningTicketRedeemed")
+                    await expect(tx).to.not.emit(broker, "ReserveClaimed")
                     assert.equal((await broker.claimedReserve(sender, recipient)).toString(), "0")
                 })
 
@@ -765,9 +765,9 @@ describe("TicketBroker", () => {
                     const senderSig2 = await signMsg(getTicketHash(ticket2), sender)
 
                     // Should not claim anything because recipient has already claimed the max allocation
-                    const tx = await broker.connect(signers[1]).redeemWinningTicket(ticket2, senderSig2, recipientRand)
+                    const tx = broker.connect(signers[1]).redeemWinningTicket(ticket2, senderSig2, recipientRand)
 
-                    expect(tx).to.not.emit(broker, "ReserveClaimed")
+                    await expect(tx).to.not.emit(broker, "ReserveClaimed")
                 })
 
                 it("allows a partial claim for a registered recipient trying to claim an amount that would exceed the max allocation", async () => {
@@ -793,9 +793,9 @@ describe("TicketBroker", () => {
                     const senderSig2 = await signMsg(getTicketHash(ticket2), sender)
 
                     // Claim the remaining partialAmount
-                    const tx = await broker.connect(signers[1]).redeemWinningTicket(ticket2, senderSig2, recipientRand)
+                    const tx = broker.connect(signers[1]).redeemWinningTicket(ticket2, senderSig2, recipientRand)
 
-                    expect(tx).to.emit(broker, "ReserveClaimed").withArgs(sender, recipient, partialAmount)
+                    await expect(tx).to.emit(broker, "ReserveClaimed").withArgs(sender, recipient, partialAmount)
                 })
 
                 it("allows a claim from a registered recipient", async () => {
@@ -811,9 +811,9 @@ describe("TicketBroker", () => {
                     const ticket = createWinningTicket(recipient, sender, recipientRand, faceValue)
                     const senderSig = await signMsg(getTicketHash(ticket), sender)
 
-                    const tx = await broker.connect(signers[1]).redeemWinningTicket(ticket, senderSig, recipientRand)
+                    const tx = broker.connect(signers[1]).redeemWinningTicket(ticket, senderSig, recipientRand)
 
-                    expect(tx).to.emit(broker, "ReserveClaimed").withArgs(sender, recipient, ticket.faceValue.toString())
+                    await expect(tx).to.emit(broker, "ReserveClaimed").withArgs(sender, recipient, ticket.faceValue.toString())
 
                     // Check that fee pool in BondingManager is updated
                     const filter = await fixture.bondingManager.filters.UpdateTranscoderWithFees()
@@ -844,8 +844,8 @@ describe("TicketBroker", () => {
                     ticket2.senderNonce++
                     const senderSig2 = await signMsg(getTicketHash(ticket2), sender)
 
-                    const tx = await broker.connect(signers[1]).redeemWinningTicket(ticket2, senderSig2, recipientRand)
-                    expect(tx).to.emit(broker, "ReserveClaimed").withArgs(sender, recipient, ticket2.faceValue.toString())
+                    const tx = broker.connect(signers[1]).redeemWinningTicket(ticket2, senderSig2, recipientRand)
+                    await expect(tx).to.emit(broker, "ReserveClaimed").withArgs(sender, recipient, ticket2.faceValue.toString())
 
                     assert.equal((await broker.claimedReserve(sender, recipient)).toString(), (ticket.faceValue + ticket2.faceValue).toString())
                 })
@@ -868,9 +868,9 @@ describe("TicketBroker", () => {
                     const ticket2 = createWinningTicket(recipient2.address, sender, recipientRand, faceValue + 15)
                     const senderSig2 = await signMsg(getTicketHash(ticket2), sender)
 
-                    const tx = await broker.connect(recipient2).redeemWinningTicket(ticket2, senderSig2, recipientRand)
+                    const tx = broker.connect(recipient2).redeemWinningTicket(ticket2, senderSig2, recipientRand)
 
-                    expect(tx).to.emit(broker, "ReserveClaimed").withArgs(sender, recipient2.address, ticket2.faceValue.toString())
+                    await expect(tx).to.emit(broker, "ReserveClaimed").withArgs(sender, recipient2.address, ticket2.faceValue.toString())
 
                     assert.equal((await broker.claimedReserve(sender, recipient)).toString(), ticket.faceValue.toString())
                     assert.equal((await broker.claimedReserve(sender, recipient2.address)).toString(), ticket2.faceValue.toString())
@@ -993,10 +993,10 @@ describe("TicketBroker", () => {
             const senderSig = await signMsg(getTicketHash(ticket), sender)
 
             // Redeem with ticket faceValue = 0
-            const tx = await broker.connect(signers[1]).redeemWinningTicket(ticket, senderSig, recipientRand)
+            const tx = broker.connect(signers[1]).redeemWinningTicket(ticket, senderSig, recipientRand)
 
-            expect(tx).to.not.emit(broker, "WinningTicketTransfer")
-            expect(tx).to.not.emit(fixture.bondingManager, "UpdateTranscoderWithFees")
+            await expect(tx).to.not.emit(broker, "WinningTicketTransfer")
+            await expect(tx).to.not.emit(fixture.bondingManager, "UpdateTranscoderWithFees")
             const endDeposit = (await broker.getSenderInfo(sender)).sender.deposit.toString()
             assert.equal(endDeposit, deposit)
         })
@@ -1081,8 +1081,8 @@ describe("TicketBroker", () => {
             const ticket = createWinningTicket(recipient, sender, recipientRand, faceValue)
             const senderSig = await signMsg(getTicketHash(ticket), sender)
 
-            const tx = await broker.connect(signers[1]).redeemWinningTicket(ticket, senderSig, recipientRand)
-            expect(tx).to.emit(broker, "WinningTicketRedeemed").withArgs(
+            const tx = broker.connect(signers[1]).redeemWinningTicket(ticket, senderSig, recipientRand)
+            await expect(tx).to.emit(broker, "WinningTicketRedeemed").withArgs(
                 sender, recipient, ticket.faceValue.toString(), ticket.winProb.toString(), ticket.senderNonce.toString(), recipientRand.toString(), ticket.auxData
             )
         })
@@ -1307,13 +1307,13 @@ describe("TicketBroker", () => {
             const senderSig = await signMsg(getTicketHash(ticket), sender)
             const senderSig2 = await signMsg(getTicketHash(ticket2), sender)
 
-            const tx = await broker.connect(signers[1]).batchRedeemWinningTickets(
+            const tx = broker.connect(signers[1]).batchRedeemWinningTickets(
                 [ticket, ticket2],
                 [senderSig, senderSig2],
                 [recipientRand, recipientRand]
             )
 
-            expect(tx).to.not.emit(broker, "WinningTicketRedeemed")
+            await expect(tx).to.not.emit(broker, "WinningTicketRedeemed")
         })
     })
 
@@ -1370,9 +1370,9 @@ describe("TicketBroker", () => {
             const expectedStartRound = currentRound
             const expectedEndRound = expectedStartRound + unlockPeriod
 
-            const tx = await broker.unlock()
+            const tx = broker.unlock()
 
-            expect(tx).to.emit(broker, "Unlock").withArgs(sender, expectedStartRound.toString(), expectedEndRound.toString())
+            await expect(tx).to.emit(broker, "Unlock").withArgs(sender, expectedStartRound.toString(), expectedEndRound.toString())
         })
 
         it("emits an Unlock event indexed by sender", async () => {
@@ -1425,9 +1425,9 @@ describe("TicketBroker", () => {
             await broker.fundDeposit({value: 1000})
             await broker.unlock()
 
-            const tx = await broker.cancelUnlock()
+            const tx = broker.cancelUnlock()
 
-            expect(tx).to.emit(broker, "UnlockCancelled").withArgs(sender)
+            await expect(tx).to.emit(broker, "UnlockCancelled").withArgs(sender)
         })
 
         it("emits an UnlockCancelled event with an indexed sender", async () => {
@@ -1552,9 +1552,9 @@ describe("TicketBroker", () => {
             await broker.unlock()
             await fixture.roundsManager.setMockUint256(functionSig("currentRound()"), currentRound + unlockPeriod)
 
-            const tx = await broker.withdraw()
+            const tx = broker.withdraw()
 
-            expect(tx).to.emit(broker, "Withdrawal").withArgs(sender, deposit.toString(), reserve.toString())
+            await expect(tx).to.emit(broker, "Withdrawal").withArgs(sender, deposit.toString(), reserve.toString())
         })
 
         it("emits a Withdrawal event with indexed sender", async () => {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
The `expect.to.emit` accepts any kind of tx state as argument - tx promise, resolved tx, or even tx hash. [Internally](https://github.com/EthWorks/Waffle/blob/master/waffle-chai/src/matchers/misc/transaction.ts) it actually waits for the tx to resolve if not already resolved and uses the transaction hash to check for events (also eliminating the need to do tx.wait after the event check). 

In the [official waffle docs](https://ethereum-waffle.readthedocs.io/en/latest/matchers.html#emitting-events) and also in it's [own test suite](https://github.com/EthWorks/Waffle/blob/f35373d822aa85bd99e08ec0bea367188b132433/waffle-chai/test/matchers/events.test.ts) the following pattern is used. 

```javascript
const tx = Contract.method() // tx promise i.e no await
await expect(tx).to.emit("Event")
```
`await` is used with `emit()` as it uses [promises inside itself](https://github.com/EthWorks/Waffle/blob/master/waffle-chai/src/matchers/emit.ts#L9-L18). For https://github.com/livepeer/protocol/pull/475#discussion_r710460706 I guess it is now okay to say that the issue was caused due to missing `await` before expect

other test suites in projects like [uniswap v3 tests](https://github.com/Uniswap/v3-core/blob/b2c5555d696428c40c4b236069b3528b2317f3c1/test/UniswapV3Pool.spec.ts#L1203-L1205) and [graph protocol tests](https://github.com/graphprotocol/contracts/blob/f09f9dea65852dc3a74671135d3caedea2db024d/test/graphToken.test.ts#L123-L124) also follow the same pattern. 

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
The tests were updated to follow the same common pattern except in cases where the tx receipt is needed to get additional data like "cumulativeGasUsed" like [PoolUpdatesWithHints test case](https://github.com/livepeer/protocol/blob/kk/test-anomaly/test/integration/PoolUpdatesWithHints.js#L158-L162) and [PollCreator test case](https://github.com/livepeer/protocol/blob/kk/test-anomaly/test/unit/PollCreator.js#L57-L60) the transaction is resolved first, the tx receipt is extracted from the tx and then `tx.hash` is passed to the emit assertion.

**Does this pull request close any open issues?**
<!-- Fixes # -->
closes #476 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
