### PR TITLE
rounds: Freeze initialization at LIP-73 round

### DIFF
--- a/contracts/rounds/RoundsManager.sol
+++ b/contracts/rounds/RoundsManager.sol
@@ -89,6 +89,9 @@ contract RoundsManager is ManagerProxyTarget, IRoundsManager {
     function initializeRound() external whenSystemNotPaused {
         uint256 currRound = currentRound();
 
+        uint256 lip73Round = lipUpgradeRound[73];
+        require(lip73Round == 0 || currRound < lip73Round, "cannot initialize past LIP-73 round");
+
         // Check if already called for the current round
         require(lastInitializedRound < currRound, "round already initialized");
 

--- a/test/unit/RoundsManager.js
+++ b/test/unit/RoundsManager.js
@@ -382,6 +382,39 @@ describe("RoundsManager", () => {
             )
         })
 
+        it("should fail if current round == LIP-73 round", async () => {
+            const currRound = await roundsManager.currentRound()
+            const lip73Round = currRound.add(1)
+            await roundsManager.setLIPUpgradeRound(73, lip73Round)
+
+            const roundLength = await roundsManager.roundLength()
+            await fixture.rpc.waitUntilNextBlockMultiple(roundLength.toNumber())
+
+            expect(await roundsManager.currentRound()).to.be.equal(lip73Round)
+            await expect(roundsManager.initializeRound()).to.be.revertedWith(
+                "cannot initialize past LIP-73 round"
+            )
+        })
+
+        it("should fail if current round > LIP-73 round", async () => {
+            const currRound = await roundsManager.currentRound()
+            const lip73Round = currRound.add(1)
+            await roundsManager.setLIPUpgradeRound(73, lip73Round)
+
+            const roundLength = await roundsManager.roundLength()
+            await fixture.rpc.waitUntilNextBlockMultiple(
+                roundLength.toNumber(),
+                2
+            )
+
+            expect(await roundsManager.currentRound()).to.be.equal(
+                lip73Round.add(1)
+            )
+            await expect(roundsManager.initializeRound()).to.be.revertedWith(
+                "cannot initialize past LIP-73 round"
+            )
+        })
+
         it("should fail if current round is already initialized", async () => {
             const roundLength = await roundsManager.roundLength()
             await fixture.rpc.waitUntilNextBlockMultiple(roundLength.toNumber())


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds a require statement in `RoundsManager.initializeRound()` that checks if the LIP-73 round is set *and* that the current round is before the LIP-73 round. Otherwise, the function will revert. This feature allows state updates to the L1 contracts during the Confluence upgrade to be frozen since all functions that support state updates for users should have the `currentRoundInitialized` modifier that prevents those functions from being called if the current round is not initialized.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #504 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
