### PR TITLE
token: Update LPT burn() func signature

### DIFF
--- a/contracts/token/ILivepeerToken.sol
+++ b/contracts/token/ILivepeerToken.sol
@@ -6,5 +6,5 @@ import "../zeppelin/Ownable.sol";
 contract ILivepeerToken is ERC20, Ownable {
     function mint(address _to, uint256 _amount) public returns (bool);
 
-    function burn(address _from, uint256 _amount) public;
+    function burn(uint256 _amount) public;
 }

--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -177,7 +177,7 @@ contract Minter is Manager, IMinter {
      * @param _amount Amount of tokens to burn
      */
     function trustedBurnTokens(uint256 _amount) external onlyBondingManager whenSystemNotPaused {
-        livepeerToken().burn(address(this), _amount);
+        livepeerToken().burn(_amount);
     }
 
     /**

--- a/test/unit/Minter.js
+++ b/test/unit/Minter.js
@@ -537,10 +537,7 @@ describe("Minter", () => {
                 )
             )
 
-            expect(tokenMock.burn).to.be.calledOnceWith(
-                minter.address,
-                burnAmount
-            )
+            expect(tokenMock.burn).to.be.calledOnceWith(burnAmount)
         })
     })
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR updates the `burn()` function signature on LPT to match the changes made in https://github.com/livepeer/arbitrum-lpt-bridge/pull/52. Note: As with before, `trustedBurnTokens()` is never called, but this update is made so that it *could* be called in the future by making sure the `burn()` function signature LPT is valid.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
