### PR TITLE
Ensure the treasury automatically resumes once balance < cap

### DIFF
--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -470,9 +470,16 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     function setCurrentRoundTotalActiveStake() external onlyRoundsManager {
         currentRoundTotalActiveStake = nextRoundTotalActiveStake;
 
-        if (nextRoundTreasuryRewardCutRate != treasuryRewardCutRate) {
+        // Set the treasury cut to 0 while the treasury balance is above the ceiling
+        uint256 treasuryBalance = livepeerToken().balanceOf(treasury());
+        if (treasuryBalanceCeiling > 0 && treasuryBalance >= treasuryBalanceCeiling) {
+            if (treasuryRewardCutRate > 0) {
+                treasuryRewardCutRate = 0;
+                emit ParameterUpdate("treasuryRewardCutRate");
+            }
+        } else if (nextRoundTreasuryRewardCutRate != treasuryRewardCutRate) {
+            // Reset to the desired treasury cut rate
             treasuryRewardCutRate = nextRoundTreasuryRewardCutRate;
-            // The treasury cut rate changes in a delayed fashion so we want to emit the parameter update event here
             emit ParameterUpdate("treasuryRewardCutRate");
         }
 
@@ -888,14 +895,6 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         uint256 lastUpdateRound = t.lastActiveStakeUpdateRound;
         if (lastUpdateRound < currentRound) {
             earningsPool.setStake(t.earningsPoolPerRound[lastUpdateRound].totalStake);
-        }
-
-        if (treasuryBalanceCeiling > 0) {
-            uint256 treasuryBalance = livepeerToken().balanceOf(treasury());
-            if (treasuryBalance >= treasuryBalanceCeiling && nextRoundTreasuryRewardCutRate > 0) {
-                // halt treasury contributions until the cut rate param is updated again
-                _setTreasuryRewardCutRate(0);
-            }
         }
 
         // Create reward based on active transcoder's stake relative to the total active stake


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Ensures the treasury automatically resumes instead of setting the cut to 0% once the cap is reached. This way, it will continue accumulating as the balance depletes.

Wondering if this can be a good solution instead of raising the cap. 
Note that this will cause an emitted `ParameterUpdate` event for the `treasuryRewardCutRate` after each round it flips below/above the cap.
This change does not affect the subgraph, as that is not updated to take the treasury into account at all at the moment.


**Specific updates (required)**
- Removes logic in reward calls which modifies `nextRoundTreasuryRewardCutRate` when the cap is reached.
- Modify Round init to set the cut for _the current round only_ to 0 for as long as the cap is reached.

**How did you test each of these updates (required)**
N/A


**Does this pull request close any open issues?**
N/A


**Checklist:**
- [ ] README and other documentation updated
- [ ] All tests using `yarn test` pass
