### PR TITLE
[delta-audit] bonding: Only provide voting power for active stake

### DIFF
--- a/contracts/bonding/IBondingVotes.sol
+++ b/contracts/bonding/IBondingVotes.sol
@@ -35,7 +35,8 @@ interface IBondingVotes is IVotes {
         address _delegateAddress,
         uint256 _delegatedAmount,
         uint256 _lastClaimRound,
-        uint256 _lastRewardRound
+        uint256 _lastRewardRound,
+        bool _isActiveTranscoder
     ) external;
 
     function checkpointTotalActiveStake(uint256 _totalStake, uint256 _round) external;

--- a/contracts/test/mocks/BondingVotesMock.sol
+++ b/contracts/test/mocks/BondingVotesMock.sol
@@ -11,7 +11,8 @@ contract BondingVotesMock is GenericMock {
         address delegateAddress,
         uint256 delegatedAmount,
         uint256 lastClaimRound,
-        uint256 lastRewardRound
+        uint256 lastRewardRound,
+        bool isActiveTranscoder
     );
     event CheckpointTotalActiveStake(uint256 totalStake, uint256 round);
 
@@ -22,7 +23,8 @@ contract BondingVotesMock is GenericMock {
         address _delegateAddress,
         uint256 _delegatedAmount,
         uint256 _lastClaimRound,
-        uint256 _lastRewardRound
+        uint256 _lastRewardRound,
+        bool _isActiveTranscoder
     ) external {
         emit CheckpointBondingState(
             _account,
@@ -31,7 +33,8 @@ contract BondingVotesMock is GenericMock {
             _delegateAddress,
             _delegatedAmount,
             _lastClaimRound,
-            _lastRewardRound
+            _lastRewardRound,
+            _isActiveTranscoder
         );
     }
 

--- a/test/integration/BondingVotes.js
+++ b/test/integration/BondingVotes.js
@@ -319,7 +319,7 @@ describe("BondingVotes", () => {
         })
 
         describe("getBondingStateAt", () => {
-            it("should provide voting power even for inactive transcoders and their delegators", async () => {
+            it("should not provide voting power for inactive transcoders and their delegators", async () => {
                 const transcoder = transcoders[transcoders.length - 1].address
                 const delegator = delegators[delegators.length - 1].address
 
@@ -328,10 +328,10 @@ describe("BondingVotes", () => {
                         address,
                         round
                     )
-                    assert.isAbove(
+                    assert.equal(
                         stake,
                         0,
-                        `expected non-zero stake checkpoint at round ${round} for account ${address}`
+                        `expected zero stake checkpoint at round ${round} for account ${address}`
                     )
                 }
 
@@ -346,12 +346,17 @@ describe("BondingVotes", () => {
                 }
             })
 
-            it("should return exactly the account pendingStake in the corresponding round", async () => {
+            it("should return the account pendingStake in the corresponding round if active", async () => {
+                const isInactive = address =>
+                    address === transcoders[transcoders.length - 1].address ||
+                    address === delegators[delegators.length - 1].address
                 for (const round of Object.keys(pendingStakesByRound)) {
                     const pendingStakes = pendingStakesByRound[round]
 
                     for (const address of Object.keys(pendingStakes)) {
-                        const expectedStake = pendingStakes[address]
+                        const expectedStake = isInactive(address) ?
+                            0 :
+                            pendingStakes[address]
 
                         const [stakeCheckpoint] =
                             await bondingVotes.getBondingStateAt(address, round)

--- a/test/unit/helpers/expectCheckpoints.ts
+++ b/test/unit/helpers/expectCheckpoints.ts
@@ -1,6 +1,6 @@
 import {assert} from "chai"
 import {ethers} from "ethers"
-import Fixture from "./Fixture"
+import {BondingVotesMock} from "../../../typechain"
 
 type Checkpoint = {
     account: string
@@ -10,10 +10,11 @@ type Checkpoint = {
     delegatedAmount: number
     lastClaimRound: number
     lastRewardRound: number
+    isActiveTranscoder: boolean
 }
 
 export default async function expectCheckpoints(
-    fixture: Fixture,
+    fixture: { bondingVotes: BondingVotesMock },
     tx: ethers.providers.TransactionReceipt,
     ...checkpoints: Checkpoint[]
 ) {
@@ -21,7 +22,7 @@ export default async function expectCheckpoints(
     const events = await fixture.bondingVotes.queryFilter(
         filter,
         tx.blockNumber,
-        tx.blockNumber
+        tx.blockNumber + 1
     )
 
     assert.equal(events.length, checkpoints.length, "Checkpoint count")
@@ -36,7 +37,8 @@ export default async function expectCheckpoints(
             delegateAddress: args[3].toString(),
             delegatedAmount: args[4].toNumber(),
             lastClaimRound: args[5].toNumber(),
-            lastRewardRound: args[6].toNumber()
+            lastRewardRound: args[6].toNumber(),
+            isActiveTranscoder: args[7] as boolean
         }
 
         for (const keyStr of Object.keys(expected)) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is to fix the `totalSupply = sum(getVotes(*))` invariant from `BondingVotes`,
which wasn't held before when we provided voting power to both active and inactive
transcoders and their delegators.

With this change, we make sure the transcoder active stake is also taken into account
and provide zero voting power when the transcoder is not active.

**Specific updates (required)**
- Start checkpointing the `isActiveTranscoder` bool, derived from activation and deactivation rounds
- Fix tests that broke and added some new tests to the new logic (like checkpoints on active set changes)

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Fixes PRO-39

Also ended up being a potential fix for https://github.com/code-423n4/2023-08-livepeer-findings/issues/194

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] All tests using `yarn test` pass
