### PR TITLE
pm: Add fundDepositAndReserveFor() in TicketBroker

### DIFF
--- a/contracts/pm/mixins/MixinTicketBrokerCore.sol
+++ b/contracts/pm/mixins/MixinTicketBrokerCore.sol
@@ -79,13 +79,26 @@ contract MixinTicketBrokerCore is MContractRegistry, MReserve, MTicketProcessor,
      * @param _depositAmount Amount of ETH to add to the caller's deposit
      * @param _reserveAmount Amount of ETH to add to the caller's reserve
      */
-    function fundDepositAndReserve(uint256 _depositAmount, uint256 _reserveAmount)
-        external
+    function fundDepositAndReserve(uint256 _depositAmount, uint256 _reserveAmount) external payable {
+        fundDepositAndReserveFor(msg.sender, _depositAmount, _reserveAmount);
+    }
+
+    /**
+     * @notice Adds ETH to the address' deposit and reserve
+     * @param _depositAmount Amount of ETH to add to the address' deposit
+     * @param _reserveAmount Amount of ETH to add to the address' reserve
+     */
+    function fundDepositAndReserveFor(
+        address _addr,
+        uint256 _depositAmount,
+        uint256 _reserveAmount
+    )
+        public
         payable
         whenSystemNotPaused
         checkDepositReserveETHValueSplit(_depositAmount, _reserveAmount)
-        processDeposit(msg.sender, _depositAmount)
-        processReserve(msg.sender, _reserveAmount)
+        processDeposit(_addr, _depositAmount)
+        processReserve(_addr, _reserveAmount)
     {
         processFunding(msg.value);
     }

--- a/test/unit/TicketBroker.js
+++ b/test/unit/TicketBroker.js
@@ -26,6 +26,7 @@ describe("TicketBroker", () => {
     let signers
     let sender
     let recipient
+    let funder
 
     const unlockPeriod = 20
     const ticketValidityPeriod = 2
@@ -36,6 +37,7 @@ describe("TicketBroker", () => {
         signers = await ethers.getSigners()
         sender = signers[0].address
         recipient = signers[1].address
+        funder = signers[3]
         fixture = new Fixture(web3)
         await fixture.deploy()
 
@@ -471,6 +473,66 @@ describe("TicketBroker", () => {
                 (await broker.getSenderInfo(sender)).reserve.fundsRemaining.toString(),
                 (remainingReserve + additionalFunds).toString()
             )
+        })
+    })
+
+    describe("fundDepositAndReserveFor", () => {
+        it("should fail if the system is paused", async () => {
+            const deposit = 500
+            const reserve = 1000
+            await fixture.controller.pause()
+            await expect(
+                broker.connect(funder).fundDepositAndReserveFor(sender, deposit, reserve, {value: 1000})
+            ).to.be.revertedWith("system is paused")
+        })
+
+        it("reverts if msg.value < sum of deposit amount and reserve amount", async () => {
+            const deposit = 500
+            const reserve = 1000
+
+            await expect(
+                broker.connect(funder).fundDepositAndReserveFor(
+                    sender,
+                    deposit,
+                    reserve,
+                    {value: deposit + reserve - 1}
+                )
+            ).to.be.revertedWith("msg.value does not equal sum of deposit amount and reserve amount")
+        })
+
+        it("reverts if msg.value > sum of deposit amount and reserve amount", async () => {
+            const deposit = 500
+            const reserve = 1000
+
+            await expect(
+                broker.connect(funder).fundDepositAndReserveFor(
+                    sender,
+                    deposit,
+                    reserve,
+                    {value: deposit + reserve + 1}
+                )
+            ).to.be.revertedWith("msg.value does not equal sum of deposit amount and reserve amount")
+        })
+
+        it("updates deposit and reserve for specified address", async () => {
+            const deposit = 500
+            const reserve = 1000
+
+            expect(funder.address).to.not.equal(sender)
+
+            const tx = await broker.connect(funder).fundDepositAndReserveFor(
+                sender,
+                deposit,
+                reserve,
+                {value: deposit + reserve}
+            )
+
+            const endSenderInfo = await broker.getSenderInfo(sender)
+            expect(endSenderInfo.sender.deposit).to.be.equal(deposit)
+            expect(endSenderInfo.reserve.fundsRemaining).to.be.equal(reserve)
+
+            expect(tx).to.changeEtherBalance(funder, -(deposit + reserve))
+            expect(tx).to.changeEtherBalance(fixture.minter, deposit + reserve)
         })
     })
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds a `fundDepositAndReserveFor()` function to the TicketBroker. This function contains the same logic as `fundDepositAndReserve()` except it uses the msg.value provided by msg.sender to fund the deposit and reserve for the specified address. This function is required for finalizing the migration on L2 for a TicketBroker sender with a deposit and reserve on L1 [1].

[1] See https://github.com/livepeer/arbitrum-lpt-bridge/pull/30

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Added `fundDepositAndReserveFor()` in TicketBroker
- Refactored `fundDepositAndReserve()` in TicketBroker to use `fundDepositAndReserveFor()` under the hood

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #502 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
