### PR TITLE
[delta-audit] bonding: Fix votes for fully slashed transcoders

### DIFF
--- a/contracts/bonding/BondingVotes.sol
+++ b/contracts/bonding/BondingVotes.sol
@@ -369,9 +369,7 @@ contract BondingVotes is ManagerProxyTarget, IBondingVotes {
         delegateAddress = bond.delegateAddress;
         bool isTranscoder = delegateAddress == _account;
 
-        if (bond.bondedAmount == 0) {
-            amount = 0;
-        } else if (isTranscoder) {
+        if (isTranscoder) {
             // Address is a registered transcoder so we use its delegated amount. This includes self and delegated stake
             // as well as any accrued rewards, even unclaimed ones
             amount = bond.delegatedAmount;
@@ -461,6 +459,10 @@ contract BondingVotes is ManagerProxyTarget, IBondingVotes {
         view
         returns (uint256)
     {
+        if (bond.bondedAmount == 0) {
+            return 0;
+        }
+
         EarningsPool.Data memory startPool = getTranscoderEarningsPoolForRound(
             bond.delegateAddress,
             bond.lastClaimRound


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This fixes another issue from the audit regarding voting power provided to transcoders. The specific issue is when a transcoder gets to state where its self-bonding a `0` amount (`delegateAddress` non-zero).

The only known corner case that can trigger this inconsistency is a transcoder getting slashed 100% of its bond. In this case, it would still be self-delegating but a zero amount, which used to give it a zero voting power. Even with the https://github.com/livepeer/protocol/pull/626 fix, this would still cause problems as delegators would have more votes than the self-delegating transcoder.

Even though slashing is not used today [1] and this state (`bondedAmount == 0 & delegateAddress != 0`) being theoretically invalid, it is still possible to happen from the current BondingManager code. So it shouldn't hurt to be more reliable and consistent on the voting power logic.

[1] We could say there are 2 problems on it today: it doesn't update `delegateAddress` nor `delegatedAmount` when the transcoder is fully slashed (which might be an even more unrealistic scenario). Not worth making changes to that function rn so we can fix the new code instead.

**Specific updates (required)**
- Update BondingVotes to not zero the voting power of transcoders with a 0 `bondedAmount`

**How did you test each of these updates (required)**
`yarn test` with pending devnet deploy

**Does this pull request close any open issues?**
Fixes https://github.com/code-423n4/2023-08-livepeer-findings/issues/194

Also related to this one, even though not a fix for it:
- https://github.com/code-423n4/2023-08-livepeer-findings/issues/206

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] All tests using `yarn test` pass
