### PR TITLE
[delta-audit] treasury: Avoid overriding vote of non self-bonding accounts

### DIFF
--- a/contracts/treasury/GovernorCountingOverridable.sol
+++ b/contracts/treasury/GovernorCountingOverridable.sol
@@ -181,15 +181,14 @@ abstract contract GovernorCountingOverridable is Initializable, GovernorUpgradea
         uint256 timepoint = proposalSnapshot(_proposalId);
         address delegate = votes().delegatedAt(_account, timepoint);
 
-        bool selfDelegates = _account == delegate;
-        if (selfDelegates) {
+        bool isSelfDelegated = _account == delegate;
+        if (isSelfDelegated) {
             // deduce weight from any previous delegators for this self-delegating account to cast a vote
             return _weight - _voter.deductions;
         }
 
-        address delegatesDelegate = votes().delegatedAt(delegate, timepoint);
-        bool delegateSelfDelegates = delegate == delegatesDelegate;
-        if (!delegateSelfDelegates) {
+        bool isDelegateSelfDelegated = delegate == votes().delegatedAt(delegate, timepoint);
+        if (!isDelegateSelfDelegated) {
             // do not override votes of non-self-delegating accounts since those don't get their voting power from the
             // sum of delegations to them, so the override logic doesn't apply.
             return _weight;


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This fixes a finding from the audit regarding on overriding votes. It addresses the problem of delegating to a non-transcoder account and then overriding their votes imprperly. 

The known corner cases that can trigger this inconsistency are:
- delegating to an account that isn't a transcoder (either another delegator or a non participant)
- transcoder unbonding their full amount (delegators stay delegated to it)

**Specific updates (required)**
- Update GovernorCountingOverridable to not override votes of accounts that don't self-delegate 

**How did you test each of these updates (required)**
`yarn test` to be deployed on devnet

**Does this pull request close any open issues?**
Fixes:
- https://github.com/code-423n4/2023-08-livepeer-findings/issues/96
- https://github.com/code-423n4/2023-08-livepeer-findings/issues/206

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
