### PR TITLE
bonding: remove duplicate IBondingManager interface

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.9;
 
 import "../ManagerProxyTarget.sol";
-import "./IBondingManager.sol";
+import "../interfaces/IBondingManager.sol";
 import "../libraries/SortedDoublyLL.sol";
 import "../libraries/MathUtils.sol";
 import "../libraries/PreciseMathUtils.sol";

--- a/contracts/interfaces/IBondingManager.sol
+++ b/contracts/interfaces/IBondingManager.sol
@@ -78,4 +78,6 @@ interface IBondingManager {
     function isActiveTranscoder(address _transcoder) external view returns (bool);
 
     function getTotalBonded() external view returns (uint256);
+
+    function pendingStake(address _addr, uint256 _endRound) external view returns (uint256);
 }

--- a/contracts/pm/mixins/interfaces/MContractRegistry.sol
+++ b/contracts/pm/mixins/interfaces/MContractRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.9;
 
-import "../../../bonding/IBondingManager.sol";
+import "../../../interfaces/IBondingManager.sol";
 import "../../../token/IMinter.sol";
 import "../../../rounds/IRoundsManager.sol";
 

--- a/contracts/polling/PollCreator.sol
+++ b/contracts/polling/PollCreator.sol
@@ -2,12 +2,7 @@
 pragma solidity 0.8.9;
 
 import "./Poll.sol";
-
-interface IBondingManager {
-    function transcoderTotalStake(address _addr) external view returns (uint256);
-
-    function pendingStake(address _addr, uint256 _endRound) external view returns (uint256);
-}
+import "../interfaces/IBondingManager.sol";
 
 contract PollCreator {
     // 33.33%

--- a/contracts/rounds/RoundsManager.sol
+++ b/contracts/rounds/RoundsManager.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.9;
 
 import "../ManagerProxyTarget.sol";
 import "./IRoundsManager.sol";
-import "../bonding/IBondingManager.sol";
+import "../interfaces/IBondingManager.sol";
 import "../token/IMinter.sol";
 import "../libraries/MathUtils.sol";
 

--- a/contracts/token/Minter.sol
+++ b/contracts/token/Minter.sol
@@ -5,7 +5,7 @@ import "../Manager.sol";
 import "./IMinter.sol";
 import "./ILivepeerToken.sol";
 import "../rounds/IRoundsManager.sol";
-import "../bonding/IBondingManager.sol";
+import "../interfaces/IBondingManager.sol";
 import "../libraries/MathUtilsV2.sol";
 
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";

--- a/test/unit/PollCreator.js
+++ b/test/unit/PollCreator.js
@@ -25,7 +25,7 @@ describe("PollCreator", () => {
         fixture = new Fixture(web3)
 
         bondingManagerMock = await smock.fake(
-            "contracts/polling/PollCreator.sol:IBondingManager",
+            "contracts/interfaces/IBondingManager.sol:IBondingManager",
             {
                 address: mockBondingManagerEOA.address
             }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Remove duplicate IBondingManager interface

**Specific updates (required)**
- Merge IBondingManager interfaces
- Move IBondingManager.sol to `contracts/interfaces`
- Adapt `test/unit/PollCreator.js` test

**How did you test each of these updates (required)**
`yarn test`
`yarn deploy`


**Does this pull request close any open issues?**
Fixes #560

**Checklist:**

- [ ] ~~README and other documentation updated~~
- [x] All tests using `yarn test` pass
