### PR TITLE
token: Change burn() signature in trustedBurnTokens()

### DIFF
--- a/contracts/token/ILivepeerToken.sol
+++ b/contracts/token/ILivepeerToken.sol
@@ -6,5 +6,5 @@ import "../zeppelin/Ownable.sol";
 contract ILivepeerToken is ERC20, Ownable {
     function mint(address _to, uint256 _amount) public returns (bool);
 
-    function burn(uint256 _amount) public;
+    function burn(address _from, uint256 _amount) public;
 }

--- a/contracts/token/LivepeerToken.sol
+++ b/contracts/token/LivepeerToken.sol
@@ -4,7 +4,7 @@ import "./ILivepeerToken.sol";
 import "./VariableSupplyToken.sol";
 
 // Livepeer Token
-contract LivepeerToken is ILivepeerToken, VariableSupplyToken {
+contract LivepeerToken is VariableSupplyToken {
     string public name = "Livepeer Token";
     uint8 public decimals = 18;
     string public symbol = "LPT";

--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -177,7 +177,7 @@ contract Minter is Manager, IMinter {
      * @param _amount Amount of tokens to burn
      */
     function trustedBurnTokens(uint256 _amount) external onlyBondingManager whenSystemNotPaused {
-        livepeerToken().burn(_amount);
+        livepeerToken().burn(address(this), _amount);
     }
 
     /**


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR updates the `burn()` signature for LPT in `Minter.trustedBurnTokens()` to match the function signature in https://github.com/livepeer/arbitrum-lpt-bridge/blob/main/contracts/L2/token/LivepeerToken.sol [1].

Instead of completely removing burning, I decided to just update the function signature so that it *could* work, but in practice any calls to `trustedBurnTokens()` via `BondingManager.slashTranscoder()` will revert because the Minter will initially not have the burner role in the ACL for L2 LPT. This is fine for now because `slashTranscoder()` will never be called for now since the verifier address will be set to null. In the future, enabling slashing + burning would involve setting a verifier address and giving the burner role to the Minter in the ACL for L2 LPT.

[1] That implementation will be brought into this repo in https://github.com/livepeer/protocol/issues/509

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #507 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
