### PR TITLE
[delta-audit] bonding: Provide votes only for registered Ts and their Ds

### DIFF
--- a/contracts/bonding/BondingVotes.sol
+++ b/contracts/bonding/BondingVotes.sol
@@ -345,10 +345,10 @@ contract BondingVotes is ManagerProxyTarget, IBondingVotes {
      * to get the same result here, call this function with `round+1` instead.
      * @dev The value returned by this can also be calculated with the following logic using BondingManager functions at
      * the start of the corresponding round:
-     * - If `isRegisteredTranscoder(_account)`, the result is `(_account, transcoderTotalStake(_account))`
+     * - If `isRegisteredTranscoder(_account)`, the result is `(transcoderTotalStake(_account), _account)`
      * - Otherwise, the `delegate` is obtained from `getDelegator(_account).delegateAddress`
-     *  - If `isRegisteredTranscoder(delegate)`, the result is `(delegate, pendingStake(_account, 0))`
-     *  - Otherwise, the result is `(delegate, 0)`
+     *  - If `isRegisteredTranscoder(delegate)`, the result is `(pendingStake(_account, 0), delegate)`
+     *  - Otherwise, the result is `(0, delegate)`
      * @param _account The account to get the voting power and delegate from.
      * @param _round The round at which to get the account state (at round start).
      * @return votes The voting power of the account at the start of the given round.

--- a/contracts/bonding/IBondingVotes.sol
+++ b/contracts/bonding/IBondingVotes.sol
@@ -46,7 +46,7 @@ interface IBondingVotes is IVotes {
 
     function getTotalActiveStakeAt(uint256 _round) external view returns (uint256);
 
-    function getBondingStateAt(address _account, uint256 _round)
+    function getVotesAndDelegateAtRoundStart(address _account, uint256 _round)
         external
         view
         returns (uint256 amount, address delegateAddress);

--- a/contracts/test/mocks/BondingVotesERC5805Harness.sol
+++ b/contracts/test/mocks/BondingVotesERC5805Harness.sol
@@ -16,7 +16,7 @@ contract BondingVotesERC5805Harness is BondingVotes {
      * @return amount lowest 4 bytes of address + _round
      * @return delegateAddress (_account << 4) | _round.
      */
-    function getBondingStateAt(address _account, uint256 _round)
+    function getVotesAndDelegateAtRoundStart(address _account, uint256 _round)
         public
         pure
         override

--- a/src/test/BondingVotesStateInitialization.sol
+++ b/src/test/BondingVotesStateInitialization.sol
@@ -108,7 +108,7 @@ contract BondingVotesStateInitialization is GovernorBaseTest {
         uint256 currentRound = ROUNDS_MANAGER.currentRound();
 
         for (uint256 i = 0; i < _testAddresses.length; i++) {
-            (uint256 checkedAmount, address checkedDelegate) = bondingVotes.getBondingStateAt(
+            (uint256 checkedAmount, address checkedDelegate) = bondingVotes.getVotesAndDelegateAtRoundStart(
                 _testAddresses[i],
                 currentRound
             );
@@ -128,11 +128,11 @@ contract BondingVotesStateInitialization is GovernorBaseTest {
 
             // Still returns zero checkpoint in the current round, checkpoint is made for the next.
             // We don't check delegatedAmount for simplicity here, it is checked in the other tests.
-            (, address checkedDelegate) = bondingVotes.getBondingStateAt(addr, currentRound);
+            (, address checkedDelegate) = bondingVotes.getVotesAndDelegateAtRoundStart(addr, currentRound);
             assertEq(checkedDelegate, address(0));
 
             // Allows querying up to the next round.
-            (, checkedDelegate) = bondingVotes.getBondingStateAt(addr, currentRound + 1);
+            (, checkedDelegate) = bondingVotes.getVotesAndDelegateAtRoundStart(addr, currentRound + 1);
             assertEq(
                 checkedDelegate,
                 addr == DELEGATOR || addr == DELEGATOR_DELEGATE ? DELEGATOR_DELEGATE : addr == TRANSCODER
@@ -144,7 +144,7 @@ contract BondingVotesStateInitialization is GovernorBaseTest {
             CHEATS.expectRevert(
                 abi.encodeWithSelector(IBondingVotes.FutureLookup.selector, currentRound + 2, currentRound + 1)
             );
-            bondingVotes.getBondingStateAt(addr, currentRound + 2);
+            bondingVotes.getVotesAndDelegateAtRoundStart(addr, currentRound + 2);
         }
     }
 
@@ -154,7 +154,10 @@ contract BondingVotesStateInitialization is GovernorBaseTest {
 
         BONDING_MANAGER.checkpointBondingState(TRANSCODER);
 
-        (uint256 checkedAmount, address checkedDelegate) = bondingVotes.getBondingStateAt(TRANSCODER, currentRound + 1);
+        (uint256 checkedAmount, address checkedDelegate) = bondingVotes.getVotesAndDelegateAtRoundStart(
+            TRANSCODER,
+            currentRound + 1
+        );
         assertEq(checkedAmount, delegatedAmount);
         assertEq(checkedDelegate, TRANSCODER);
     }
@@ -170,7 +173,10 @@ contract BondingVotesStateInitialization is GovernorBaseTest {
         // the delegate also needs to be checkpointed in case of delegators
         BONDING_MANAGER.checkpointBondingState(DELEGATOR_DELEGATE);
 
-        (uint256 checkedAmount, address checkedDelegate) = bondingVotes.getBondingStateAt(DELEGATOR, currentRound + 1);
+        (uint256 checkedAmount, address checkedDelegate) = bondingVotes.getVotesAndDelegateAtRoundStart(
+            DELEGATOR,
+            currentRound + 1
+        );
 
         assertEq(checkedAmount, pendingStake);
         assertEq(checkedDelegate, DELEGATOR_DELEGATE);

--- a/test/gas-report/checkpoints.js
+++ b/test/gas-report/checkpoints.js
@@ -111,31 +111,41 @@ describe("checkpoint bonding state gas report", () => {
         })
     })
 
-    describe("getBondingStateAt", () => {
+    describe("getVotesAndDelegateAtRoundStart", () => {
         beforeEach(async () => {
             await bondingManager.checkpointBondingState(transcoder.address)
             await bondingManager.checkpointBondingState(delegator.address)
             await bondingManager.checkpointBondingState(signers[99].address)
         })
 
-        const gasGetBondingStateAt = async (address, round) => {
-            const tx = await bondingVotes.populateTransaction.getBondingStateAt(
-                address,
-                round
-            )
+        const gasGetVotesAndDelegateAtRoundStart = async (address, round) => {
+            const tx =
+                await bondingVotes.populateTransaction.getVotesAndDelegateAtRoundStart(
+                    address,
+                    round
+                )
             await signers[0].sendTransaction(tx)
         }
 
         it("delegator", async () => {
-            await gasGetBondingStateAt(delegator.address, currentRound + 1)
+            await gasGetVotesAndDelegateAtRoundStart(
+                delegator.address,
+                currentRound + 1
+            )
         })
 
         it("transcoder", async () => {
-            await gasGetBondingStateAt(transcoder.address, currentRound + 1)
+            await gasGetVotesAndDelegateAtRoundStart(
+                transcoder.address,
+                currentRound + 1
+            )
         })
 
         it("non-participant", async () => {
-            await gasGetBondingStateAt(signers[99].address, currentRound + 1)
+            await gasGetVotesAndDelegateAtRoundStart(
+                signers[99].address,
+                currentRound + 1
+            )
         })
     })
 })

--- a/test/integration/BondingVotes.js
+++ b/test/integration/BondingVotes.js
@@ -142,7 +142,7 @@ describe("BondingVotes", () => {
             await nextRound()
         })
 
-        describe("getBondingStateAt", () => {
+        describe("getVotesAndDelegateAtRoundStart", () => {
             it("should return partial rewards for any rounds since bonding", async () => {
                 const pendingRewards0 = math.precise.percOf(
                     mintableTokens[currentRound].div(2), // 50% cut rate
@@ -157,7 +157,10 @@ describe("BondingVotes", () => {
 
                 const stakeAt = round =>
                     bondingVotes
-                        .getBondingStateAt(delegator.address, round)
+                        .getVotesAndDelegateAtRoundStart(
+                            delegator.address,
+                            round
+                        )
                         .then(n => n[0].toString())
 
                 assert.equal(await stakeAt(2), 0)
@@ -176,7 +179,10 @@ describe("BondingVotes", () => {
             it("should return partial rewards for all transcoder stake", async () => {
                 const stakeAt = round =>
                     bondingVotes
-                        .getBondingStateAt(transcoder.address, round)
+                        .getVotesAndDelegateAtRoundStart(
+                            transcoder.address,
+                            round
+                        )
                         .then(n => n[0].toString())
 
                 assert.equal(await stakeAt(2), 0)
@@ -318,16 +324,17 @@ describe("BondingVotes", () => {
             assert.isFalse(await isActive(inactiveTranscoder.address))
         })
 
-        describe("getBondingStateAt", () => {
+        describe("getVotesAndDelegateAtRoundStart", () => {
             it("should provide voting power even for inactive transcoders and their delegators", async () => {
                 const transcoder = transcoders[transcoders.length - 1].address
                 const delegator = delegators[delegators.length - 1].address
 
                 const testHasStake = async (address, round) => {
-                    const [stake] = await bondingVotes.getBondingStateAt(
-                        address,
-                        round
-                    )
+                    const [stake] =
+                        await bondingVotes.getVotesAndDelegateAtRoundStart(
+                            address,
+                            round
+                        )
                     assert.isAbove(
                         stake,
                         0,
@@ -354,7 +361,10 @@ describe("BondingVotes", () => {
                         const expectedStake = pendingStakes[address]
 
                         const [stakeCheckpoint] =
-                            await bondingVotes.getBondingStateAt(address, round)
+                            await bondingVotes.getVotesAndDelegateAtRoundStart(
+                                address,
+                                round
+                            )
                         assert.equal(
                             stakeCheckpoint.toString(),
                             expectedStake,
@@ -382,10 +392,11 @@ describe("BondingVotes", () => {
                 for (const r = currentRound - 2; r <= currentRound + 2; r++) {
                     const activeStakeSum = BigNumber.from(0)
                     for (const transcoder of activeTranscoders) {
-                        const [stake] = await bondingVotes.getBondingStateAt(
-                            transcoder.address,
-                            r
-                        )
+                        const [stake] =
+                            await bondingVotes.getVotesAndDelegateAtRoundStart(
+                                transcoder.address,
+                                r
+                            )
                         activeStakeSum = activeStakeSum.add(stake)
                     }
 
@@ -458,10 +469,10 @@ describe("BondingVotes", () => {
             await nextRound()
         })
 
-        describe("getBondingStateAt", () => {
+        describe("getVotesAndDelegateAtRoundStart", () => {
             const stakeAt = (account, round) =>
                 bondingVotes
-                    .getBondingStateAt(account.address, round)
+                    .getVotesAndDelegateAtRoundStart(account.address, round)
                     .then(n => n[0].toString())
             const expectStakeAt = async (account, round, expected) => {
                 assert.equal(
@@ -608,10 +619,11 @@ describe("BondingVotes", () => {
         })
 
         const expectStakeAt = async (account, round, expected, delegate) => {
-            const stakeAndAddress = await bondingVotes.getBondingStateAt(
-                account.address,
-                round
-            )
+            const stakeAndAddress =
+                await bondingVotes.getVotesAndDelegateAtRoundStart(
+                    account.address,
+                    round
+                )
             assert.equal(
                 stakeAndAddress[0].toString(),
                 expected.toString(),

--- a/test/unit/BondingVotes.js
+++ b/test/unit/BondingVotes.js
@@ -463,7 +463,10 @@ describe("BondingVotes", () => {
 
             assert.deepEqual(
                 await bondingVotes
-                    .getBondingStateAt(transcoder.address, currentRound + 1)
+                    .getVotesAndDelegateAtRoundStart(
+                        transcoder.address,
+                        currentRound + 1
+                    )
                     .then(t => t.map(v => v.toString())),
                 ["1000", transcoder.address]
             )
@@ -493,7 +496,10 @@ describe("BondingVotes", () => {
 
             assert.deepEqual(
                 await bondingVotes
-                    .getBondingStateAt(transcoder.address, currentRound + 1)
+                    .getVotesAndDelegateAtRoundStart(
+                        transcoder.address,
+                        currentRound + 1
+                    )
                     .then(t => t.map(v => v.toString())),
                 ["2000", transcoder.address]
             )
@@ -738,7 +744,7 @@ describe("BondingVotes", () => {
         })
     })
 
-    describe("getBondingStateAt", () => {
+    describe("getVotesAndDelegateAtRoundStart", () => {
         let transcoder
         let delegator
         let currentRound
@@ -752,7 +758,7 @@ describe("BondingVotes", () => {
         })
 
         it("should fail if round is after the next round", async () => {
-            const tx = bondingVotes.getBondingStateAt(
+            const tx = bondingVotes.getVotesAndDelegateAtRoundStart(
                 delegator.address,
                 currentRound + 2
             )
@@ -782,7 +788,10 @@ describe("BondingVotes", () => {
             const expectZeroCheckpoint = async queryRound => {
                 expect(
                     await bondingVotes
-                        .getBondingStateAt(delegator.address, queryRound)
+                        .getVotesAndDelegateAtRoundStart(
+                            delegator.address,
+                            queryRound
+                        )
                         .then(t => t.map(v => v.toString()))
                 ).to.deep.equal(["0", constants.NULL_ADDRESS])
             }
@@ -838,7 +847,10 @@ describe("BondingVotes", () => {
 
                 assert.deepEqual(
                     await bondingVotes
-                        .getBondingStateAt(transcoder.address, currentRound - 2)
+                        .getVotesAndDelegateAtRoundStart(
+                            transcoder.address,
+                            currentRound - 2
+                        )
                         .then(t => t.map(v => v.toString())),
                     ["0", constants.NULL_ADDRESS]
                 )
@@ -849,7 +861,10 @@ describe("BondingVotes", () => {
 
                 assert.deepEqual(
                     await bondingVotes
-                        .getBondingStateAt(transcoder.address, currentRound)
+                        .getVotesAndDelegateAtRoundStart(
+                            transcoder.address,
+                            currentRound
+                        )
                         .then(t => t.map(v => v.toString())),
                     ["1000", transcoder.address]
                 )
@@ -861,14 +876,20 @@ describe("BondingVotes", () => {
 
                 assert.deepEqual(
                     await bondingVotes
-                        .getBondingStateAt(transcoder.address, currentRound - 7)
+                        .getVotesAndDelegateAtRoundStart(
+                            transcoder.address,
+                            currentRound - 7
+                        )
                         .then(t => t.map(v => v.toString())),
                     ["1000", transcoder.address]
                 )
 
                 assert.deepEqual(
                     await bondingVotes
-                        .getBondingStateAt(transcoder.address, currentRound)
+                        .getVotesAndDelegateAtRoundStart(
+                            transcoder.address,
+                            currentRound
+                        )
                         .then(t => t.map(v => v.toString())),
                     ["2000", transcoder.address]
                 )
@@ -962,7 +983,10 @@ describe("BondingVotes", () => {
 
                 assert.deepEqual(
                     await bondingVotes
-                        .getBondingStateAt(delegator.address, currentRound)
+                        .getVotesAndDelegateAtRoundStart(
+                            delegator.address,
+                            currentRound
+                        )
                         .then(t => t.map(v => v.toString())),
                     ["0", constants.NULL_ADDRESS]
                 )
@@ -978,7 +1002,10 @@ describe("BondingVotes", () => {
 
                 assert.deepEqual(
                     await bondingVotes
-                        .getBondingStateAt(delegator.address, currentRound)
+                        .getVotesAndDelegateAtRoundStart(
+                            delegator.address,
+                            currentRound
+                        )
                         .then(t => t.map(v => v.toString())),
                     ["1000", transcoder.address]
                 )
@@ -1001,14 +1028,20 @@ describe("BondingVotes", () => {
 
                 assert.deepEqual(
                     await bondingVotes
-                        .getBondingStateAt(delegator.address, currentRound - 7)
+                        .getVotesAndDelegateAtRoundStart(
+                            delegator.address,
+                            currentRound - 7
+                        )
                         .then(t => t.map(v => v.toString())),
                     ["1000", transcoder.address]
                 )
 
                 assert.deepEqual(
                     await bondingVotes
-                        .getBondingStateAt(delegator.address, currentRound)
+                        .getVotesAndDelegateAtRoundStart(
+                            delegator.address,
+                            currentRound
+                        )
                         .then(t => t.map(v => v.toString())),
                     ["2000", transcoder2.address]
                 )
@@ -1040,7 +1073,10 @@ describe("BondingVotes", () => {
 
                 assert.deepEqual(
                     await bondingVotes
-                        .getBondingStateAt(delegator.address, currentRound)
+                        .getVotesAndDelegateAtRoundStart(
+                            delegator.address,
+                            currentRound
+                        )
                         .then(t => t.map(v => v.toString())),
                     ["1000", transcoder.address]
                 )
@@ -1066,7 +1102,7 @@ describe("BondingVotes", () => {
                 })
                 // no earning pool for currentRound - 2
 
-                const tx = bondingVotes.getBondingStateAt(
+                const tx = bondingVotes.getVotesAndDelegateAtRoundStart(
                     delegator.address,
                     currentRound
                 )
@@ -1103,7 +1139,10 @@ describe("BondingVotes", () => {
 
                 assert.deepEqual(
                     await bondingVotes
-                        .getBondingStateAt(delegator.address, currentRound)
+                        .getVotesAndDelegateAtRoundStart(
+                            delegator.address,
+                            currentRound
+                        )
                         .then(t => t.map(v => v.toString())),
                     ["3000", transcoder.address]
                 )
@@ -1131,7 +1170,10 @@ describe("BondingVotes", () => {
 
                 assert.deepEqual(
                     await bondingVotes
-                        .getBondingStateAt(delegator.address, currentRound)
+                        .getVotesAndDelegateAtRoundStart(
+                            delegator.address,
+                            currentRound
+                        )
                         .then(t => t.map(v => v.toString())),
                     ["5000", transcoder.address]
                 )
@@ -1212,7 +1254,10 @@ describe("BondingVotes", () => {
                 [expectedAmount, expectedDelegate]
             ) => {
                 const actual = await bondingVotes
-                    .getBondingStateAt(delegator.address, currentRound)
+                    .getVotesAndDelegateAtRoundStart(
+                        delegator.address,
+                        currentRound
+                    )
                     .then(t => t.map(v => v.toString()))
                 const expected = [
                     expectedAmount.toString(),
@@ -1337,7 +1382,7 @@ describe("BondingVotes", () => {
 
         // Same implementation as the BondingVotesERC5805Mock
         const mock = {
-            getBondingStateAt: (_account, _round) => {
+            getVotesAndDelegateAtRoundStart: (_account, _round) => {
                 const intAddr = BigNumber.from(_account)
 
                 // lowest 4 bytes of address + _round
@@ -1382,8 +1427,8 @@ describe("BondingVotes", () => {
         })
 
         describe("getVotes", () => {
-            it("should proxy to getBondingStateAt with the next round", async () => {
-                const [expected] = mock.getBondingStateAt(
+            it("should proxy to getVotesAndDelegateAtRoundStart with the next round", async () => {
+                const [expected] = mock.getVotesAndDelegateAtRoundStart(
                     signers[0].address,
                     currentRound + 1
                 )
@@ -1402,9 +1447,9 @@ describe("BondingVotes", () => {
                 await expect(tx).to.be.revertedWith("FutureLookup(1000, 999)")
             })
 
-            it("should proxy to getBondingStateAt with next round", async () => {
+            it("should proxy to getVotesAndDelegateAtRoundStart with next round", async () => {
                 const testOnce = async (account, round) => {
-                    const [expected] = mock.getBondingStateAt(
+                    const [expected] = mock.getVotesAndDelegateAtRoundStart(
                         account.address,
                         round + 1
                     )
@@ -1424,8 +1469,8 @@ describe("BondingVotes", () => {
         })
 
         describe("delegates", () => {
-            it("should proxy to getBondingStateAt with the next round", async () => {
-                const [, expected] = mock.getBondingStateAt(
+            it("should proxy to getVotesAndDelegateAtRoundStart with the next round", async () => {
+                const [, expected] = mock.getVotesAndDelegateAtRoundStart(
                     signers[5].address,
                     currentRound + 1
                 )
@@ -1437,9 +1482,9 @@ describe("BondingVotes", () => {
         })
 
         describe("delegatedAt", () => {
-            it("should proxy to getBondingStateAt with next round", async () => {
+            it("should proxy to getVotesAndDelegateAtRoundStart with next round", async () => {
                 const testOnce = async (account, round) => {
-                    const [, expected] = mock.getBondingStateAt(
+                    const [, expected] = mock.getVotesAndDelegateAtRoundStart(
                         account.address,
                         round + 1
                     )

--- a/test/unit/BondingVotes.js
+++ b/test/unit/BondingVotes.js
@@ -719,13 +719,14 @@ describe("BondingVotes", () => {
                         constants.NULL_ADDRESS,
                         transcoder.address
                     )
+                // this is still emitted because lastClaimRound changed
+                await expect(tx)
+                    .to.emit(bondingVotes, "DelegatorBondedAmountChanged")
+                    .withArgs(transcoder.address, 0, 0, 0, currentRound)
+
                 await expect(tx).not.to.emit(
                     bondingVotes,
                     "DelegateVotesChanged"
-                )
-                await expect(tx).not.to.emit(
-                    bondingVotes,
-                    "DelegatorBondedAmountChanged"
                 )
             })
         })

--- a/test/unit/BondingVotes.js
+++ b/test/unit/BondingVotes.js
@@ -861,7 +861,7 @@ describe("BondingVotes", () => {
                     const functionData = encodeCheckpointBondingState({
                         account,
                         startRound,
-                        bondedAmount: 0, // not used in these tests
+                        bondedAmount: 1, // required to be considered a registered transcoder
                         delegateAddress: account,
                         delegatedAmount: 0, // not used in these tests
                         lastClaimRound: startRound - 1,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This fixes another issue from the audit regarding voting power provided to delegators. The specific issue is when a delegator has a bond with an account that is not a "registered transcoder" (`delegateAddress == self && bondedAmount > 0`). 

This can happen when bonding to a random account that is not a transcoder, when the transcoder unbonds or gets slashed 100%. The main problem created from this is that the transcoder would then have `0` voting power, while the delegators would still hold on to their delegated voting power, messing up vote overriding on `GovenorCountingOverridable`. Even with the https://github.com/livepeer/protocol/pull/626 fix, there would still be a problem in case `bondedAmount == 0` but still `delegateAddress == self` (can happen in the slash case).

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Update BondingVotes to not give voting power to delegators to non-transcoders (transcoder defined as self-delegate a non 0 amount)
- Add tests

**How did you test each of these updates (required)**
`yarn test` with pending devnet deploy

**Does this pull request close any open issues?**
Fixes:
- https://github.com/code-423n4/2023-08-livepeer-findings/issues/194
- https://github.com/code-423n4/2023-08-livepeer-findings/issues/96

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] All tests using `yarn test` pass
