### PR TITLE
Add ArbitrumLivepeerToken for Rinkeby testnet

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -9,5 +9,6 @@ module.exports = {
         "rounds/AdjustableRoundsManager.sol",
         "pm/mixins/interfaces",
         "bonding/deprecated",
+        "token/ArbitrumLivepeerToken.sol" // testnet only
     ],
 };

--- a/contracts/token/ArbitrumLivepeerToken.sol
+++ b/contracts/token/ArbitrumLivepeerToken.sol
@@ -1,0 +1,63 @@
+pragma solidity ^0.5.11;
+
+import "./LivepeerToken.sol";
+
+interface IL1GatewayRouter {
+    function setGateway(
+        address _gateway,
+        uint256 _maxGas,
+        uint256 _gasPriceBid,
+        uint256 _maxSubmissionCost,
+        address _creditBackAddress
+    ) external payable;
+}
+
+// Based off of https://github.com/OffchainLabs/arbitrum/blob/master/packages/arb-bridge-peripherals/contracts/tokenbridge/test/TestCustomTokenL1.sol
+// TESTNET ONLY
+contract ArbitrumLivepeerToken is LivepeerToken {
+    address public routerAdmin;
+    address public router;
+
+    bool private shouldRegisterGateway;
+
+    modifier onlyRouterAdmin() {
+        require(msg.sender == routerAdmin, "NOT_ROUTER_ADMIN");
+        _;
+    }
+
+    constructor(address _router) public {
+        router = _router;
+        routerAdmin = msg.sender;
+    }
+
+    function setRouterAdmin(address _routerAdmin) external onlyRouterAdmin {
+        routerAdmin = _routerAdmin;
+    }
+
+    function registerGatewayWithRouter(
+        address _gateway,
+        uint256 _maxGas,
+        uint256 _gasPriceBid,
+        uint256 _maxSubmissionCost,
+        address _creditBackAddress
+    ) external payable onlyRouterAdmin {
+        // we temporarily set `shouldRegisterGateway` to true for the callback in setGateway() to succeed
+        bool prev = shouldRegisterGateway;
+        shouldRegisterGateway = true;
+
+        IL1GatewayRouter(router).setGateway.value(msg.value)(
+            _gateway,
+            _maxGas,
+            _gasPriceBid,
+            _maxSubmissionCost,
+            _creditBackAddress
+        );
+
+        shouldRegisterGateway = prev;
+    }
+
+    function isArbitrumEnabled() external view returns (uint8) {
+        require(shouldRegisterGateway, "NOT_EXPECTED_CALL");
+        return uint8(0xa4b1);
+    }
+}

--- a/deploy/deploy_contracts.ts
+++ b/deploy/deploy_contracts.ts
@@ -20,11 +20,22 @@ const func: DeployFunction = async function(hre: HardhatRuntimeEnvironment) {
 
     const Controller: Controller = await contractDeployer.deployController()
 
-    const livepeerToken = await contractDeployer.deployAndRegister({
-        contract: "LivepeerToken",
-        name: "LivepeerToken",
-        args: []
-    })
+    let livepeerToken
+    if (hre.network.name === "rinkeby") {
+        livepeerToken = await contractDeployer.deployAndRegister({
+            contract: "ArbitrumLivepeerToken",
+            name: "LivepeerToken",
+            args: [
+                config.rinkeby.arbitrumLivepeerToken.router
+            ]
+        })
+    } else {
+        livepeerToken = await contractDeployer.deployAndRegister({
+            contract: "LivepeerToken",
+            name: "LivepeerToken",
+            args: []
+        })
+    }
 
     const minter = await contractDeployer.deployAndRegister({
         contract: "Minter",

--- a/deploy/migrations.config.ts
+++ b/deploy/migrations.config.ts
@@ -25,5 +25,10 @@ export default {
         inflation: 137,
         inflationChange: 3,
         targetBondingRate: 500000
+    },
+    rinkeby: {
+        arbitrumLivepeerToken: {
+            router: "0x70C143928eCfFaf9F5b406f7f4fC28Dc43d68380"
+        }
     }
 }

--- a/test/unit/ArbitrumLivepeerToken.ts
+++ b/test/unit/ArbitrumLivepeerToken.ts
@@ -1,0 +1,60 @@
+import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/dist/src/signers"
+import {FakeContract, smock} from "@defi-wonderland/smock"
+import {expect, use} from "chai"
+import {ethers} from "hardhat"
+import {
+    ArbitrumLivepeerToken,
+    ArbitrumLivepeerToken__factory
+} from "../../typechain"
+
+use(smock.matchers)
+
+describe("ArbitrumLivepeerToken", () => {
+    let token: ArbitrumLivepeerToken
+
+    let eoa: SignerWithAddress
+
+    let routerMock: FakeContract
+    let mockRouterEOA: SignerWithAddress
+    let mockGatewayEOA: SignerWithAddress
+
+    beforeEach(async () => {
+        ;[eoa, mockRouterEOA, mockGatewayEOA] = await ethers.getSigners()
+
+        const ArbitrumLivepeerToken: ArbitrumLivepeerToken__factory =
+            await ethers.getContractFactory("ArbitrumLivepeerToken")
+        token = await ArbitrumLivepeerToken.deploy(mockRouterEOA.address)
+
+        routerMock = await smock.fake("IL1GatewayRouter", {
+            address: mockRouterEOA.address
+        })
+    })
+
+    describe("registerGatewayWithRouter", () => {
+        it("calls setGateway() on the L1GatewayRouter", async () => {
+            const maxGas = 555
+            const gasPriceBid = 666
+            const maxSubmissionCost = 777
+            const creditBackAddr = eoa.address
+            const l1CallValue = 100
+
+            const tx = await token.registerGatewayWithRouter(
+                mockGatewayEOA.address,
+                maxGas,
+                gasPriceBid,
+                maxSubmissionCost,
+                creditBackAddr,
+                {value: l1CallValue}
+            )
+
+            expect(routerMock.setGateway).to.be.calledOnceWith(
+                mockGatewayEOA.address,
+                maxGas,
+                gasPriceBid,
+                maxSubmissionCost,
+                creditBackAddr
+            )
+            await expect(tx).to.changeEtherBalance(routerMock, l1CallValue)
+        })
+    })
+})


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds ArbitrumLivepeerToken which inherits from LivepeerToken and exposes additional functions required for registering the token's L1 gateway on Rinkeby with the L1GatewayRouter.

The contract supports:

- `isArbitrumEnabled()` is required since `L1GatewayRouter.setGateway()` will call that function when the token calls `registerGatewayWithRouter()`
- `registerGatewayWithRouter()` calls `L1GatewayRouter.setGateway()`
- Setting a "router admin" which is authorized to call `registerGatewayWithRouter()` to register the token's gateway with the L1GatewayRouter. The idea is that on testnet, the router admin can call this whenever it needs to register a new gateway if needed for testing

Resources:

- [Docs](https://developer.offchainlabs.com/docs/bridging_assets#the-arbitrum-generic-custom-gateway) - note that the generic custom gateway stuff isn't relevant since a custom gateway is being used for LPT, but the points about isArbitrumEnabled() are relevant
- [Example token implementation](https://github.com/OffchainLabs/arbitrum/blob/master/packages/arb-bridge-peripherals/contracts/tokenbridge/test/TestCustomTokenL1.sol)

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

- Added ArbitrumLivepeerToken
- Updated deploy script to use ArbitrumLivepeerToken on Rinkeby

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes livepeer/arbitrum-lpt-bridge#35

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
