### PR TITLE
[delta-audit] bonding: Fix treasury cut precision on fee withdrawal

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -351,8 +351,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
                 currentRoundTotalActiveStake
             );
 
-            // Deduct what would have been the treasury rewards
-            uint256 treasuryRewards = MathUtils.percOf(rewards, treasuryRewardCutRate);
+            // deduct what were the treasury rewards
+            uint256 treasuryRewards = PreciseMathUtils.percOf(rewards, treasuryRewardCutRate);
             rewards = rewards.sub(treasuryRewards);
 
             uint256 transcoderCommissionRewards = MathUtils.percOf(rewards, earningsPool.transcoderRewardCut);

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -5199,6 +5199,79 @@ describe("BondingManager", () => {
             )
         })
 
+        it("should retroactively calculate previous round cumulative factors considering treasury rewards", async () => {
+            const FIFTY_PCT = math.precise.percPoints(BigNumber.from(50), 100)
+            await bondingManager.setTreasuryRewardCutRate(FIFTY_PCT)
+
+            await fixture.roundsManager.setMockUint256(
+                functionSig("currentRound()"),
+                currentRound + 2
+            )
+            await fixture.roundsManager.execute(
+                bondingManager.address,
+                functionSig("setCurrentRoundTotalActiveStake()")
+            )
+
+            // rewards on each round will be 500 due to treasury cut
+            await fixture.minter.setMockUint256(
+                functionSig("createReward(uint256,uint256)"),
+                1000
+            )
+            await bondingManager.reward()
+
+            // currently at currentRound + 2, skip to currentRound + 4
+            await fixture.roundsManager.setMockUint256(
+                functionSig("currentRound()"),
+                currentRound + 4
+            )
+            await fixture.roundsManager.execute(
+                bondingManager.address,
+                functionSig("setCurrentRoundTotalActiveStake()")
+            )
+            // notice that we DO call reward for currentRound + 4, but no rewards in currentRound + 3
+            await bondingManager.reward()
+
+            const tr = await bondingManager.getTranscoder(transcoder.address)
+            const cumulativeRewards = tr.cumulativeRewards
+            assert.equal(cumulativeRewards.toString(), "541") // 2 x 250 commissions + (250 / 1500) * 250 commission interest on 2nd round
+
+            await fixture.minter.setMockUint256(
+                functionSig("currentMintableTokens()"),
+                1000
+            )
+            await fixture.ticketBroker.execute(
+                bondingManager.address,
+                functionEncodedABI(
+                    "updateTranscoderWithFees(address,uint256,uint256)",
+                    ["address", "uint256", "uint256"],
+                    [transcoder.address, 1000, currentRound + 3]
+                )
+            )
+
+            const earningsPool =
+                await bondingManager.getTranscoderEarningsPoolForRound(
+                    transcoder.address,
+                    currentRound + 4
+                )
+            assert.equal(
+                earningsPool.cumulativeFeeFactor.toString(),
+                "416666666666666666666666665", // ~ 124999... * 500 / 1500
+                "wrong cumulativeFeeFactor"
+            )
+            assert.equal(
+                (
+                    await bondingManager.getTranscoder(transcoder.address)
+                ).cumulativeFees.toString(),
+                "583" // 500 commission + (250 / 1500) * 500 rewards commission piece
+            )
+            assert.equal(
+                (
+                    await bondingManager.pendingFees(transcoder.address, 0)
+                ).toString(),
+                "999" // rounding error, should be 1000
+            )
+        })
+
         it("should update transcoder's pendingFees when lastActiveStakeUpdateRound > currentRound when stake decreases before function call", async () => {
             // Make sure that lastActiveStakeUpdateRound > currentRound
             await bondingManager


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This fixes the precision used when handleing the `treasuryRewardCutRate` variable in the
`updateTranscoderWithFees` function.

The cut rate is saved in `PreciseMathUtils` precision (27-digit) and was being used as 
a `MathUtils` precision (6-digit).

Also added tests to exercise the specific code (I suspect there wasn't a test case for that specific branch).

**Specific updates (required)**
- Fix the code on BondingManager
- Add unit test for it incl a treasury reward cut set

**How did you test each of these updates (required)**
`yarn test` to be deployed to devnet

**Does this pull request close any open issues?**
Fixes https://github.com/code-423n4/2023-08-livepeer-findings/issues/165


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
