### PR TITLE
hardhat-config: Added mnemonic for local node setup and related bash …

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -83,7 +83,13 @@ const config: HardhatUserConfig = {
             accounts: PRIVATE_KEY ? [`0x${PRIVATE_KEY}`] : undefined
         },
         localhost: {
-            url: "http://127.0.0.1:8545"
+            url: "http://127.0.0.1:8545",
+            allowUnlimitedContractSize: true,
+            accounts: {
+                // note: run ganache / your local node set up with the same mnemonic {see: run_local_deployment.sh}
+                mnemonic: "test test test test test test test test test test test junk",
+                count: 250
+            }
         }
     },
     gasReporter: {

--- a/scripts/run_local_deployment.sh
+++ b/scripts/run_local_deployment.sh
@@ -1,0 +1,2 @@
+docker run --detach --publish 8545:8545 trufflesuite/ganache-cli:latest --mnemonic "test test test test test test test test test test test junk"
+npx hardhat deploy --tags Contracts,Poll --network localhost --reset


### PR DESCRIPTION
…script

**What does this pull request do? Explain your changes. (required)**
- It adds a junk mnemonic to the localhost network config to sync a local node's accounts with the accounts injected in the hardhat runtime environment.
- It adds a bash script to run a dockerized ganache and deploy the contracts under the "Poll, Contract" tags

**Specific updates (required)**
- Modified the localhost field in the hardhat.config.ts  
- Added bash script under the scripts directory

**How did you test each of these updates (required)**
Manual deployment

**Does this pull request close any open issues?**
[issue](https://github.com/livepeer/protocol/issues/550)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] All tests using `yarn test` pass
