### PR TITLE
Read l1CirculatingSupply in L2 Minter for bonding rate calculation

### DIFF
--- a/test/gas-report/poolsize.js
+++ b/test/gas-report/poolsize.js
@@ -1,5 +1,6 @@
 import RPC from "../../utils/rpc"
 import {web3, ethers} from "hardhat"
+import setupIntegrationTest from "../helpers/setupIntegrationTest"
 
 import chai from "chai"
 import {solidity} from "ethereum-waffle"
@@ -41,7 +42,7 @@ describe("transcoder pool size gas report", () => {
     before(async () => {
         rpc = new RPC(web3)
 
-        const fixture = await deployments.fixture(["Contracts"])
+        const fixture = await setupIntegrationTest()
         controller = await ethers.getContractAt(
             "Controller",
             fixture.Controller.address

--- a/test/gas-report/redeemTicket.js
+++ b/test/gas-report/redeemTicket.js
@@ -7,7 +7,8 @@ import {
 } from "../helpers/ticket"
 import signMsg from "../helpers/signMsg"
 
-import {deployments, ethers} from "hardhat"
+import {ethers} from "hardhat"
+import setupIntegrationTest from "../helpers/setupIntegrationTest"
 
 import chai from "chai"
 import {solidity} from "ethereum-waffle"
@@ -38,7 +39,7 @@ describe("redeem ticket gas report", () => {
         transcoder = signers[0]
         broadcaster = signers[1]
 
-        const fixture = await deployments.fixture(["Contracts"])
+        const fixture = await setupIntegrationTest()
         controller = await ethers.getContractAt(
             "Controller",
             fixture.Controller.address

--- a/test/helpers/math.js
+++ b/test/helpers/math.js
@@ -21,6 +21,15 @@ const precise = {
     }
 }
 
+const v2 = {
+    percPoints: (a, b) => {
+        return _percPoints(a, b, constants.PERC_DIVISOR_V2)
+    },
+    percOf: (a, b, c) => {
+        return _percOf(a, b, c, constants.PERC_DIVISOR_V2)
+    }
+}
+
 const _percPoints = (a, b, percDivisor) => {
     return a.mul(percDivisor).div(b)
 }
@@ -32,5 +41,6 @@ const _percOf = (a, b, c, percDivisor) => {
 module.exports = {
     percPoints,
     percOf,
-    precise
+    precise,
+    v2
 }

--- a/test/helpers/setupIntegrationTest.ts
+++ b/test/helpers/setupIntegrationTest.ts
@@ -1,0 +1,36 @@
+import {deployments} from "hardhat"
+import {GenericMock__factory} from "../../typechain"
+import {contractId} from "../../utils/helpers"
+
+const setupIntegrationTest = deployments.createFixture(
+    async ({deployments, getNamedAccounts, ethers}) => {
+        const fixture = await deployments.fixture(["Contracts"])
+        const {deployer} = await getNamedAccounts()
+        const signer = await ethers.getSigner(deployer)
+
+        const controller = await ethers.getContractAt(
+            "Controller",
+            fixture.Controller.address
+        )
+
+        const GenericMock: GenericMock__factory =
+            await ethers.getContractFactory("GenericMock")
+        const mock = await GenericMock.deploy()
+
+        const info = await controller.getContractInfo(
+            contractId("BondingManager")
+        )
+        const gitCommitHash = info[1]
+        await controller
+            .connect(signer)
+            .setContractInfo(
+                contractId("L2LPTDataCache"),
+                mock.address,
+                gitCommitHash
+            )
+
+        return fixture
+    }
+)
+
+module.exports = setupIntegrationTest

--- a/test/integration/BroadcasterWithdrawalFlow.js
+++ b/test/integration/BroadcasterWithdrawalFlow.js
@@ -1,6 +1,7 @@
 import calcTxCost from "../helpers/calcTxCost"
 
-import {deployments, ethers} from "hardhat"
+import {ethers} from "hardhat"
+import setupIntegrationTest from "../helpers/setupIntegrationTest"
 
 import chai, {expect} from "chai"
 import {solidity} from "ethereum-waffle"
@@ -19,7 +20,7 @@ describe("BroadcasterWithdrawalFlow", () => {
     before(async () => {
         signers = await ethers.getSigners()
         broadcaster = signers[0].address
-        const fixture = await deployments.fixture(["Contracts"])
+        const fixture = await setupIntegrationTest()
         broker = await ethers.getContractAt(
             "TicketBroker",
             fixture.TicketBroker.address

--- a/test/integration/Delegation.js
+++ b/test/integration/Delegation.js
@@ -1,5 +1,6 @@
 import {constants} from "../../utils/constants"
-import {deployments, ethers} from "hardhat"
+import {ethers} from "hardhat"
+import setupIntegrationTest from "../helpers/setupIntegrationTest"
 import {BigNumber} from "ethers"
 import chai, {expect, assert} from "chai"
 import {solidity} from "ethereum-waffle"
@@ -29,7 +30,7 @@ describe("Delegation", () => {
         transcoder2 = signers[1]
         delegator1 = signers[2]
         delegator2 = signers[3]
-        const fixture = await deployments.fixture(["Contracts"])
+        const fixture = await setupIntegrationTest()
         controller = await ethers.getContractAt(
             "Controller",
             fixture.Controller.address

--- a/test/integration/Earnings.js
+++ b/test/integration/Earnings.js
@@ -3,7 +3,8 @@ import {createWinningTicket, getTicketHash} from "../helpers/ticket"
 import signMsg from "../helpers/signMsg"
 import math from "../helpers/math"
 
-import {deployments, ethers} from "hardhat"
+import {ethers} from "hardhat"
+import setupIntegrationTest from "../helpers/setupIntegrationTest"
 
 import chai, {assert, expect} from "chai"
 import {solidity} from "ethereum-waffle"
@@ -67,7 +68,7 @@ describe("Earnings", () => {
         delegator = signers[2]
         transcoder2 = signers[3]
 
-        const fixture = await deployments.fixture(["Contracts"])
+        const fixture = await setupIntegrationTest()
         controller = await ethers.getContractAt(
             "Controller",
             fixture.Controller.address

--- a/test/integration/GovernorUpdate.js
+++ b/test/integration/GovernorUpdate.js
@@ -1,6 +1,7 @@
 import {contractId} from "../../utils/helpers"
 
-import {deployments, ethers} from "hardhat"
+import {ethers} from "hardhat"
+import setupIntegrationTest from "../helpers/setupIntegrationTest"
 
 import chai, {assert, expect} from "chai"
 import {solidity} from "ethereum-waffle"
@@ -16,7 +17,7 @@ describe("Governor update", () => {
 
     before(async () => {
         signers = await ethers.getSigners()
-        const fixture = await deployments.fixture(["Contracts"])
+        const fixture = await setupIntegrationTest()
         controller = await ethers.getContractAt(
             "Controller",
             fixture.Controller.address

--- a/test/integration/MinterUpgrade.js
+++ b/test/integration/MinterUpgrade.js
@@ -1,5 +1,6 @@
 import {contractId} from "../../utils/helpers"
-import {deployments, ethers} from "hardhat"
+import {ethers} from "hardhat"
+import setupIntegrationTest from "../helpers/setupIntegrationTest"
 
 import chai, {assert, expect} from "chai"
 import {solidity} from "ethereum-waffle"
@@ -57,7 +58,7 @@ describe("MinterUpgrade", () => {
         broadcaster1 = signers[2]
         broadcaster2 = signers[3]
 
-        const fixture = await deployments.fixture(["Contracts"])
+        const fixture = await setupIntegrationTest()
 
         controller = await ethers.getContractAt(
             "Controller",

--- a/test/integration/PoolUpdatesWithHints.js
+++ b/test/integration/PoolUpdatesWithHints.js
@@ -1,7 +1,9 @@
 import RPC from "../../utils/rpc"
-import {deployments, ethers} from "hardhat"
+import {ethers} from "hardhat"
 import chai, {assert, expect} from "chai"
 import {solidity} from "ethereum-waffle"
+import setupIntegrationTest from "../helpers/setupIntegrationTest"
+
 chai.use(solidity)
 
 describe("PoolUpdatesWithHints", () => {
@@ -80,7 +82,7 @@ describe("PoolUpdatesWithHints", () => {
         newTranscoder = signers[12]
         rpc = new RPC(web3)
 
-        const fixture = await deployments.fixture(["Contracts"])
+        const fixture = await setupIntegrationTest()
         controller = await ethers.getContractAt(
             "Controller",
             fixture.Controller.address

--- a/test/integration/Rewards.js
+++ b/test/integration/Rewards.js
@@ -4,6 +4,7 @@ import math from "../helpers/math"
 import chai, {expect} from "chai"
 import {solidity} from "ethereum-waffle"
 import {ethers} from "hardhat"
+import setupIntegrationTest from "../helpers/setupIntegrationTest"
 
 chai.use(solidity)
 
@@ -35,7 +36,7 @@ describe("Rewards", () => {
         delegator2 = signers[3]
         delegator3 = signers[4]
 
-        const fixture = await deployments.fixture(["Contracts"])
+        const fixture = await setupIntegrationTest()
 
         controller = await ethers.getContractAt(
             "Controller",

--- a/test/integration/RoundInitialization.js
+++ b/test/integration/RoundInitialization.js
@@ -3,6 +3,7 @@ import {constants} from "../../utils/constants"
 import chai, {expect} from "chai"
 import {solidity} from "ethereum-waffle"
 import {ethers} from "hardhat"
+import setupIntegrationTest from "../helpers/setupIntegrationTest"
 
 chai.use(solidity)
 
@@ -41,7 +42,7 @@ describe("RoundInitialization", () => {
     before(async () => {
         signers = await ethers.getSigners()
 
-        const fixture = await deployments.fixture(["Contracts"])
+        const fixture = await setupIntegrationTest()
 
         controller = await ethers.getContractAt(
             "Controller",

--- a/test/integration/SystemPause.js
+++ b/test/integration/SystemPause.js
@@ -3,6 +3,8 @@ import {constants} from "../../utils/constants"
 import chai, {assert, expect} from "chai"
 import {solidity} from "ethereum-waffle"
 import {ethers} from "hardhat"
+import setupIntegrationTest from "../helpers/setupIntegrationTest"
+
 chai.use(solidity)
 
 describe("System Pause", () => {
@@ -24,7 +26,7 @@ describe("System Pause", () => {
         delegator1 = signers[2]
         delegator2 = signers[3]
 
-        const fixture = await deployments.fixture(["Contracts"])
+        const fixture = await setupIntegrationTest()
 
         controller = await ethers.getContractAt(
             "Controller",

--- a/test/integration/TicketFlow.js
+++ b/test/integration/TicketFlow.js
@@ -5,6 +5,7 @@ import signMsg from "../helpers/signMsg"
 import chai, {expect} from "chai"
 import {solidity} from "ethereum-waffle"
 import {ethers} from "hardhat"
+import setupIntegrationTest from "../helpers/setupIntegrationTest"
 
 chai.use(solidity)
 
@@ -26,7 +27,7 @@ describe("TicketFlow", () => {
         transcoder = signers[0]
         broadcaster = signers[1]
 
-        const fixture = await deployments.fixture(["Contracts"])
+        const fixture = await setupIntegrationTest()
 
         broker = await ethers.getContractAt(
             "TicketBroker",

--- a/test/integration/TicketFrontRun.js
+++ b/test/integration/TicketFrontRun.js
@@ -4,7 +4,8 @@ import signMsg from "../helpers/signMsg"
 
 import chai, {assert, expect} from "chai"
 import {solidity} from "ethereum-waffle"
-import {deployments, ethers} from "hardhat"
+import {ethers} from "hardhat"
+import setupIntegrationTest from "../helpers/setupIntegrationTest"
 
 chai.use(solidity)
 
@@ -64,7 +65,7 @@ describe("TicketFrontRun", () => {
 
         honestTranscoder = otherAccounts[0]
 
-        const fixture = await deployments.fixture(["Contracts"])
+        const fixture = await setupIntegrationTest()
 
         controller = await ethers.getContractAt(
             "Controller",

--- a/test/unit/helpers/Fixture.js
+++ b/test/unit/helpers/Fixture.js
@@ -50,6 +50,10 @@ export default class Fixture {
         // aware of the TicketBroker contract ID and it will only be aware of the JobsManager contract ID
         await this.register("JobsManager", this.ticketBroker.address)
         this.verifier = await this.deployAndRegister(GenericMock, "Verifier")
+        this.l2LPTDataCache = await this.deployAndRegister(
+            GenericMock,
+            "L2LPTDataCache"
+        )
     }
 
     async register(name, addr) {

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -7,6 +7,7 @@ export const constants = {
     PERC_DIVISOR: 1000000,
     PERC_MULTIPLIER: 10000,
     PERC_DIVISOR_PRECISE: BigNumber.from(10).pow(27),
+    PERC_DIVISOR_V2: BigNumber.from(1000000000),
     RESCALE_FACTOR: BigNumber.from(10).pow(21),
     MAX_UINT256: ethers.constants.MaxUint256,
     DelegatorStatus: {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR updates the Minter (which will be deployed on L2 since this on the `confluence` branch track) to read the L1 circulating supply from a L2LPTDataCache contract (implemented in https://github.com/livepeer/arbitrum-lpt-bridge/pull/41) when calculating the bonding rate (i.e. participation rate). The L1 circulating supply is added to the L2 LPT total supply in order to calculate the global total supply across L1 and L2.

Refer to https://github.com/livepeer/arbitrum-lpt-bridge/pull/41 for details on how the L1 circulating supply is calculated by the L2LPTDataCache.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updated the Minter and its unit tests
- Updated the integration tests in 914bf9fcb1c3f5ca296f39d7e4a8bfe32582a369 to use a `setupIntegrationTest()` function to create a fixture. The new function loads the deployment fixture that was previously being used and then registers a GenericMock contract as the L2LPTDataCache with the Controller. This was required to fix integration tests since the Minter will call the contract that is registered as the L2LPTDataCache whenever a round is initialized.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated unit tests and fixed integration tests. 

An integration test where the L2LPTDataCache is not stubbed with a GenericMock contract is left to be addressed separately.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #501 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
