### PR TITLE
polling: Use min stake in PollCreator

### DIFF
--- a/contracts/polling/PollCreator.sol
+++ b/contracts/polling/PollCreator.sol
@@ -30,15 +30,15 @@ contract PollCreator {
      * @param _proposal The IPFS multihash for the proposal.
      */
     function createPoll(bytes calldata _proposal) external {
-        uint256 endBlock = block.number + POLL_PERIOD;
-        Poll poll = new Poll(endBlock);
-
         require(
             // pendingStake() ignores the second arg
             bondingManager.pendingStake(msg.sender, 0) >= POLL_CREATION_COST ||
                 bondingManager.transcoderTotalStake(msg.sender) >= POLL_CREATION_COST,
             "PollCreator#createPoll: INSUFFICIENT_STAKE"
         );
+
+        uint256 endBlock = block.number + POLL_PERIOD;
+        Poll poll = new Poll(endBlock);
 
         emit PollCreated(address(poll), _proposal, endBlock, QUORUM, QUOTA);
     }

--- a/contracts/polling/PollCreator.sol
+++ b/contracts/polling/PollCreator.sol
@@ -1,7 +1,12 @@
 pragma solidity ^0.5.11;
 
 import "./Poll.sol";
-import "../token/ILivepeerToken.sol";
+
+interface IBondingManager {
+    function transcoderTotalStake(address _addr) external view returns (uint256);
+
+    function pendingStake(address _addr, uint256 _endRound) external view returns (uint256);
+}
 
 contract PollCreator {
     // 33.33%
@@ -12,26 +17,28 @@ contract PollCreator {
     uint256 public constant POLL_PERIOD = 10 * 5760;
     uint256 public constant POLL_CREATION_COST = 100 * 1 ether;
 
-    ILivepeerToken public token;
+    IBondingManager public bondingManager;
 
     event PollCreated(address indexed poll, bytes proposal, uint256 endBlock, uint256 quorum, uint256 quota);
 
-    constructor(address _tokenAddr) public {
-        token = ILivepeerToken(_tokenAddr);
+    constructor(address _bondingManagerAddr) public {
+        bondingManager = IBondingManager(_bondingManagerAddr);
     }
 
     /**
-     * @dev Create a poll by burning POLL_CREATION_COST LPT.
-     *      Reverts if this contract's LPT allowance for the sender < POLL_CREATION_COST.
+     * @notice Create a poll if caller has POLL_CREATION_COST LPT stake (own stake or stake delegated to it).
      * @param _proposal The IPFS multihash for the proposal.
      */
     function createPoll(bytes calldata _proposal) external {
         uint256 endBlock = block.number + POLL_PERIOD;
         Poll poll = new Poll(endBlock);
 
-        require(token.transferFrom(msg.sender, address(this), POLL_CREATION_COST), "LivepeerToken transferFrom failed");
-
-        token.burn(POLL_CREATION_COST);
+        require(
+            // pendingStake() ignores the second arg
+            bondingManager.pendingStake(msg.sender, 0) >= POLL_CREATION_COST ||
+                bondingManager.transcoderTotalStake(msg.sender) >= POLL_CREATION_COST,
+            "PollCreator#createPoll: INSUFFICIENT_STAKE"
+        );
 
         emit PollCreated(address(poll), _proposal, endBlock, QUORUM, QUOTA);
     }

--- a/test/unit/PollCreator.js
+++ b/test/unit/PollCreator.js
@@ -1,10 +1,12 @@
 import Fixture from "./helpers/Fixture"
-import {functionSig} from "../../utils/helpers"
 import {web3, ethers} from "hardhat"
 
-import chai, {expect, assert} from "chai"
+import {expect, use} from "chai"
 import {solidity} from "ethereum-waffle"
-chai.use(solidity)
+import {smock} from "@defi-wonderland/smock"
+
+use(solidity)
+use(smock.matchers)
 
 const QUORUM = 333300
 const QUOTA = 500000
@@ -12,12 +14,22 @@ const POLL_PERIOD = 10 * 5760
 
 describe("PollCreator", () => {
     let fixture
-    let token
     let pollCreator
 
+    let bondingManagerMock
+    let mockBondingManagerEOA
+
     before(async () => {
+        ;[, mockBondingManagerEOA] = await ethers.getSigners()
+
         fixture = new Fixture(web3)
-        token = await (await ethers.getContractFactory("GenericMock")).deploy()
+
+        bondingManagerMock = await smock.fake(
+            "contracts/polling/PollCreator.sol:IBondingManager",
+            {
+                address: mockBondingManagerEOA.address
+            }
+        )
     })
 
     beforeEach(async () => {
@@ -32,11 +44,13 @@ describe("PollCreator", () => {
         before(async () => {
             pollCreator = await (
                 await ethers.getContractFactory("PollCreator")
-            ).deploy(token.address)
+            ).deploy(bondingManagerMock.address)
         })
 
-        it("initialize state: token", async () => {
-            assert.equal(await pollCreator.token(), token.address)
+        it("initialize state: bondingManager", async () => {
+            expect(await pollCreator.bondingManager()).to.be.equal(
+                bondingManagerMock.address
+            )
         })
     })
 
@@ -46,27 +60,97 @@ describe("PollCreator", () => {
         before(async () => {
             pollCreator = await (
                 await ethers.getContractFactory("PollCreator")
-            ).deploy(token.address)
+            ).deploy(bondingManagerMock.address)
         })
 
-        it("revert when not enough tokens approved", async () => {
+        it("revert when caller has insufficient stake", async () => {
+            const cost = await pollCreator.POLL_CREATION_COST()
+
+            // pendingStake() == 0 && transcoderTotalStake() == 0
             await expect(pollCreator.createPoll(hash)).to.be.revertedWith(
-                "LivepeerToken transferFrom failed"
+                "PollCreator#createPoll: INSUFFICIENT_STAKE"
+            )
+
+            // pendingStake() > 0 && transcoderTotalStake() == 0
+            bondingManagerMock.pendingStake.returns(cost.sub(1))
+            await expect(pollCreator.createPoll(hash)).to.be.revertedWith(
+                "PollCreator#createPoll: INSUFFICIENT_STAKE"
+            )
+
+            // pendingStake() == 0 && transcoderTotalStake() > 0
+            bondingManagerMock.pendingStake.returns(0)
+            bondingManagerMock.transcoderTotalStake.returns(cost.sub(1))
+            await expect(pollCreator.createPoll(hash)).to.be.revertedWith(
+                "PollCreator#createPoll: INSUFFICIENT_STAKE"
+            )
+
+            // pendingStake() > 0 && transcoderTotalStake() > 0
+            bondingManagerMock.pendingStake.returns(cost.sub(1))
+            await expect(pollCreator.createPoll(hash)).to.be.revertedWith(
+                "PollCreator#createPoll: INSUFFICIENT_STAKE"
             )
         })
 
         it("creates a poll", async () => {
-            await token.setMockBool(
-                functionSig("transferFrom(address,address,uint256)"),
-                true
-            )
+            const cost = await pollCreator.POLL_CREATION_COST()
+
+            // pendingStake() > POLL_CREATION_COST
+            bondingManagerMock.pendingStake.returns(cost.add(1))
+
             const start = await fixture.rpc.getBlockNumberAsync()
             const end = start + POLL_PERIOD + 1 // + 1 because createPoll tx will mine a new block
-            const tx = await pollCreator.createPoll(hash)
-            const receipt = await tx.wait()
-            await expect(tx.hash)
+
+            let tx = await pollCreator.createPoll(hash)
+            let receipt = await tx.wait()
+            await expect(tx)
                 .to.emit(pollCreator, "PollCreated")
                 .withArgs(receipt.events[0].args[0], hash, end, QUORUM, QUOTA)
+
+            // pendingStake() == POLL_CREATION_COST
+            bondingManagerMock.pendingStake.returns(cost)
+
+            tx = await pollCreator.createPoll(hash)
+            receipt = await tx.wait()
+            await expect(tx)
+                .to.emit(pollCreator, "PollCreated")
+                .withArgs(
+                    receipt.events[0].args[0],
+                    hash,
+                    end + 1,
+                    QUORUM,
+                    QUOTA
+                )
+
+            // transcoderTotalStake() > POLL_CREATION_COST
+            bondingManagerMock.pendingStake.returns(0)
+            bondingManagerMock.transcoderTotalStake.returns(cost.add(1))
+
+            tx = await pollCreator.createPoll(hash)
+            receipt = await tx.wait()
+            await expect(tx)
+                .to.emit(pollCreator, "PollCreated")
+                .withArgs(
+                    receipt.events[0].args[0],
+                    hash,
+                    end + 2,
+                    QUORUM,
+                    QUOTA
+                )
+
+            // transcoderTotalStake() == POLL_CREATION_COST
+            bondingManagerMock.transcoderTotalStake.returns(cost)
+
+            tx = await pollCreator.createPoll(hash)
+            receipt = await tx.wait()
+            await expect(tx)
+                .to.emit(pollCreator, "PollCreated")
+                .withArgs(
+                    receipt.events[0].args[0],
+                    hash,
+                    end + 3,
+                    QUORUM,
+                    QUOTA
+                )
         })
     })
 })


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR updates the PollCreator to require a minimum stake >= POLL_CREATION_COST from the caller instead of requiring the caller to burn the POLL_CREATION_COST. The caller can meet the minimum stake req with its own stake (i.e. BondingManager.pendingStake()) *or* its delegated stake (i.e. BondingManager.transcoderTotalStake()).

Since the PollCreator.js unit test was pretty small I updated it to use smock for mocking instead of the GenericMock contract since smock is easier to use for mocking return values.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #508 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
