### PR TITLE
arbitrumMainnet config values + misc updates

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -6,6 +6,7 @@
     "reason-string": "off",
     "no-empty-blocks": "off",
     "prettier/prettier": "error",
-    "compiler-version": ["error", "^0.8.8"]
+    "compiler-version": ["error", "^0.8.8"],
+    "func-visibility": ["warn", {"ignoreConstructors": true}]
   }
 }

--- a/contracts/arbitrum/DummyGateway.sol
+++ b/contracts/arbitrum/DummyGateway.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.5.11;
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.8;
 
 contract DummyGateway {
     function calculateL2TokenAddress(address _token) external pure returns (address) {

--- a/contracts/token/LivepeerToken.sol
+++ b/contracts/token/LivepeerToken.sol
@@ -9,16 +9,14 @@ import { ERC20Burnable } from "@openzeppelin/contracts/token/ERC20/extensions/ER
 // Copy of https://github.com/livepeer/arbitrum-lpt-bridge/blob/main/contracts/L2/token/LivepeerToken.sol
 // Tests at https://github.com/livepeer/arbitrum-lpt-bridge/blob/main/test/unit/L2/livepeerToken.test.ts
 contract LivepeerToken is AccessControl, ERC20Burnable, ERC20Permit {
-    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
-    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
+    bytes32 private immutable MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 private immutable BURNER_ROLE = keccak256("BURNER_ROLE");
 
     event Mint(address indexed to, uint256 amount);
     event Burn(address indexed burner, uint256 amount);
 
     constructor() ERC20("Livepeer Token", "LPT") ERC20Permit("Livepeer Token") {
-        _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
-        _setRoleAdmin(MINTER_ROLE, DEFAULT_ADMIN_ROLE);
-        _setRoleAdmin(BURNER_ROLE, DEFAULT_ADMIN_ROLE);
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
     }
 
     /**

--- a/deploy/genesis.config.ts
+++ b/deploy/genesis.config.ts
@@ -1,4 +1,5 @@
 import {BigNumber, utils} from "ethers"
+// Values for L1 for reference
 export default {
     initialSupply: utils.parseEther("10000000"),
     crowdSupply: utils.parseEther("6343700"),

--- a/deploy/migrations.config.ts
+++ b/deploy/migrations.config.ts
@@ -95,11 +95,44 @@ const arbitrumRinkeby = {
 
 const arbitrumRinkebyDevnet = arbitrumRinkeby
 
+const arbitrumMainnet = {
+    governor: {
+        // Governance multisig
+        owner: "0x04F53A0bb244f015cC97731570BeD26F0229da05"
+    },
+    bondingManager: {
+        numActiveTranscoders: 100,
+        // Rounds
+        unbondingPeriod: 7
+    },
+    broker: {
+        // Rounds
+        unblockPeriod: 2,
+        // Rounds
+        ticketValidityPeriod: 2
+    },
+    roundsManager: {
+        roundLength: 5760,
+        roundLockAmount: 100000
+    },
+    minter: {
+        // As of L1 round 2460 inflation was 221500 and bonding rate > 50% so inflation was declining
+        // The switch to L2 projected to occur in L1 round 2466
+        // If inflation continues to decrease inflation projected to be 221500 - (6 * 500) = 218500 in L1 round 2466
+        // No reward calls will happen on L2 until the round after migrations start since it takes a round for orchestrators to become active
+        // The inflation at the start of that round will be 218500 - 500 = 218000
+        inflation: 218500,
+        inflationChange: 500,
+        targetBondingRate: 500000000
+    }
+}
+
 const networkConfigs: any = {
     rinkeby,
     rinkebyDevnet,
     arbitrumRinkeby,
-    arbitrumRinkebyDevnet
+    arbitrumRinkebyDevnet,
+    arbitrumMainnet
 }
 
 export default function getNetworkConfig(network: string) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Adds arbitrumMainnet config values for deployment. The values of all params are the same as those used on mainnet except for:

- The owner of the Governor is the L2 governance multisig specified in [LIP-73](https://github.com/livepeer/LIPs/blob/master/LIPs/LIP-73.md)
- The `inflation` param (i.e. starting inflation rate) in the Minter is calculated based on a projection of what it will be on L1 in the round at which the LIP-73 upgrade is executed. See the comments for the arbitrumMainnet config in `migrations.config.js` for an explanation for how it was calculated

A few other minor updates are included in this PR as well which are explained by each of the commits.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I ran `yarn deploy` with a local HH network. Note this does not test the network conditional logic that would only be triggered when connected to arbitrumMainnet.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
