### PR TITLE
Call reward for another eth addr

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -298,7 +298,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * @notice Mint token rewards for an active transcoder and its delegators
      * @param _transcoder Address of the transcoder to call reward as
     */
-    function reward(address _transcoder) external {
+    function rewardAs(address _transcoder) external {
         rewardWithHint(_transcoder, address(0), address(0));
     }
 

--- a/test/gas-report/poolsize.js
+++ b/test/gas-report/poolsize.js
@@ -492,6 +492,7 @@ describe("transcoder pool size gas report", () => {
                         await bondingManager
                             .connect(transcoders[0])
                             .rewardWithHint(
+                                transcoders[0].address,
                                 transcoders[1].address,
                                 ethers.constants.AddressZero
                             )

--- a/test/integration/PoolUpdatesWithHints.js
+++ b/test/integration/PoolUpdatesWithHints.js
@@ -152,6 +152,7 @@ describe("PoolUpdatesWithHints", () => {
             await bondingManager
                 .connect(transcoders[size - 1])
                 .rewardWithHint(
+                    transcoders[size - 1].address,
                     transcoders[size - 2].address,
                     ethers.constants.AddressZero
                 )


### PR DESCRIPTION
Adds the function to call reward for a given orch eth address. This is useful, since a throwaway wallet could then be used to call reward, keeping the main wallet more secure


**Todo:**
- Added a separate function cause the JS test library would vomit on function overloading, but can be fixed by modifying all tests...
- Add new tests
