### PR TITLE
Add reward caller (using propose-confirm pattern)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,6 +47,9 @@ jobs:
           name: ${{ github.event.repository.name }}
           token: ${{ secrets.CI_CODECOV_TOKEN }}
 
+      - name: Enforce test coverage threshold
+        run: yarn test:coverage:check
+
   editorconfig:
     name: Run editorconfig checker
     runs-on: ubuntu-latest

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -105,7 +105,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     // Transcoder addresses proposed by the RewardCallers
     mapping(address => address) public rewardCallerToTranscoderProposed;
 
-    // Transcoder addresses confirmed by the transcoders
+    // RewardCaller addresses confirmed by the transcoders
     mapping(address => address) public rewardCallerToTranscoderConfirmed;
 
     // Check if sender is TicketBroker

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -910,7 +910,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         address transcoder = msg.sender;
         if (!isActiveTranscoder(transcoder)) {
             transcoder = rewardCallerToTranscoderConfirmed[msg.sender];
-            require(isActiveTranscoder(transcoder), "caller must be an active transcoder or rewardCaller");
+            require(isActiveTranscoder(transcoder), "transcoder must be active");
         }
         require(
             transcoders[transcoder].lastRewardRound != currentRound,

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -199,7 +199,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * @param _transcoder Address of the transcoder
      * @dev Only callable by the RewardCaller
      */
-    function proposeRewardCaller(address _transcoder) external whenSystemNotPaused {
+    function proposeTranscoderForRewardCaller(address _transcoder) external whenSystemNotPaused {
         rewardCallerToTranscoderProposed[msg.sender] = _transcoder;
         emit RewardCallerProposed(_transcoder, msg.sender);
     }
@@ -207,7 +207,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     /**
      * @notice Confirm a reward caller for a transcoder
      * @param _rewardCaller Address of the new reward caller
-     * @dev Only callable by the transcoder, after RewardCaller was proposed via proposeRewardCaller
+     * @dev Only callable by the transcoder, after RewardCaller was proposed via proposeTranscoderForRewardCaller
      */
     function confirmRewardCaller(address _rewardCaller) external whenSystemNotPaused {
         require(rewardCallerToTranscoderProposed[_rewardCaller] == msg.sender, "reward caller was not proposed");

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -102,8 +102,11 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     // If the balance of the treasury in LPT is above this value, automatic treasury contributions will halt.
     uint256 public treasuryBalanceCeiling;
 
-    // Allow reward() calls by pre-defined set of addresses
-    mapping(address => address) private rewardCallerToTranscoder;
+    // Transcoder addresses proposed by the RewardCallers
+    mapping(address => address) public rewardCallerToTranscoderProposed;
+
+    // Transcoder addresses confirmed by the transcoders
+    mapping(address => address) public rewardCallerToTranscoderConfirmed;
 
     // Check if sender is TicketBroker
     modifier onlyTicketBroker() {
@@ -192,23 +195,36 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @notice Set a reward caller for a transcoder
-     * @param _rewardCaller Address of the new reward caller
+     * @notice Propose a transcoder for a reward caller
+     * @param _transcoder Address of the transcoder
+     * @dev Only callable by the RewardCaller
      */
-    function setRewardCaller(address _rewardCaller) external whenSystemNotPaused {
-        require(rewardCallerToTranscoder[_rewardCaller] == address(0), "reward caller is already set");
-        rewardCallerToTranscoder[_rewardCaller] = msg.sender;
-        emit RewardCallerSet(msg.sender, _rewardCaller);
+    function proposeRewardCaller(address _transcoder) external whenSystemNotPaused {
+        rewardCallerToTranscoderProposed[msg.sender] = _transcoder;
+        emit RewardCallerProposed(_transcoder, msg.sender);
     }
 
     /**
-     * @notice Unset a reward caller for a transcoder
-     * @param _rewardCaller Address of the existing reward caller
+     * @notice Confirm a reward caller for a transcoder
+     * @param _rewardCaller Address of the new reward caller
+     * @dev Only callable by the transcoder, after RewardCaller was proposed via proposeRewardCaller
      */
-    function unsetRewardCaller(address _rewardCaller) external whenSystemNotPaused {
-        require(rewardCallerToTranscoder[_rewardCaller] == msg.sender, "only relevant transcoder can unset");
-        rewardCallerToTranscoder[_rewardCaller] = address(0);
-        emit RewardCallerUnset(msg.sender, _rewardCaller);
+    function confirmRewardCaller(address _rewardCaller) external whenSystemNotPaused {
+        require(rewardCallerToTranscoderProposed[_rewardCaller] == msg.sender, "reward caller was not proposed");
+        rewardCallerToTranscoderProposed[_rewardCaller] = address(0);
+        rewardCallerToTranscoderConfirmed[_rewardCaller] = msg.sender;
+        emit RewardCallerConfirmed(msg.sender, _rewardCaller);
+    }
+
+    /**
+     * @notice Remove a reward caller for a transcoder
+     * @param _rewardCaller Address of the existing reward caller
+     * @dev Only callable by the transcoder, when the _rewardCaller was already proposed
+     */
+    function removeRewardCaller(address _rewardCaller) external whenSystemNotPaused {
+        require(rewardCallerToTranscoderConfirmed[_rewardCaller] == msg.sender, "only relevant transcoder can unset");
+        rewardCallerToTranscoderConfirmed[_rewardCaller] = address(0);
+        emit RewardCallerRemoved(msg.sender, _rewardCaller);
     }
 
     /**
@@ -888,21 +904,20 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         public
         whenSystemNotPaused
         currentRoundInitialized
-        autoCheckpoint(msg.sender)
     {
         uint256 currentRound = roundsManager().currentRound();
 
-        address transcoderAddress = msg.sender;
-        if (!isActiveTranscoder(transcoderAddress)) {
-            transcoderAddress = rewardCallerToTranscoder[msg.sender];
-            require(isActiveTranscoder(transcoderAddress), "caller must be an active transcoder or rewardCaller");
+        address transcoder = msg.sender;
+        if (!isActiveTranscoder(transcoder)) {
+            transcoder = rewardCallerToTranscoderConfirmed[msg.sender];
+            require(isActiveTranscoder(transcoder), "caller must be an active transcoder or rewardCaller");
         }
         require(
-            transcoders[transcoderAddress].lastRewardRound != currentRound,
+            transcoders[transcoder].lastRewardRound != currentRound,
             "caller has already called reward for the current round"
         );
 
-        Transcoder storage t = transcoders[transcoderAddress];
+        Transcoder storage t = transcoders[transcoder];
         EarningsPool.Data storage earningsPool = t.earningsPoolPerRound[currentRound];
 
         // Set last round that transcoder called reward
@@ -935,17 +950,20 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
             mtr.trustedTransferTokens(trsry, treasuryRewards);
 
-            emit TreasuryReward(transcoderAddress, trsry, treasuryRewards);
+            emit TreasuryReward(transcoder, trsry, treasuryRewards);
         }
 
         uint256 transcoderRewards = totalRewardTokens.sub(treasuryRewards);
 
-        updateTranscoderWithRewards(transcoderAddress, transcoderRewards, currentRound, _newPosPrev, _newPosNext);
+        updateTranscoderWithRewards(transcoder, transcoderRewards, currentRound, _newPosPrev, _newPosNext);
 
         // Set last round that transcoder called reward
         t.lastRewardRound = currentRound;
 
-        emit Reward(transcoderAddress, transcoderRewards);
+        emit Reward(transcoder, transcoderRewards);
+
+        // Manual execution of the `autoCheckpoint` modifier due to conditional nature of `transcoder`
+        _checkpointBondingState(transcoder, delegators[transcoder], transcoders[transcoder]);
     }
 
     /**

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -196,8 +196,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * @param _rewardCaller Address of the new reward caller
      */
     function setRewardCaller(address _rewardCaller) external whenSystemNotPaused {
-        address transcoder = rewardCallerToTranscoder[_rewardCaller];
-        require(transcoder == address(0), "reward caller is already set");
+        require(rewardCallerToTranscoder[_rewardCaller] == address(0), "reward caller is already set");
         rewardCallerToTranscoder[_rewardCaller] = msg.sender;
         emit RewardCallerSet(msg.sender, _rewardCaller);
     }
@@ -207,8 +206,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * @param _rewardCaller Address of the existing reward caller
      */
     function unsetRewardCaller(address _rewardCaller) external whenSystemNotPaused {
-        address transcoder = rewardCallerToTranscoder[_rewardCaller];
-        require(transcoder == msg.sender, "only relevant transcoder can unset");
+        require(rewardCallerToTranscoder[_rewardCaller] == msg.sender, "only relevant transcoder can unset");
         rewardCallerToTranscoder[_rewardCaller] = address(0);
         emit RewardCallerUnset(msg.sender, _rewardCaller);
     }

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -894,9 +894,9 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
     /**
      * @notice Mint token rewards for an active transcoder and its delegators and update the transcoder pool using an optional list hint if needed
-     * @dev If the caller is in the transcoder pool, the caller can provide an optional hint for its insertion position in the
-     * pool via the `_newPosPrev` and `_newPosNext` params. A linear search will be executed starting at the hint to find the correct position.
-     * In the best case, the hint is the correct position so no search is executed. See SortedDoublyLL.sol for details on list hints
+     * @dev If the caller (or the transcoder associated with the RewardCaller) is in the transcoder pool, they can provide an optional hint for its
+     * insertion position in the pool via the `_newPosPrev` and `_newPosNext` params. A linear search will be executed starting at the hint to find the
+     * correct position. In the best case, the hint is the correct position so no search is executed. See SortedDoublyLL.sol for details on list hints
      * @param _newPosPrev Address of previous transcoder in pool if the caller is in the pool
      * @param _newPosNext Address of next transcoder in pool if the caller is in the pool
      */

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -102,6 +102,9 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     // If the balance of the treasury in LPT is above this value, automatic treasury contributions will halt.
     uint256 public treasuryBalanceCeiling;
 
+    // Allow reward() calls by pre-defined set of addresses
+    mapping(address => address) private rewardCallerToTranscoder;
+
     // Check if sender is TicketBroker
     modifier onlyTicketBroker() {
         _onlyTicketBroker();
@@ -186,6 +189,15 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         transcoderPool.setMaxSize(_numActiveTranscoders);
 
         emit ParameterUpdate("numActiveTranscoders");
+    }
+
+    /**
+     * @notice Set (or unset using 0 address) a reward caller for a transcoder
+     * @param _rewardCaller Address of a trusted reward caller
+     */
+    function setRewardCaller(address _rewardCaller) external whenSystemNotPaused {
+        rewardCallerToTranscoder[_rewardCaller] = msg.sender;
+        emit RewardCallerUpdated(_rewardCaller, msg.sender);
     }
 
     /**
@@ -869,13 +881,17 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     {
         uint256 currentRound = roundsManager().currentRound();
 
-        require(isActiveTranscoder(msg.sender), "caller must be an active transcoder");
+        address transcoderAddress = msg.sender;
+        if (!isActiveTranscoder(transcoderAddress)) {
+            transcoderAddress = rewardCallerToTranscoder[msg.sender];
+            require(isActiveTranscoder(transcoderAddress), "caller must be an active transcoder");
+        }
         require(
-            transcoders[msg.sender].lastRewardRound != currentRound,
+            transcoders[transcoderAddress].lastRewardRound != currentRound,
             "caller has already called reward for the current round"
         );
 
-        Transcoder storage t = transcoders[msg.sender];
+        Transcoder storage t = transcoders[transcoderAddress];
         EarningsPool.Data storage earningsPool = t.earningsPoolPerRound[currentRound];
 
         // Set last round that transcoder called reward
@@ -908,17 +924,17 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
 
             mtr.trustedTransferTokens(trsry, treasuryRewards);
 
-            emit TreasuryReward(msg.sender, trsry, treasuryRewards);
+            emit TreasuryReward(transcoderAddress, trsry, treasuryRewards);
         }
 
         uint256 transcoderRewards = totalRewardTokens.sub(treasuryRewards);
 
-        updateTranscoderWithRewards(msg.sender, transcoderRewards, currentRound, _newPosPrev, _newPosNext);
+        updateTranscoderWithRewards(transcoderAddress, transcoderRewards, currentRound, _newPosPrev, _newPosNext);
 
         // Set last round that transcoder called reward
         t.lastRewardRound = currentRound;
 
-        emit Reward(msg.sender, transcoderRewards);
+        emit Reward(transcoderAddress, transcoderRewards);
     }
 
     /**

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -211,6 +211,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      */
     function confirmRewardCaller(address _rewardCaller) external whenSystemNotPaused {
         require(rewardCallerToTranscoderProposed[_rewardCaller] == msg.sender, "reward caller was not proposed");
+        require(rewardCallerToTranscoderConfirmed[_rewardCaller] == address(0), "reward caller is already set");
         rewardCallerToTranscoderProposed[_rewardCaller] = address(0);
         rewardCallerToTranscoderConfirmed[_rewardCaller] = msg.sender;
         emit RewardCallerConfirmed(msg.sender, _rewardCaller);
@@ -222,7 +223,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
      * @dev Only callable by the transcoder, when the _rewardCaller was already proposed
      */
     function removeRewardCaller(address _rewardCaller) external whenSystemNotPaused {
-        require(rewardCallerToTranscoderConfirmed[_rewardCaller] == msg.sender, "only relevant transcoder can unset");
+        require(rewardCallerToTranscoderConfirmed[_rewardCaller] == msg.sender, "only relevant transcoder can remove");
         rewardCallerToTranscoderConfirmed[_rewardCaller] = address(0);
         emit RewardCallerRemoved(msg.sender, _rewardCaller);
     }

--- a/contracts/bonding/BondingManager.sol
+++ b/contracts/bonding/BondingManager.sol
@@ -192,12 +192,25 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
     }
 
     /**
-     * @notice Set (or unset using 0 address) a reward caller for a transcoder
-     * @param _rewardCaller Address of a trusted reward caller
+     * @notice Set a reward caller for a transcoder
+     * @param _rewardCaller Address of the new reward caller
      */
     function setRewardCaller(address _rewardCaller) external whenSystemNotPaused {
+        address transcoder = rewardCallerToTranscoder[_rewardCaller];
+        require(transcoder == address(0), "reward caller is already set");
         rewardCallerToTranscoder[_rewardCaller] = msg.sender;
-        emit RewardCallerUpdated(_rewardCaller, msg.sender);
+        emit RewardCallerSet(msg.sender, _rewardCaller);
+    }
+
+    /**
+     * @notice Unset a reward caller for a transcoder
+     * @param _rewardCaller Address of the existing reward caller
+     */
+    function unsetRewardCaller(address _rewardCaller) external whenSystemNotPaused {
+        address transcoder = rewardCallerToTranscoder[_rewardCaller];
+        require(transcoder == msg.sender, "only relevant transcoder can unset");
+        rewardCallerToTranscoder[_rewardCaller] = address(0);
+        emit RewardCallerUnset(msg.sender, _rewardCaller);
     }
 
     /**
@@ -884,7 +897,7 @@ contract BondingManager is ManagerProxyTarget, IBondingManager {
         address transcoderAddress = msg.sender;
         if (!isActiveTranscoder(transcoderAddress)) {
             transcoderAddress = rewardCallerToTranscoder[msg.sender];
-            require(isActiveTranscoder(transcoderAddress), "caller must be an active transcoder");
+            require(isActiveTranscoder(transcoderAddress), "caller must be an active transcoder or rewardCaller");
         }
         require(
             transcoders[transcoderAddress].lastRewardRound != currentRound,

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -44,6 +44,7 @@ interface IBondingManager {
         uint256 startRound,
         uint256 endRound
     );
+    event RewardCallerUpdated(address indexed rewardCaller, address indexed transcoder);
 
     // Deprecated events
     // These event signatures can be used to construct the appropriate topic hashes to filter for past logs corresponding

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -44,8 +44,9 @@ interface IBondingManager {
         uint256 startRound,
         uint256 endRound
     );
-    event RewardCallerSet(address indexed transcoder, address indexed rewardCaller);
-    event RewardCallerUnset(address indexed transcoder, address indexed rewardCaller);
+    event RewardCallerProposed(address indexed transcoder, address indexed rewardCaller);
+    event RewardCallerConfirmed(address indexed transcoder, address indexed rewardCaller);
+    event RewardCallerRemoved(address indexed transcoder, address indexed rewardCaller);
 
     // Deprecated events
     // These event signatures can be used to construct the appropriate topic hashes to filter for past logs corresponding

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -74,6 +74,16 @@ interface IBondingManager {
 
     function setCurrentRoundTotalActiveStake() external;
 
+    function proposeTranscoderForRewardCaller(address _transcoder) external;
+
+    function confirmRewardCaller(address _rewardCaller) external;
+
+    function removeRewardCaller(address _rewardCaller) external;
+
+    function reward() external;
+
+    function rewardWithHint(address _newPosPrev, address _newPosNext) external;
+
     // Public functions
     function getTranscoderPoolSize() external view returns (uint256);
 

--- a/contracts/bonding/IBondingManager.sol
+++ b/contracts/bonding/IBondingManager.sol
@@ -44,7 +44,8 @@ interface IBondingManager {
         uint256 startRound,
         uint256 endRound
     );
-    event RewardCallerUpdated(address indexed rewardCaller, address indexed transcoder);
+    event RewardCallerSet(address indexed transcoder, address indexed rewardCaller);
+    event RewardCallerUnset(address indexed transcoder, address indexed rewardCaller);
 
     // Deprecated events
     // These event signatures can be used to construct the appropriate topic hashes to filter for past logs corresponding

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "clean": "rm -rf cache artifacts typechain",
     "compile": "npx hardhat compile",
     "test:coverage": "npx hardhat coverage",
+    "test:coverage:check": "npx istanbul check-coverage ./coverage.json --statements 100 --branches 100 --functions 100 --lines 100",
     "test": "npx hardhat test",
     "test:unit": "npx hardhat test test/unit/*.*",
     "test:integration": "npx hardhat test test/integration/**",

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -6100,6 +6100,42 @@ describe("BondingManager", () => {
                 atCeilingTest("when above limit", 1500)
             })
         })
+
+        describe("reward delegation", () => {
+            const transcoderRewards = 1000
+
+            it("should allow a RewardCaller to call reward", async () => {
+                // Transcoder should be able to set a non-transcoder as a reward caller
+                const setRewardCallerTx = bondingManager
+                    .connect(transcoder)
+                    .setRewardCaller(nonTranscoder.address)
+                await expect(setRewardCallerTx)
+                    .to.emit(bondingManager, "RewardCallerUpdated")
+                    .withArgs(nonTranscoder.address, transcoder.address)
+
+                // Non-transcoder should now be able to call reward on behalf of the transcoder
+                const rewardTx = bondingManager.connect(nonTranscoder).reward()
+                await expect(rewardTx)
+                    .to.emit(bondingManager, "Reward")
+                    .withArgs(transcoder.address, transcoderRewards)
+            })
+
+            it("should allow a transcoder to call reward even if RewardCaller is set", async () => {
+                // Transcoder should be able to set a non-transcoder as a reward caller
+                const setRewardCallerTx = bondingManager
+                    .connect(transcoder)
+                    .setRewardCaller(nonTranscoder.address)
+                await expect(setRewardCallerTx)
+                    .to.emit(bondingManager, "RewardCallerUpdated")
+                    .withArgs(nonTranscoder.address, transcoder.address)
+
+                // Non-transcoder should now be able to call reward on behalf of the transcoder
+                const rewardTx = bondingManager.connect(transcoder).reward()
+                await expect(rewardTx)
+                    .to.emit(bondingManager, "Reward")
+                    .withArgs(transcoder.address, transcoderRewards)
+            })
+        })
     })
 
     describe("updateTranscoderWithFees", () => {

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -6109,11 +6109,17 @@ describe("BondingManager", () => {
             const transcoderRewards = 1000
 
             it("should allow a transcoder to call reward even if RewardCaller is set", async () => {
-                const setRewardCallerTx = bondingManager
+                const proposeRewardCallerTx = bondingManager
+                    .connect(nonTranscoder)
+                    .proposeRewardCaller(transcoder.address)
+                await expect(proposeRewardCallerTx)
+                    .to.emit(bondingManager, "RewardCallerProposed")
+                    .withArgs(transcoder.address, nonTranscoder.address)
+                const confirmRewardCallerTx = bondingManager
                     .connect(transcoder)
-                    .setRewardCaller(nonTranscoder.address)
-                await expect(setRewardCallerTx)
-                    .to.emit(bondingManager, "RewardCallerSet")
+                    .confirmRewardCaller(nonTranscoder.address)
+                await expect(confirmRewardCallerTx)
+                    .to.emit(bondingManager, "RewardCallerConfirmed")
                     .withArgs(transcoder.address, nonTranscoder.address)
 
                 const rewardTx = bondingManager.connect(transcoder).reward()
@@ -6126,11 +6132,12 @@ describe("BondingManager", () => {
                     currentRound + 3
                 )
 
-                const unsetRewardCallerTx = bondingManager
+                // should allow a transcoder to call reward after removing RewardCaller
+                const removeRewardCallerTx = bondingManager
                     .connect(transcoder)
-                    .unsetRewardCaller(nonTranscoder.address)
-                await expect(unsetRewardCallerTx)
-                    .to.emit(bondingManager, "RewardCallerUnset")
+                    .removeRewardCaller(nonTranscoder.address)
+                await expect(removeRewardCallerTx)
+                    .to.emit(bondingManager, "RewardCallerRemoved")
                     .withArgs(transcoder.address, nonTranscoder.address)
 
                 const rewardTx2 = bondingManager.connect(transcoder).reward()
@@ -6139,16 +6146,20 @@ describe("BondingManager", () => {
                     .withArgs(transcoder.address, transcoderRewards)
             })
 
-            it("should allow a RewardCaller to call reward", async () => {
-                const setRewardCallerTx = bondingManager
-                    .connect(transcoder)
-                    .setRewardCaller(nonTranscoder.address)
-                await expect(setRewardCallerTx)
-                    .to.emit(bondingManager, "RewardCallerSet")
-                    .withArgs(transcoder.address, nonTranscoder.address)
+            it("should allow a RewardCaller to call reward only after confirmation", async () => {
+                await bondingManager
+                    .connect(nonTranscoder)
+                    .proposeRewardCaller(transcoder.address)
+                const rewardTx1 = bondingManager.connect(nonTranscoder).reward()
+                await expect(rewardTx1).to.be.revertedWith(
+                    "caller must be an active transcoder or rewardCaller"
+                )
 
-                const rewardTx = bondingManager.connect(nonTranscoder).reward()
-                await expect(rewardTx)
+                await bondingManager
+                    .connect(transcoder)
+                    .confirmRewardCaller(nonTranscoder.address)
+                const rewardTx2 = bondingManager.connect(nonTranscoder).reward()
+                await expect(rewardTx2)
                     .to.emit(bondingManager, "Reward")
                     .withArgs(transcoder.address, transcoderRewards)
 
@@ -6156,50 +6167,76 @@ describe("BondingManager", () => {
                     functionSig("currentRound()"),
                     currentRound + 3
                 )
-
-                const unsetRewardCallerTx = bondingManager
+                await bondingManager
                     .connect(transcoder)
-                    .unsetRewardCaller(nonTranscoder.address)
-                await expect(unsetRewardCallerTx)
-                    .to.emit(bondingManager, "RewardCallerUnset")
-                    .withArgs(transcoder.address, nonTranscoder.address)
-
-                const rewardTx2 = bondingManager.connect(nonTranscoder).reward()
-                await expect(rewardTx2).to.be.revertedWith(
+                    .removeRewardCaller(nonTranscoder.address)
+                const rewardTx3 = bondingManager.connect(nonTranscoder).reward()
+                await expect(rewardTx3).to.be.revertedWith(
                     "caller must be an active transcoder or rewardCaller"
                 )
             })
 
-            it("impossible to set the same RewardCaller twice", async () => {
-                const setRewardCallerTx = bondingManager
+            it("should not allow a RewardCaller to be confirmed more than once", async () => {
+                await bondingManager
+                    .connect(nonTranscoder)
+                    .proposeRewardCaller(transcoder.address)
+                await bondingManager
                     .connect(transcoder)
-                    .setRewardCaller(nonTranscoder.address)
-                await expect(setRewardCallerTx)
-                    .to.emit(bondingManager, "RewardCallerSet")
-                    .withArgs(transcoder.address, nonTranscoder.address)
-
-                const setRewardCallerTx2 = bondingManager
+                    .confirmRewardCaller(nonTranscoder.address)
+                const confirmRewardCallerTx2 = bondingManager
                     .connect(transcoder)
-                    .setRewardCaller(nonTranscoder.address)
-                await expect(setRewardCallerTx2).to.be.revertedWith(
-                    "reward caller is already set"
+                    .confirmRewardCaller(nonTranscoder.address)
+                await expect(confirmRewardCallerTx2).to.be.revertedWith(
+                    "reward caller was not proposed"
                 )
             })
 
-            it("impossible to unset the RewardCaller for another transcoder", async () => {
-                const setRewardCallerTx = bondingManager
+            it("impossible to confirm RewardCaller without the proposal", async () => {
+                const confirmRewardCallerTx = bondingManager
                     .connect(transcoder)
-                    .setRewardCaller(nonTranscoder.address)
-                await expect(setRewardCallerTx)
-                    .to.emit(bondingManager, "RewardCallerSet")
-                    .withArgs(transcoder.address, nonTranscoder.address)
+                    .confirmRewardCaller(nonTranscoder.address)
+                await expect(confirmRewardCallerTx).to.be.revertedWith(
+                    "reward caller was not proposed"
+                )
+            })
 
-                const unsetRewardCallerTx = bondingManager
+            it("impossible to remove the RewardCaller for another transcoder", async () => {
+                await bondingManager
                     .connect(nonTranscoder)
-                    .unsetRewardCaller(nonTranscoder.address)
-                await expect(unsetRewardCallerTx).to.be.revertedWith(
+                    .proposeRewardCaller(transcoder.address)
+                await bondingManager
+                    .connect(transcoder)
+                    .confirmRewardCaller(nonTranscoder.address)
+
+                const removeRewardCallerTx = bondingManager
+                    .connect(nonTranscoder)
+                    .removeRewardCaller(nonTranscoder.address)
+                await expect(removeRewardCallerTx).to.be.revertedWith(
                     "only relevant transcoder can unset"
                 )
+            })
+
+            it("should always checkpoint the reward recipient, not the RewardCaller", async () => {
+                await bondingManager
+                    .connect(nonTranscoder)
+                    .proposeRewardCaller(transcoder.address)
+                await bondingManager
+                    .connect(transcoder)
+                    .confirmRewardCaller(nonTranscoder.address)
+
+                const rewardCallerTx = await bondingManager
+                    .connect(nonTranscoder)
+                    .reward()
+
+                await expectCheckpoints(fixture, rewardCallerTx, {
+                    account: transcoder.address,
+                    startRound: currentRound + 2,
+                    bondedAmount: 1000,
+                    delegateAddress: transcoder.address,
+                    delegatedAmount: 2000,
+                    lastClaimRound: currentRound,
+                    lastRewardRound: currentRound + 1
+                })
             })
         })
     })

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -5414,12 +5414,14 @@ describe("BondingManager", () => {
 
     describe("reward", () => {
         let transcoder
+        let transcoder2
         let nonTranscoder
         let currentRound
 
         beforeEach(async () => {
             transcoder = signers[0]
-            nonTranscoder = signers[1]
+            transcoder2 = signers[1]
+            nonTranscoder = signers[2]
             currentRound = 100
 
             await fixture.roundsManager.setMockBool(
@@ -6208,7 +6210,26 @@ describe("BondingManager", () => {
                     .connect(nonTranscoder)
                     .removeRewardCaller(nonTranscoder.address)
                 await expect(removeRewardCallerTx).to.be.revertedWith(
-                    "only relevant transcoder can unset"
+                    "only relevant transcoder can remove"
+                )
+            })
+
+            it("impossible to confirm RewardCaller for a second transcoder", async () => {
+                await bondingManager
+                    .connect(nonTranscoder)
+                    .proposeTranscoderForRewardCaller(transcoder.address)
+                await bondingManager
+                    .connect(transcoder)
+                    .confirmRewardCaller(nonTranscoder.address)
+                await bondingManager
+                    .connect(nonTranscoder)
+                    .proposeTranscoderForRewardCaller(transcoder2.address)
+
+                const removeRewardCallerTx = bondingManager
+                    .connect(transcoder2)
+                    .confirmRewardCaller(nonTranscoder.address)
+                await expect(removeRewardCallerTx).to.be.revertedWith(
+                    "reward caller is already set"
                 )
             })
 

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -6169,6 +6169,38 @@ describe("BondingManager", () => {
                     "caller must be an active transcoder or rewardCaller"
                 )
             })
+
+            it("impossible to set the same RewardCaller twice", async () => {
+                const setRewardCallerTx = bondingManager
+                    .connect(transcoder)
+                    .setRewardCaller(nonTranscoder.address)
+                await expect(setRewardCallerTx)
+                    .to.emit(bondingManager, "RewardCallerSet")
+                    .withArgs(transcoder.address, nonTranscoder.address)
+
+                const setRewardCallerTx2 = bondingManager
+                    .connect(transcoder)
+                    .setRewardCaller(nonTranscoder.address)
+                await expect(setRewardCallerTx2).to.be.revertedWith(
+                    "reward caller is already set"
+                )
+            })
+
+            it("impossible to unset the RewardCaller for another transcoder", async () => {
+                const setRewardCallerTx = bondingManager
+                    .connect(transcoder)
+                    .setRewardCaller(nonTranscoder.address)
+                await expect(setRewardCallerTx)
+                    .to.emit(bondingManager, "RewardCallerSet")
+                    .withArgs(transcoder.address, nonTranscoder.address)
+
+                const unsetRewardCallerTx = bondingManager
+                    .connect(nonTranscoder)
+                    .unsetRewardCaller(nonTranscoder.address)
+                await expect(unsetRewardCallerTx).to.be.revertedWith(
+                    "only relevant transcoder can unset"
+                )
+            })
         })
     })
 

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -6105,10 +6105,10 @@ describe("BondingManager", () => {
             const transcoderRewards = 1000
 
             it("should allow a transcoder to call reward even if RewardCaller is set", async () => {
-                const proposeRewardCallerTx = bondingManager
+                const proposeTranscoderForRewardCallerTx = bondingManager
                     .connect(nonTranscoder)
-                    .proposeRewardCaller(transcoder.address)
-                await expect(proposeRewardCallerTx)
+                    .proposeTranscoderForRewardCaller(transcoder.address)
+                await expect(proposeTranscoderForRewardCallerTx)
                     .to.emit(bondingManager, "RewardCallerProposed")
                     .withArgs(transcoder.address, nonTranscoder.address)
                 const confirmRewardCallerTx = bondingManager
@@ -6145,7 +6145,7 @@ describe("BondingManager", () => {
             it("should allow a RewardCaller to call reward only after confirmation", async () => {
                 await bondingManager
                     .connect(nonTranscoder)
-                    .proposeRewardCaller(transcoder.address)
+                    .proposeTranscoderForRewardCaller(transcoder.address)
                 const rewardTx1 = bondingManager.connect(nonTranscoder).reward()
                 await expect(rewardTx1).to.be.revertedWith(
                     "transcoder must be active"
@@ -6175,7 +6175,7 @@ describe("BondingManager", () => {
             it("should not allow a RewardCaller to be confirmed more than once", async () => {
                 await bondingManager
                     .connect(nonTranscoder)
-                    .proposeRewardCaller(transcoder.address)
+                    .proposeTranscoderForRewardCaller(transcoder.address)
                 await bondingManager
                     .connect(transcoder)
                     .confirmRewardCaller(nonTranscoder.address)
@@ -6199,7 +6199,7 @@ describe("BondingManager", () => {
             it("impossible to remove the RewardCaller for another transcoder", async () => {
                 await bondingManager
                     .connect(nonTranscoder)
-                    .proposeRewardCaller(transcoder.address)
+                    .proposeTranscoderForRewardCaller(transcoder.address)
                 await bondingManager
                     .connect(transcoder)
                     .confirmRewardCaller(nonTranscoder.address)
@@ -6215,7 +6215,7 @@ describe("BondingManager", () => {
             it("should always checkpoint the reward recipient, not the RewardCaller", async () => {
                 await bondingManager
                     .connect(nonTranscoder)
-                    .proposeRewardCaller(transcoder.address)
+                    .proposeTranscoderForRewardCaller(transcoder.address)
                 await bondingManager
                     .connect(transcoder)
                     .confirmRewardCaller(nonTranscoder.address)

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -5474,9 +5474,7 @@ describe("BondingManager", () => {
         it("should fail if caller is not a transcoder", async () => {
             await expect(
                 bondingManager.connect(nonTranscoder).reward()
-            ).to.be.revertedWith(
-                "caller must be an active transcoder or rewardCaller"
-            )
+            ).to.be.revertedWith("transcoder must be active")
         })
 
         it("should fail if caller is registered but not an active transcoder yet in the current round", async () => {
@@ -5486,9 +5484,7 @@ describe("BondingManager", () => {
             )
             await expect(
                 bondingManager.connect(transcoder).reward()
-            ).to.be.revertedWith(
-                "caller must be an active transcoder or rewardCaller"
-            )
+            ).to.be.revertedWith("transcoder must be active")
         })
 
         it("should fail if caller already called reward during the current round", async () => {
@@ -6152,7 +6148,7 @@ describe("BondingManager", () => {
                     .proposeRewardCaller(transcoder.address)
                 const rewardTx1 = bondingManager.connect(nonTranscoder).reward()
                 await expect(rewardTx1).to.be.revertedWith(
-                    "caller must be an active transcoder or rewardCaller"
+                    "transcoder must be active"
                 )
 
                 await bondingManager
@@ -6172,7 +6168,7 @@ describe("BondingManager", () => {
                     .removeRewardCaller(nonTranscoder.address)
                 const rewardTx3 = bondingManager.connect(nonTranscoder).reward()
                 await expect(rewardTx3).to.be.revertedWith(
-                    "caller must be an active transcoder or rewardCaller"
+                    "transcoder must be active"
                 )
             })
 

--- a/test/unit/BondingManager.js
+++ b/test/unit/BondingManager.js
@@ -5474,7 +5474,9 @@ describe("BondingManager", () => {
         it("should fail if caller is not a transcoder", async () => {
             await expect(
                 bondingManager.connect(nonTranscoder).reward()
-            ).to.be.revertedWith("caller must be an active transcoder")
+            ).to.be.revertedWith(
+                "caller must be an active transcoder or rewardCaller"
+            )
         })
 
         it("should fail if caller is registered but not an active transcoder yet in the current round", async () => {
@@ -5484,7 +5486,9 @@ describe("BondingManager", () => {
             )
             await expect(
                 bondingManager.connect(transcoder).reward()
-            ).to.be.revertedWith("caller must be an active transcoder")
+            ).to.be.revertedWith(
+                "caller must be an active transcoder or rewardCaller"
+            )
         })
 
         it("should fail if caller already called reward during the current round", async () => {
@@ -6104,36 +6108,66 @@ describe("BondingManager", () => {
         describe("reward delegation", () => {
             const transcoderRewards = 1000
 
-            it("should allow a RewardCaller to call reward", async () => {
-                // Transcoder should be able to set a non-transcoder as a reward caller
-                const setRewardCallerTx = bondingManager
-                    .connect(transcoder)
-                    .setRewardCaller(nonTranscoder.address)
-                await expect(setRewardCallerTx)
-                    .to.emit(bondingManager, "RewardCallerUpdated")
-                    .withArgs(nonTranscoder.address, transcoder.address)
-
-                // Non-transcoder should now be able to call reward on behalf of the transcoder
-                const rewardTx = bondingManager.connect(nonTranscoder).reward()
-                await expect(rewardTx)
-                    .to.emit(bondingManager, "Reward")
-                    .withArgs(transcoder.address, transcoderRewards)
-            })
-
             it("should allow a transcoder to call reward even if RewardCaller is set", async () => {
-                // Transcoder should be able to set a non-transcoder as a reward caller
                 const setRewardCallerTx = bondingManager
                     .connect(transcoder)
                     .setRewardCaller(nonTranscoder.address)
                 await expect(setRewardCallerTx)
-                    .to.emit(bondingManager, "RewardCallerUpdated")
-                    .withArgs(nonTranscoder.address, transcoder.address)
+                    .to.emit(bondingManager, "RewardCallerSet")
+                    .withArgs(transcoder.address, nonTranscoder.address)
 
-                // Non-transcoder should now be able to call reward on behalf of the transcoder
                 const rewardTx = bondingManager.connect(transcoder).reward()
                 await expect(rewardTx)
                     .to.emit(bondingManager, "Reward")
                     .withArgs(transcoder.address, transcoderRewards)
+
+                await fixture.roundsManager.setMockUint256(
+                    functionSig("currentRound()"),
+                    currentRound + 3
+                )
+
+                const unsetRewardCallerTx = bondingManager
+                    .connect(transcoder)
+                    .unsetRewardCaller(nonTranscoder.address)
+                await expect(unsetRewardCallerTx)
+                    .to.emit(bondingManager, "RewardCallerUnset")
+                    .withArgs(transcoder.address, nonTranscoder.address)
+
+                const rewardTx2 = bondingManager.connect(transcoder).reward()
+                await expect(rewardTx2)
+                    .to.emit(bondingManager, "Reward")
+                    .withArgs(transcoder.address, transcoderRewards)
+            })
+
+            it("should allow a RewardCaller to call reward", async () => {
+                const setRewardCallerTx = bondingManager
+                    .connect(transcoder)
+                    .setRewardCaller(nonTranscoder.address)
+                await expect(setRewardCallerTx)
+                    .to.emit(bondingManager, "RewardCallerSet")
+                    .withArgs(transcoder.address, nonTranscoder.address)
+
+                const rewardTx = bondingManager.connect(nonTranscoder).reward()
+                await expect(rewardTx)
+                    .to.emit(bondingManager, "Reward")
+                    .withArgs(transcoder.address, transcoderRewards)
+
+                await fixture.roundsManager.setMockUint256(
+                    functionSig("currentRound()"),
+                    currentRound + 3
+                )
+
+                const unsetRewardCallerTx = bondingManager
+                    .connect(transcoder)
+                    .unsetRewardCaller(nonTranscoder.address)
+                await expect(unsetRewardCallerTx)
+                    .to.emit(bondingManager, "RewardCallerUnset")
+                    .withArgs(transcoder.address, nonTranscoder.address)
+
+                const rewardTx2 = bondingManager.connect(nonTranscoder).reward()
+                await expect(rewardTx2).to.be.revertedWith(
+                    "caller must be an active transcoder or rewardCaller"
+                )
             })
         })
     })


### PR DESCRIPTION
### What does this pull request do? Explain your changes. (required)
<!-- A clear and concise description of what this pull request does. -->

This PR adds a new feature to the livepeer protocol which will allow transcoders to set a multiple addresses they trust to claim the rewards on every round without requiring the main wallet to stay unlocked.

### Specific updates (required)
<!--- List out all significant updates your code introduces -->

- `contracts/bonding/BondingManager.sol` contract is modified to include
  - New `rewardCallerToTranscoderProposed` public mapping to keep self-proposed rewardCallers 
  - New `rewardCallerToTranscoderConfirmed` public mapping to keep RewardCallers confirmed by the relevant transcoders
  - New `proposeTranscoderForRewardCaller` function to propose RewardCaller for transcoders
    - Can be undone by proposing `address(0)`
  - New `confirmRewardCaller` function to confirm previously proposed RewardCaller
    - Also resets the proposed address to zero
  - New `removeRewardCaller`, function to remove confirmed RewardCallers by the transcoders
  - Existing `rewardWithHint` is modified to also be callable by the confirmed RewardCallers
- `test/unit/BondingManager.js` test is modified to include new "reward delegation" section
- `yarn test:coverage:check` command is added to the CI to insure 100% test coverage


### How did you test each of these updates (required)
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

A new "reward delegation" section contains tests that ensure:
- A transcoder is able to to call the reward even if RewardCaller is set for them, or removed
- If a RewardCaller is set, the account is able to call `reward`
- If the RewardCaller is not set or removed, it is not able to call `reward`
- A transcoder is not able to re-confirm RewardCaller after adding them, adding and removing them
- It is impossible to confirm RewardCaller without a proposal submitted by the RewardCaller itself
- It is impossible to remove the RewardCaller for another transcoder
- Checkpoint logs reward recipient, not the RewardCaller

### Does this pull request close any open issues?
<!-- Fixes # -->

No


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] ~~README and other documentation updated~~
  - No relevant documentation found, the changes are backwards compatible
- [x] All tests using `yarn test` pass
