### PR TITLE
bonding: Skip fee calculation for voting power

### DIFF
--- a/contracts/bonding/BondingVotes.sol
+++ b/contracts/bonding/BondingVotes.sol
@@ -485,13 +485,7 @@ contract BondingVotes is ManagerProxyTarget, IBondingVotes {
             return bond.bondedAmount;
         }
 
-        (uint256 stakeWithRewards, ) = EarningsPoolLIP36.delegatorCumulativeStakeAndFees(
-            startPool,
-            endPool,
-            bond.bondedAmount,
-            0
-        );
-        return stakeWithRewards;
+        return EarningsPoolLIP36.delegatorCumulativeStake(startPool, endPool, bond.bondedAmount);
     }
 
     /**

--- a/contracts/bonding/libraries/EarningsPoolLIP36.sol
+++ b/contracts/bonding/libraries/EarningsPoolLIP36.sol
@@ -125,11 +125,6 @@ library EarningsPoolLIP36 {
             _startPool.cumulativeRewardFactor = PreciseMathUtils.percPoints(1, 1);
         }
 
-        // If the end cumulativeRewardFactor is 0 set the default value to PreciseMathUtils.percPoints(1, 1)
-        if (_endPool.cumulativeRewardFactor == 0) {
-            _endPool.cumulativeRewardFactor = PreciseMathUtils.percPoints(1, 1);
-        }
-
         uint256 earnedFees = PreciseMathUtils.percOf(
             _stake,
             _endPool.cumulativeFeeFactor.sub(_startPool.cumulativeFeeFactor),

--- a/contracts/test/mocks/EarningsPoolFixture.sol
+++ b/contracts/test/mocks/EarningsPoolFixture.sol
@@ -36,6 +36,11 @@ contract EarningsPoolFixture {
         prevPool.cumulativeRewardFactor = _cumulativeRewardFactor;
     }
 
+    function setEarningsFactors(uint256 _cumulativeFeeFactor, uint256 _cumulativeRewardFactor) public {
+        pool.cumulativeFeeFactor = _cumulativeFeeFactor;
+        pool.cumulativeRewardFactor = _cumulativeRewardFactor;
+    }
+
     function getTranscoderRewardCut() public view returns (uint256) {
         return pool.transcoderRewardCut;
     }
@@ -54,5 +59,21 @@ contract EarningsPoolFixture {
 
     function getCumulativeFeeFactor() public view returns (uint256) {
         return pool.cumulativeFeeFactor;
+    }
+
+    function delegatorCumulativeStake(uint256 _stake) public view returns (uint256) {
+        return EarningsPoolLIP36.delegatorCumulativeStake(prevPool, pool, _stake);
+    }
+
+    function delegatorCumulativeFees(uint256 _stake, uint256 _fees) public view returns (uint256) {
+        return EarningsPoolLIP36.delegatorCumulativeFees(prevPool, pool, _stake, _fees);
+    }
+
+    function delegatorCumulativeStakeAndFees(uint256 _stake, uint256 _fees)
+        public
+        view
+        returns (uint256 cStake, uint256 cFees)
+    {
+        return EarningsPoolLIP36.delegatorCumulativeStakeAndFees(prevPool, pool, _stake, _fees);
     }
 }

--- a/deploy/deploy_bonding_votes.ts
+++ b/deploy/deploy_bonding_votes.ts
@@ -1,0 +1,33 @@
+import {HardhatRuntimeEnvironment} from "hardhat/types"
+import {DeployFunction} from "hardhat-deploy/types"
+
+import ContractDeployer from "../utils/deployer"
+
+const PROD_NETWORKS = ["mainnet", "arbitrumMainnet"]
+
+const isProdNetwork = (name: string): boolean => {
+    return PROD_NETWORKS.indexOf(name) > -1
+}
+
+const func: DeployFunction = async function(hre: HardhatRuntimeEnvironment) {
+    const {deployments, getNamedAccounts} = hre // Get the deployments and getNamedAccounts which are provided by hardhat-deploy
+
+    const {deployer} = await getNamedAccounts() // Fetch named accounts from hardhat.config.ts
+
+    const contractDeployer = new ContractDeployer(deployer, deployments)
+    const controller = await contractDeployer.fetchDeployedController()
+
+    const deploy = isProdNetwork(hre.network.name) ?
+        contractDeployer.deploy.bind(contractDeployer) :
+        contractDeployer.deployAndRegister.bind(contractDeployer)
+
+    await deploy({
+        contract: "BondingVotes",
+        name: "BondingVotesTarget",
+        args: [controller.address],
+        proxy: false // deploying only the target
+    })
+}
+
+func.tags = ["BONDING_VOTES"]
+export default func

--- a/src/test/BondingVotesFeeLessVotesFix.sol
+++ b/src/test/BondingVotesFeeLessVotesFix.sol
@@ -1,0 +1,58 @@
+pragma solidity ^0.8.9;
+
+import "ds-test/test.sol";
+import "./base/GovernorBaseTest.sol";
+import "contracts/Controller.sol";
+import "contracts/bonding/BondingVotes.sol";
+import "contracts/bonding/BondingManager.sol";
+import "./interfaces/ICheatCodes.sol";
+
+// forge test --match-contract BondingVotesFeeLessVotesFix --fork-url https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY -vvv --fork-block-number 140314540
+contract BondingVotesFeeLessVotesFix is GovernorBaseTest {
+    bytes public constant arithmeticError = abi.encodeWithSignature("Panic(uint256)", 0x11);
+
+    BondingManager public constant BONDING_MANAGER = BondingManager(0x35Bcf3c30594191d53231E4FF333E8A770453e40);
+    IBondingVotes public constant BONDING_VOTES = IBondingVotes(0x0B9C254837E72Ebe9Fe04960C43B69782E68169A);
+
+    bytes32 public constant BONDING_VOTES_TARGET_ID = keccak256("BondingVotesTarget");
+
+    BondingVotes public newBondingVotesTarget;
+
+    address public DELEGATOR = 0xdB18A9353139880d73616e4972a855d66C9B69f0;
+
+    function setUp() public {
+        newBondingVotesTarget = new BondingVotes(address(CONTROLLER));
+    }
+
+    function doUpgrade() internal {
+        (, gitCommitHash) = CONTROLLER.getContractInfo(BONDING_VOTES_TARGET_ID);
+
+        stageAndExecuteOne(
+            address(CONTROLLER),
+            0,
+            abi.encodeWithSelector(
+                CONTROLLER.setContractInfo.selector,
+                BONDING_VOTES_TARGET_ID,
+                address(newBondingVotesTarget),
+                gitCommitHash
+            )
+        );
+
+        // Check that new BondingVotesTarget is registered
+        (address infoAddr, bytes20 infoGitCommitHash) = fetchContractInfo(BONDING_VOTES_TARGET_ID);
+        assertEq(infoAddr, address(newBondingVotesTarget));
+        assertEq(infoGitCommitHash, gitCommitHash);
+    }
+
+    function testBeforeUpgrade() public {
+        CHEATS.expectRevert(arithmeticError);
+        BONDING_VOTES.getVotes(DELEGATOR);
+    }
+
+    function testAfterUpgrade() public {
+        doUpgrade();
+
+        uint256 votes = BONDING_VOTES.getVotes(DELEGATOR);
+        assertTrue(votes > 0);
+    }
+}

--- a/test/integration/BondingVotes.js
+++ b/test/integration/BondingVotes.js
@@ -961,7 +961,6 @@ describe("BondingVotes", () => {
                 const creationRound = await roundsManager.currentRound()
                 const creationRoundBlockHash =
                     await roundsManager.blockHashForRound(creationRound)
-                console.log(creationRoundBlockHash)
                 const auxData = ethers.utils.solidityPack(
                     ["uint256", "bytes32"],
                     [creationRound, creationRoundBlockHash]


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This fixes a bug observed after deploying the new BondingVotes to production.

It happens when trying to calculate voting power for a delegator whose transcoder hadn't
initialized their `cumulativeFeeFactor` on the corresponding round.

This causes the voting power calculation to underflow, because we don't initialize the
`cumulativeFeeFactor` of the `endPool` like `BondingManager` does. Even though we 
don't really care about fees for voting power, the underflow causes a revert on any 
transaction that needs to access the delegator votes at the uninitialized round.

**Specific updates (required)**
- Break `delegatorCumulativeStakeAndFees` logic in 2, to allow calculating only stake or only fees
- Call the stake-only version from BondingVotes
- PENDING: a couple tests

**How did you test each of these updates (required)**
`yarn test` that it didnt change any existing behavior on BondingManager
New tests on BondingVotes
May do a tenderly fork test before actual deploy

**Does this pull request close any open issues?**
N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] All tests using `yarn test` pass
