### PR TITLE
[delta-audit] bonding: Disallow making bonds for the zero address

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -724,6 +724,8 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
             // Requirements for caller
             // Does not trigger self-delegation
             require(oldDelDelegate != _delegator, "INVALID_DELEGATOR");
+            // Does not transfer bond to the zero address
+            require(address(0) != _delegator, "INVALID_DELEGATOR");
 
             newDel.delegateAddress = oldDelDelegate;
         }

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -558,11 +558,14 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
         // Requirements for a third party caller that is not the L2Migrator
         if (msg.sender != _owner && msg.sender != l2Migrator()) {
-            // Does not trigger self-delegation
-            // Does not change the delegate if it is already non-null
+            // Does not bond for the zero address
+            require(_owner != address(0), "INVALID_DELEGATOR");
+
             if (delegatorStatus(_owner) == DelegatorStatus.Unbonded) {
+                // Does not trigger self-delegation
                 require(_to != _owner, "INVALID_DELEGATE");
             } else {
+                // Does not change the delegate if it is already non-null
                 require(currentDelegate == _to, "INVALID_DELEGATE_CHANGE");
             }
         }

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -3815,6 +3815,21 @@ describe("BondingManager", () => {
             })
 
             describe("receiver is not bonded", () => {
+                it("should fail if receiver is the zero address", async () => {
+                    const tx = bondingManager
+                        .connect(delegator3)
+                        .transferBond(
+                            ZERO_ADDRESS,
+                            1,
+                            ZERO_ADDRESS,
+                            ZERO_ADDRESS,
+                            ZERO_ADDRESS,
+                            ZERO_ADDRESS
+                        )
+
+                    await expect(tx).to.be.revertedWith("INVALID_DELEGATOR")
+                })
+
                 it("should fail if caller is delegated to receiver", async () => {
                     const tx = bondingManager
                         .connect(delegator3)

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -2234,6 +2234,22 @@ describe("BondingManager", () => {
                     )
                 })
 
+                it("should fail to make a bond for the zero address", async () => {
+                    const tx = bondingManager
+                        .connect(thirdParty)
+                        .bondForWithHint(
+                            1000,
+                            ethers.constants.AddressZero,
+                            transcoder1.address,
+                            ethers.constants.AddressZero,
+                            ethers.constants.AddressZero,
+                            ethers.constants.AddressZero,
+                            ethers.constants.AddressZero
+                        )
+
+                    await expect(tx).to.be.revertedWith("INVALID_DELEGATOR")
+                })
+
                 it("should increase delegated amount for a delegator without changing delegate", async () => {
                     const delegate = (
                         await bondingManager.getDelegator(delegator2.address)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is to disallow the `*For` functions to be called with the zero address
as the owner, which is effectively a buggy way of burning tokens. This also
fixes the `BondingVotes` behavior to not allow the zero address to ever have
any voting power, as specified in the corresponding EIP.

**Specific updates (required)**
- Make `bondForWithHint` disallow bonding for `address(0)`
- Make `transferBond` disallow transferring bond to `address(0)`

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Fixes https://github.com/code-423n4/2023-08-livepeer-findings/issues/190

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] All tests using `yarn test` pass
