### PR TITLE
bonding: Remove artificial treasury stake

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -98,8 +98,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
     // Rate of global rewards that will be sent to the treasury
     uint256 public treasuryRewardCutRate;
-    // Value to the reward distribution code t
-    uint256 public currentRoundTreasuryArtificialStake;
 
     // TODO: Move these to controller
     BondingCheckpoints public checkpointsAddr;
@@ -331,10 +329,14 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
                 // `minter().createReward`, seems like we're double-counting the already minted tokens here.
                 mtr.currentMintableTokens().add(mtr.currentMintedTokens()),
                 totalStake,
-                currentRoundTotalActiveStake + currentRoundTreasuryArtificialStake
+                currentRoundTotalActiveStake
             );
+
+            uint256 treasuryRewards = MathUtils.percOf(rewards, treasuryRewardCutRate);
+            rewards = rewards.sub(treasuryRewards);
+
             uint256 transcoderCommissionRewards = MathUtils.percOf(rewards, earningsPool.transcoderRewardCut);
-            uint256 delegatorsRewards = rewards.sub(transcoderCommissionRewards);
+            uint256 delegatorsRewards = rewards.sub(transcoderCommissionRewards).sub(treasuryRewards);
 
             prevEarningsPool.cumulativeRewardFactor = PreciseMathUtils.percOf(
                 earningsPool.cumulativeRewardFactor,
@@ -445,26 +447,11 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
     function mintTreasuryRewards() public onlyRoundsManager {
         if (treasuryRewardCutRate == 0) {
-            currentRoundTreasuryArtificialStake = 0;
             return;
         }
 
-        // we calculate this artificial stake so that the treasury gets the corresponding cut of the rewards.
-        // it is calculated with the formula: treasuryStake = rate * TotalStake / (1 - rate)
-        uint256 cutRateComplement = PreciseMathUtils.percPoints(1, 1).sub(treasuryRewardCutRate);
-        currentRoundTreasuryArtificialStake = PreciseMathUtils.percOf(
-            currentRoundTotalActiveStake,
-            treasuryRewardCutRate,
-            cutRateComplement
-        );
-
-        // Create reward based on artificial treasury stake relative to the total active stake
-        // rewardTokens = (current mintable tokens for the round * artificial treasury stake) / (total active stake + artificial treasury stale)
-        uint256 rewardTokens = minter().createReward(
-            currentRoundTreasuryArtificialStake,
-            currentRoundTotalActiveStake + currentRoundTreasuryArtificialStake
-        );
-
+        // Create treasury reward based on the cut rate
+        uint256 rewardTokens = minter().createReward(treasuryRewardCutRate, PreciseMathUtils.percPoints(1, 1));
         minter().trustedTransferTokens(address(treasury()), rewardTokens);
     }
 
@@ -866,17 +853,18 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
         // Create reward based on active transcoder's stake relative to the total active stake
         // rewardTokens = (current mintable tokens for the round * active transcoder stake) / (total active stake + treasury stake adjustment)
-        uint256 rewardTokens = minter().createReward(
-            earningsPool.totalStake,
-            currentRoundTotalActiveStake + currentRoundTreasuryArtificialStake
-        );
+        uint256 totalRewardTokens = minter().createReward(earningsPool.totalStake, currentRoundTotalActiveStake);
 
-        updateTranscoderWithRewards(msg.sender, rewardTokens, currentRound, _newPosPrev, _newPosNext);
+        // The wholesome of treasury rewards were already minted on round initialization, only calculate them to subtract.
+        uint256 treasuryRewards = PreciseMathUtils.percOf(totalRewardTokens, treasuryRewardCutRate);
+        uint256 transcoderRewards = totalRewardTokens.sub(treasuryRewards);
+
+        updateTranscoderWithRewards(msg.sender, transcoderRewards, currentRound, _newPosPrev, _newPosNext);
 
         // Set last round that transcoder called reward
         t.lastRewardRound = currentRound;
 
-        emit Reward(msg.sender, rewardTokens);
+        emit Reward(msg.sender, transcoderRewards);
     }
 
     /**


### PR DESCRIPTION
This is another simpler implementation for the treasury rewards calculation,
mixing #611 and #612. The caveat is that we will have a bit more rounding errors
on this approach, since there are more perc calculations. The losses might be 
relatively trivial tho (worst case 1 fractional unit of LPT for each transcoder, so up to
100/1**18 LPT per round).