### PR TITLE
[delta-audit] bonding: Add stake checkpointing to withdrawFees

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -275,6 +275,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         whenSystemNotPaused
         currentRoundInitialized
         autoClaimEarnings(msg.sender)
+        autoCheckpoint(msg.sender)
     {
         require(_recipient != address(0), "invalid recipient");
         uint256 fees = delegators[msg.sender].fees;

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -4527,6 +4527,23 @@ describe("BondingManager", () => {
                 .to.emit(bondingManager, "WithdrawFees")
                 .withArgs(transcoder0.address, recipient.address, amount)
         })
+
+        it("should checkpoint the caller state", async () => {
+            const amount = 500
+            const tx = await bondingManager
+                .connect(transcoder0)
+                .withdrawFees(recipient.address, amount)
+
+            await expectCheckpoints(fixture, tx, {
+                account: transcoder0.address,
+                startRound: currentRound + 2,
+                bondedAmount: 1000,
+                delegateAddress: transcoder0.address,
+                delegatedAmount: 1000,
+                lastClaimRound: currentRound + 1,
+                lastRewardRound: 0
+            })
+        })
     })
 
     describe("reward", () => {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This adds a missing checkpoint in BondingManager found during the code4rena audit.

The `withdrawFees` function was using `autoClaimEarnings` but not `autoCheckpoint` modifiers, so fixed that and added a test.

**Specific updates (required)**
- Add `autoCheckpoint` modifier to `withdrawFees`
- Add unit test to make sure checkpoint is made

**How did you test each of these updates (required)**
`yarn test` to be deployed to devnet

**Does this pull request close any open issues?**
Fixes:
- https://github.com/code-423n4/2023-08-livepeer-findings/issues/104
- https://github.com/code-423n4/2023-08-livepeer-findings/issues/86

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [ ] All tests using `yarn test` pass
