### PR TITLE
[delta-audit] bonding: Various fixes from audit findings

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -441,8 +441,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
     /**
      * @notice Claim token pools shares for a delegator from its lastClaimRound through the end round
-     * @param _endRound Unused, represented the last round for which to claim token pools shares for a delegator.
-     * Currently, the earnings are always claimed until the current round instead.
+     * @param _endRound Unused, but used to represented the last round for which to claim token pools shares for a
+     * delegator. Currently, the earnings are always claimed until the current round instead.
      */
     function claimEarnings(uint256 _endRound)
         external
@@ -587,7 +587,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             delegationAmount = delegationAmount.add(currentBondedAmount);
 
             decreaseTotalStake(currentDelegate, currentBondedAmount, _oldDelegateNewPosPrev, _oldDelegateNewPosNext);
-            // currentDelegate is always different than msg.sender so no need to avoid double checkpointing
+            // no need to prevent double checkpointing since _owner is not a transcoder (i.e. currentDelegate != _owner)
             _checkpointBondingState(currentDelegate, delegators[currentDelegate], transcoders[currentDelegate]);
         }
 
@@ -912,8 +912,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     /**
      * @notice Returns pending bonded stake for a delegator from its lastClaimRound through an end round
      * @param _delegator Address of delegator
-     * @param _endRound Unused, but represented the last round to compute pending stake from. Currently, the pending
-     * stake is always calculated for the current round instead.
+     * @param _endRound Unused, but used to represent the last round to compute pending stake from. Currently, the
+     * pending stake is always calculated for the current round instead.
      * @return Pending bonded stake for '_delegator' since last claiming rewards
      */
     function pendingStake(address _delegator, uint256 _endRound) public view returns (uint256) {
@@ -928,7 +928,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     /**
      * @notice Returns pending fees for a delegator from its lastClaimRound through an end round
      * @param _delegator Address of delegator
-     * @param _endRound The last round to compute pending fees from
+     * @param _endRound Unused, but used to represent the last round to compute pending fees from. Currently, the
+     * pending fees are always calculated for the current round instead.
      * @return Pending fees for '_delegator' since last claiming fees
      */
     function pendingFees(address _delegator, uint256 _endRound) public view returns (uint256) {

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -41,7 +41,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         uint256 feeShare; // % of fees paid to delegators by transcoder
         mapping(uint256 => EarningsPool.Data) earningsPoolPerRound; // Mapping of round => earnings pool for the round
         uint256 lastActiveStakeUpdateRound; // Round for which the stake was last updated while the transcoder is active
-        uint256 activationRound; // Round in which the transcoder became active - 0 if inactive
+        uint256 activationRound; // Round in which the transcoder became active - if inactive will be 0 or <=deactivationRound
         uint256 deactivationRound; // Round in which the transcoder will become inactive
         uint256 activeCumulativeRewards; // The transcoder's cumulative rewards that are active in the current round
         uint256 cumulativeRewards; // The transcoder's cumulative rewards (earned via the its active staked rewards and its reward cut).
@@ -143,7 +143,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * should be used to initialize state variables post-deployment:
      * - setUnbondingPeriod()
      * - setNumActiveTranscoders()
-     * - setMaxEarningsClaimsRounds()
      * @param _controller Address of Controller that this contract will be registered with
      */
     constructor(address _controller) Manager(_controller) {}

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -384,7 +384,9 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @notice Slash a transcoder. Only callable by the Verifier
+     * @notice Slash a transcoder. Only callable by the Verifier.
+     * @dev DEPRECATED: This function is not currently used in the protocol and the Verifier role is not configured. Its
+     * implementation is not compatible with the rest of the BondingManager code anymore.
      * @param _transcoder Transcoder address
      * @param _finder Finder that proved a transcoder violated a slashing condition. Null address if there is no finder
      * @param _slashAmount Percentage of transcoder bond to be slashed

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -441,7 +441,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
     /**
      * @notice Claim token pools shares for a delegator from its lastClaimRound through the end round
-     * @param _endRound The last round for which to claim token pools shares for a delegator
+     * @param _endRound Unused, represented the last round for which to claim token pools shares for a delegator.
+     * Currently, the earnings are always claimed until the current round instead.
      */
     function claimEarnings(uint256 _endRound)
         external
@@ -911,7 +912,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     /**
      * @notice Returns pending bonded stake for a delegator from its lastClaimRound through an end round
      * @param _delegator Address of delegator
-     * @param _endRound The last round to compute pending stake from
+     * @param _endRound Unused, but represented the last round to compute pending stake from. Currently, the pending
+     * stake is always calculated for the current round instead.
      * @return Pending bonded stake for '_delegator' since last claiming rewards
      */
     function pendingStake(address _delegator, uint256 _endRound) public view returns (uint256) {

--- a/contracts/bonding/BondingVotes.sol
+++ b/contracts/bonding/BondingVotes.sol
@@ -62,7 +62,7 @@ contract BondingVotes is ManagerProxyTarget, IBondingVotes {
     }
 
     /**
-     * @dev Stores a list of checkpoints for the total active stake, queryable and mapped by round. Notce that
+     * @dev Stores a list of checkpoints for the total active stake, queryable and mapped by round. Notice that
      * differently from bonding checkpoints, it's only accessible on the specific round. To access the checkpoint for a
      * given round, look for the checkpoint in the {data}} and if it's zero ensure the round was actually checkpointed on
      * the {rounds} array ({SortedArrays-findLowerBound}).
@@ -478,8 +478,8 @@ contract BondingVotes is ManagerProxyTarget, IBondingVotes {
         );
 
         if (rewardRound < bond.lastClaimRound) {
-            // If the transcoder hasn't called reward() since the last time the delegator claimed earnings, there wil be
-            // no rewards to add to the delegator's stake so we just return the originally bonded amount.
+            // If the transcoder hasn't called reward() since the last time the delegator claimed earnings, there will
+            // be no rewards to add to the delegator's stake so we just return the originally bonded amount.
             return bond.bondedAmount;
         }
 

--- a/contracts/bonding/BondingVotes.sol
+++ b/contracts/bonding/BondingVotes.sol
@@ -406,8 +406,14 @@ contract BondingVotes is ManagerProxyTarget, IBondingVotes {
 
         // Always send delegator events since transcoders are delegators themselves. The way our rewards work, the
         // delegator voting power calculated from events will only reflect their claimed stake without pending rewards.
-        if (previous.bondedAmount != current.bondedAmount) {
-            emit DelegatorBondedAmountChanged(_account, previous.bondedAmount, current.bondedAmount);
+        if (previous.bondedAmount != current.bondedAmount || previous.lastClaimRound != current.lastClaimRound) {
+            emit DelegatorBondedAmountChanged(
+                _account,
+                previous.bondedAmount,
+                previous.lastClaimRound,
+                current.bondedAmount,
+                current.lastClaimRound
+            );
         }
     }
 

--- a/contracts/bonding/IBondingVotes.sol
+++ b/contracts/bonding/IBondingVotes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "../treasury/IVotes.sol";
 

--- a/contracts/bonding/IBondingVotes.sol
+++ b/contracts/bonding/IBondingVotes.sol
@@ -24,7 +24,13 @@ interface IBondingVotes is IVotes {
      * from IERC5805 by also supporting voting power for the delegators themselves, though requiring knowledge about our
      * specific reward-claiming protocol to calculate voting power based on this value.
      */
-    event DelegatorBondedAmountChanged(address indexed delegate, uint256 previousBondedAmount, uint256 newBondedAmount);
+    event DelegatorBondedAmountChanged(
+        address indexed delegate,
+        uint256 previousBondedAmount,
+        uint256 previousLastClaimRound,
+        uint256 newBondedAmount,
+        uint256 newLastClaimRound
+    );
 
     // BondingManager hooks
 

--- a/contracts/treasury/GovernorCountingOverridable.sol
+++ b/contracts/treasury/GovernorCountingOverridable.sol
@@ -56,7 +56,7 @@ abstract contract GovernorCountingOverridable is Initializable, GovernorUpgradea
     mapping(uint256 => ProposalTally) private _proposalTallies;
 
     /**
-     * @notice The required percentage of "for" votes in relation to the total opinionated votes (for and abstain) for
+     * @notice The required percentage of "for" votes in relation to the total opinionated votes (for and against) for
      * a proposal to succeed. Represented as a MathUtils percentage value (e.g. 6 decimal places).
      */
     uint256 public quota;

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,8 @@
+@ensdomains/=node_modules/@ensdomains/
+@openzeppelin/=node_modules/@openzeppelin/
+contracts/=contracts/
+ds-test/=lib/ds-test/src/
+eth-gas-reporter/=node_modules/eth-gas-reporter/
+hardhat-deploy/=node_modules/hardhat-deploy/
+hardhat/=node_modules/hardhat/
+sol-explore/=node_modules/sol-explore/

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -1961,7 +1961,7 @@ describe("BondingManager", () => {
         })
 
         it("should checkpoint the delegator and transcoder states", async () => {
-            // make sure trancoder has a non-null `lastRewardRound`
+            // make sure transcoder has a non-null `lastRewardRound`
             await bondingManager.connect(transcoder0).reward()
 
             const tx = await bondingManager
@@ -1978,7 +1978,7 @@ describe("BondingManager", () => {
                     delegateAddress: transcoder0.address,
                     delegatedAmount: 2000,
                     lastClaimRound: currentRound - 1,
-                    lastRewardRound: 100
+                    lastRewardRound: currentRound
                 },
                 {
                     account: delegator.address,
@@ -1990,6 +1990,25 @@ describe("BondingManager", () => {
                     lastRewardRound: 0
                 }
             )
+        })
+
+        it("should checkpoint transcoder only once on self-bond", async () => {
+            // make sure transcoder has a non-null `lastRewardRound`
+            await bondingManager.connect(transcoder0).reward()
+
+            const tx = await bondingManager
+                .connect(transcoder0)
+                .bond(1000, transcoder0.address)
+
+            await expectCheckpoints(fixture, tx, {
+                account: transcoder0.address,
+                startRound: currentRound + 1,
+                bondedAmount: 2000,
+                delegateAddress: transcoder0.address,
+                delegatedAmount: 2000,
+                lastClaimRound: currentRound,
+                lastRewardRound: currentRound
+            })
         })
     })
 
@@ -2669,6 +2688,22 @@ describe("BondingManager", () => {
             )
         })
 
+        it("should checkpoint transcoder only once on self-unbond", async () => {
+            // make sure transcoder has a non-null `lastRewardRound`
+            await bondingManager.connect(transcoder).reward()
+            const tx = await bondingManager.connect(transcoder).unbond(500)
+
+            await expectCheckpoints(fixture, tx, {
+                account: transcoder.address,
+                startRound: currentRound + 2,
+                bondedAmount: 500,
+                delegateAddress: transcoder.address,
+                delegatedAmount: 1500,
+                lastClaimRound: currentRound + 1,
+                lastRewardRound: currentRound + 1
+            })
+        })
+
         describe("partial unbonding", () => {
             it("should create an unbonding lock for a partial unbond", async () => {
                 const unbondingLockID = (
@@ -3309,6 +3344,28 @@ describe("BondingManager", () => {
                     lastRewardRound: 0
                 }
             )
+        })
+
+        it("should checkpoint transcoder only once on self-rebond", async () => {
+            // make sure transcoder has a non-null `lastRewardRound`
+            await bondingManager.connect(transcoder).reward()
+
+            // unbonding lock id will be the same
+            await bondingManager.connect(transcoder).unbond(500)
+
+            const tx = await bondingManager
+                .connect(transcoder)
+                .rebond(unbondingLockID)
+
+            await expectCheckpoints(fixture, tx, {
+                account: transcoder.address,
+                startRound: currentRound + 2,
+                bondedAmount: 1000,
+                delegateAddress: transcoder.address,
+                delegatedAmount: 1500,
+                lastClaimRound: currentRound + 1,
+                lastRewardRound: currentRound + 1
+            })
         })
 
         describe("current delegate is a registered transcoder", () => {
@@ -4152,6 +4209,45 @@ describe("BondingManager", () => {
                             delegatedAmount: 0,
                             lastClaimRound: currentRound + 3,
                             lastRewardRound: 0
+                        }
+                    )
+                })
+
+                it("should checkpoint transcoders only once", async () => {
+                    // make sure trancoder has a non-null `lastRewardRound`
+                    await bondingManager.connect(transcoder0).reward()
+
+                    const tx = await bondingManager
+                        .connect(transcoder1)
+                        .transferBond(
+                            transcoder0.address,
+                            999,
+                            ZERO_ADDRESS,
+                            ZERO_ADDRESS,
+                            ZERO_ADDRESS,
+                            ZERO_ADDRESS
+                        )
+
+                    await expectCheckpoints(
+                        fixture,
+                        tx,
+                        {
+                            account: transcoder1.address,
+                            startRound: currentRound + 4,
+                            bondedAmount: 1001,
+                            delegateAddress: transcoder1.address,
+                            delegatedAmount: 3001,
+                            lastClaimRound: currentRound + 3,
+                            lastRewardRound: 0
+                        },
+                        {
+                            account: transcoder0.address,
+                            startRound: currentRound + 4,
+                            bondedAmount: 1999,
+                            delegateAddress: transcoder0.address,
+                            delegatedAmount: 3999,
+                            lastClaimRound: currentRound + 3,
+                            lastRewardRound: currentRound + 3
                         }
                     )
                 })


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This mitigates a couple minor findings from the audit that either haven't been flagged by wardens but we found through self-review (e.g. duplicate checkpoints) or too minor issue to have its own PR (solidity version). Even though I'm combining all the fixes in this PR, each mitigation is done on a separate commit to facilitate review.

**Specific updates (required)**
- Avoid double-checkpointing of transcoders when making self-bonding actions
- Add the `previous/newLastClaimRound` to the `DelegatorBondedAmountChanged` event (otherwise some changes would be silent on the event side, like unbonding exactly the amount of pending rewards)

The minorest:
- Fix solidity version in `IBondingVotes.sol` file
- Add a `remappings.txt` file to the project, which improves VS Code suggestions and navigation
- Fix a few misleading or typod documentations

**How did you test each of these updates (required)**
Added tests to all the functional changes and `yarn test`

Will deploy on devnet after merged.

**Does this pull request close any open issues?**
N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] All tests using `yarn test` pass
