### PR TITLE
feat: extend auxData to 96 bytes

### DIFF
--- a/contracts/pm/mixins/MixinTicketProcessor.sol
+++ b/contracts/pm/mixins/MixinTicketProcessor.sol
@@ -74,7 +74,10 @@ abstract contract MixinTicketProcessor is MixinContractRegistry, MTicketProcesso
         pure
         returns (uint256 creationRound, bytes32 creationRoundBlockHash)
     {
-        require(_auxData.length == 64, "invalid length for ticket auxData: must be 64 bytes");
+        require(
+            _auxData.length >= 64 && _auxData.length <= 96,
+            "invalid length for ticket auxData: must be between 64 and 96 bytes"
+        );
 
         // _auxData format:
         // Bytes [0:31] = creationRound

--- a/test/unit/TicketBroker.js
+++ b/test/unit/TicketBroker.js
@@ -798,22 +798,79 @@ describe("TicketBroker", () => {
             ).to.be.revertedWith("ticket sender is null address")
         })
 
-        it("reverts if ticket auxData != 64 bytes", async () => {
-            const auxData = ethers.constants.HashZero
-
+        it("reverts if ticket auxData length is less than 64 bytes", async () => {
             await expect(
                 broker.redeemWinningTicket(
                     createTicket({
                         recipient,
                         sender,
-                        auxData
+                        auxData: ethers.constants.HashZero
                     }),
                     web3.utils.asciiToHex("sig"),
                     5
                 )
             ).to.be.revertedWith(
-                "invalid length for ticket auxData: must be 64 bytes"
+                "invalid length for ticket auxData: must be between 64 and 96 bytes"
             )
+        })
+
+        it("reverts if ticket auxData is greater than 96 bytes", async () => {
+            await expect(
+                broker.redeemWinningTicket(
+                    createTicket({
+                        recipient,
+                        sender,
+                        auxData: ethers.utils.hexConcat([
+                            createAuxData(
+                                currentRound,
+                                DUMMY_TICKET_CREATION_ROUND_BLOCK_HASH
+                            ),
+                            ethers.constants.HashZero,
+                            ethers.constants.HashZero
+                        ])
+                    }),
+                    web3.utils.asciiToHex("sig"),
+                    5
+                )
+            ).to.be.revertedWith(
+                "invalid length for ticket auxData: must be between 64 and 96 bytes"
+            )
+        })
+
+        it("accepts 96-byte ticket auxData", async () => {
+            const recipientRand = 5
+            const faceValue = 1
+
+            await broker.fundDeposit({value: faceValue})
+            const auxData = ethers.utils.hexConcat([
+                createAuxData(
+                    currentRound,
+                    DUMMY_TICKET_CREATION_ROUND_BLOCK_HASH
+                ),
+                ethers.constants.HashZero
+            ])
+
+            const ticket = createWinningTicket(
+                recipient,
+                sender,
+                recipientRand,
+                faceValue,
+                auxData
+            )
+            const senderSig = await signMsg(getTicketHash(ticket), sender)
+
+            try {
+                await broker.redeemWinningTicket(
+                    ticket,
+                    senderSig,
+                    recipientRand
+                )
+            } catch (error) {
+                console.log(
+                    error.reason || error.error?.message || error.message
+                )
+                throw error
+            }
         })
 
         it("reverts if block hash for ticket creationRound is null", async () => {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Allow a 64–96 byte `auxData` field to support additional on-chain metadata. This was part of the protocol work to distinguish different job types on-chain (see this tech spec: [https://www.notion.so/On-Chain-Ticket-Job-Type-Distinction-2bf660222d08814d89b1fa7221ad3291](https://www.notion.so/On-Chain-Ticket-Job-Type-Distinction-2bf660222d08814d89b1fa7221ad3291)).

This proposal was originally drafted as a protocol change that would not materially increase gas costs or code complexity. However, given the new requirement to also [encode payment clearinghouse information on-chain](https://www.notion.so/livepeer/Payments-Clearinghouse-25e0a3485687817394d0c3442ffca622), please review this approach with @mehrdadmms, @yondonfu, and @j0sh to confirm whether this is still the preferred solution.

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->
- Extended auxData field to accept 96 bytes.
- Updated tests.

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Not fully tested, however made sure tests pass.

**Does this pull request close any open issues?**
<!-- Fixes # -->

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] All tests using `yarn test` pass
